### PR TITLE
feat: add iblai init and --yes flag documentation

### DIFF
--- a/.claude/skills/vibe-new-app.md
+++ b/.claude/skills/vibe-new-app.md
@@ -41,7 +41,19 @@ Scaffold a new AI-powered app using the iblai CLI.
 6. **Set up AI-assisted development**:
    - The generated app includes `.mcp.json` for the @iblai/mcp server
    - Skills are in `.claude/skills/` -- invoke with `/` prefix
-   - Run `iblai add mcp` if MCP config is missing
+   - For existing projects without MCP config, run `npx @iblai/cli init`
+
+## Non-Interactive Mode (CI/CD)
+
+Skip all prompts with `--yes` (requires `--platform` and `--app-name`):
+
+```bash
+npx @iblai/cli startapp agent \
+  --yes \
+  --platform acme \
+  --agent my-agent-id \
+  --app-name my-app
+```
 
 ## AI-Enhanced Scaffolding
 
@@ -52,6 +64,16 @@ npx @iblai/cli startapp agent \
   --anthropic-key sk-ant-... \
   --prompt "Make this a kids learning assistant with bright, playful colors"
 ```
+
+## Add AI Skills to an Existing Project
+
+For existing Next.js projects that need MCP config and AI skills:
+```bash
+cd your-existing-project
+npx @iblai/cli init
+```
+
+This adds `.mcp.json`, `skills/`, and tool symlinks for Claude Code, OpenCode, and Cursor.
 
 ## What Gets Generated
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,10 @@ pnpm build              # Production build
 pnpm lint               # ESLint
 pnpm typecheck          # TypeScript type checking
 pnpm test:e2e           # Playwright E2E tests
+
+iblai config show       # View current configuration
+iblai config set KEY VAL  # Update .env.local
+iblai open              # Open localhost:3000 in browser
 ```
 
 ## Adding Features
@@ -119,7 +123,9 @@ All `add` commands (except `init` and `mcp`) require auth to be set up first.
 | shadcn/ui | `npx shadcn@latest add` | Everything else -- forms, tables, modals, date pickers |
 | shadcnspace blocks | `npx shadcn@latest add @shadcn-space/<block>` | Pre-built page sections |
 
-ibl.ai and shadcn components share the same Tailwind theme. They are visually seamless.
+ibl.ai and shadcn components share the same Tailwind theme via OKLCH CSS variables
+mapped in `globals.css`. A shadcn `bg-primary` button renders in ibl.ai blue (#0058cc),
+not the default shadcn black. No manual theme work needed.
 
 ## Brand
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,18 @@ get_playwright_helper_info("createConfig")    # E2E test utilities
 # Scaffold a new app
 npx @iblai/cli startapp agent
 
-# Or add features to an existing Next.js app
+# Non-interactive (CI/CD)
+npx @iblai/cli startapp agent --yes --platform acme --app-name my-app
+
+# Add AI skills to an existing project
+npx @iblai/cli init
+
+# Add features to an existing Next.js app
 npx @iblai/cli add auth
 npx @iblai/cli add chat
 npx @iblai/cli add profile
+npx @iblai/cli add account
+npx @iblai/cli add analytics
 npx @iblai/cli add notifications
 ```
 
@@ -90,15 +98,18 @@ pnpm test:e2e           # Playwright E2E tests
 ## Adding Features
 
 ```bash
+iblai init               # Add MCP server + AI skills to current project
 iblai add auth           # SSO authentication + Redux store + providers
 iblai add chat           # AI chat widget (<mentor-ai> web component)
-iblai add profile        # User profile dropdown
-iblai add account        # Organization/account settings
-iblai add analytics      # Analytics dashboard
-iblai add notifications  # Notification bell with unread badge
+iblai add profile        # User profile dropdown + settings page
+iblai add account        # Organization/account settings page
+iblai add analytics      # Analytics dashboard page
+iblai add notifications  # Notification bell + center page
 iblai add builds         # Tauri v2 desktop/mobile shell
 iblai add mcp            # MCP server config + Claude/OpenCode/Cursor skills
 ```
+
+All `add` commands (except `init` and `mcp`) require auth to be set up first.
 
 ## Component Hierarchy
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ To get your own branded tenant (custom domain, your logo, your users), register 
 
 ## Add to Existing Apps
 
-Already have a project? Pull in individual features with `iblai add`:
+Already have a project? Start by adding AI development skills, then pull in features:
 
 ```bash
+npx @iblai/cli init               # Add MCP server + AI skills
 npx @iblai/cli add auth           # SSO authentication
 npx @iblai/cli add chat           # AI chat with streaming
 npx @iblai/cli add profile        # User profile page
@@ -78,6 +79,14 @@ npx @iblai/cli add notifications  # Real-time notifications
 ```
 
 Each command scaffolds the feature into your app with the right components, hooks, and routes.
+
+### CI/CD
+
+Use `--yes` to skip interactive prompts:
+
+```bash
+npx @iblai/cli startapp agent --yes --platform acme --agent my-id --app-name my-app
+```
 
 ## The iblai Backend
 


### PR DESCRIPTION
## Summary

Update vibe docs to reflect new iblai-app-cli features: `iblai init` command, `--yes` flag for CI/CD, and `iblai add account`/`analytics` generators.

## Changes

### `.claude/skills/vibe-new-app.md`
- Added **Non-Interactive Mode (CI/CD)** section with `--yes` flag example
- Added **Add AI Skills to an Existing Project** section with `iblai init`
- Updated step 6 to reference `iblai init` instead of `iblai add mcp`

### `CLAUDE.md`
- Added `iblai init`, `--yes` flag, and `iblai add account`/`analytics` to Getting Started
- Added `iblai init` to Adding Features section
- Noted auth requirement for add commands

### `README.md`
- Added `iblai init` to "Add to Existing Apps" section
- Added CI/CD subsection with `--yes` flag usage

## Context

These features were implemented in iblai-app-cli on the `simplification` branch:
- `iblai init` — alias for `iblai add mcp` (agent-native onboarding)
- `--yes`/`-y` flag — skip all interactive prompts for CI/CD
- `iblai add account` + `iblai add analytics` — now have full generators (were previously skills-only)