### PR TITLE
fix: update stale CLI flag names

### DIFF
--- a/.claude/skills/vibe-new-app.md
+++ b/.claude/skills/vibe-new-app.md
@@ -14,10 +14,10 @@ Scaffold a new AI-powered app using the iblai CLI.
 
 2. **Scaffold the app**:
    ```bash
-   npx @iblai/cli startapp agent --platform-key <tenant> --mentor-id <agent-id>
+   npx @iblai/cli startapp agent --platform <tenant> --agent <agent-id>
    ```
    - If the user doesn't have a tenant yet, use `iblai` as the default
-   - If they don't have an agent ID, omit `--mentor-id` (will prompt or use default)
+   - If they don't have an agent ID, omit `--agent` (will prompt or use default)
    - For a minimal app without the chat UI, use `startapp base` instead
 
 3. **Install dependencies**:
@@ -48,7 +48,7 @@ Scaffold a new AI-powered app using the iblai CLI.
 To customize the app with AI during scaffolding:
 ```bash
 npx @iblai/cli startapp agent \
-  --platform-key acme \
+  --platform acme \
   --anthropic-key sk-ant-... \
   --prompt "Make this a kids learning assistant with bright, playful colors"
 ```


### PR DESCRIPTION
## Summary

Update the `/vibe-new-app` skill to use the current iblai-app-cli flag names.

The CLI renamed these flags:
- `--platform-key` → `--platform`
- `--mentor-id` → `--agent`

## Changes

1 file changed: `.claude/skills/vibe-new-app.md`
- `--platform-key <tenant>` → `--platform <tenant>`
- `--mentor-id <agent-id>` → `--agent <agent-id>`
- `omit --mentor-id` → `omit --agent`

## Context

These flags were renamed in the iblai-app-cli repo during the `feat/integrations-with-external-apps` branch work. The vibe repo's skill was referencing the old names.