### PR TITLE
Feat/vibe add auth

### DIFF
--- a/.claude/skills/vibe-add-auth.md
+++ b/.claude/skills/vibe-add-auth.md
@@ -1,0 +1,218 @@
+---
+description: Add ibl.ai SSO authentication to a vanilla Next.js app
+globs:
+alwaysApply: false
+---
+
+# /vibe-add-auth
+
+Add ibl.ai SSO authentication to a vanilla Next.js app. After completion,
+unauthenticated users are redirected to login.iblai.app and returned with
+a session -- no API tokens to manage.
+
+## Prerequisites
+
+- Next.js 14+ with App Router (`app/` directory)
+- Node.js 18+
+- `iblai` CLI available (`iblai --version` to verify)
+- If `iblai` is not available, install from: https://github.com/iblai/iblai-app-cli
+- An ibl.ai tenant key (use `iblai` for the free default tenant, or register at https://iblai.app)
+
+## Step 1: Run the Generator
+
+```bash
+cd your-nextjs-app
+iblai add auth
+```
+
+The generator creates 7 files and patches `next.config`, `globals.css`, and `.env.local`.
+It auto-detects `src/` directory layout and places files accordingly.
+
+## Step 2: Install Dependencies
+
+```bash
+pnpm install
+```
+
+The generator adds these to `package.json`:
+
+- `@iblai/iblai-js` -- SDK (auth, data layer, UI components)
+- `@reduxjs/toolkit` + `react-redux` -- state management (SDK uses RTK Query)
+- `sonner` -- toast notifications
+- `lucide-react` -- icons
+- `react-markdown` + `remark-gfm` -- markdown rendering
+
+## Step 3: Wire Providers into Layout
+
+Open `app/layout.tsx` and wrap `{children}` with the generated `IblaiProviders`.
+
+**If you have no existing providers:**
+
+```tsx
+import { IblaiProviders } from "@/providers/iblai-providers";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <IblaiProviders>{children}</IblaiProviders>
+      </body>
+    </html>
+  );
+}
+```
+
+**If you have existing providers** (e.g., ThemeProvider, custom contexts):
+
+```tsx
+import { IblaiProviders } from "@/providers/iblai-providers";
+import { ThemeProvider } from "next-themes";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <IblaiProviders>
+          <ThemeProvider attribute="class" defaultTheme="system">
+            {children}
+          </ThemeProvider>
+        </IblaiProviders>
+      </body>
+    </html>
+  );
+}
+```
+
+`IblaiProviders` must be the **outermost** provider -- it contains Redux, Auth,
+and Tenant providers that other components depend on. Place your own providers
+inside it.
+
+## Step 4: Configure Environment
+
+Edit `.env.local` (created by the generator):
+
+```bash
+NEXT_PUBLIC_API_BASE_URL=https://api.iblai.app
+NEXT_PUBLIC_AUTH_URL=https://login.iblai.app
+NEXT_PUBLIC_BASE_WS_URL=wss://asgi.data.iblai.app
+NEXT_PUBLIC_PLATFORM_BASE_DOMAIN=iblai.app
+NEXT_PUBLIC_MAIN_TENANT_KEY=iblai
+```
+
+Replace `iblai` with your tenant key if you have one.
+Register at https://iblai.app for a free tenant.
+
+## Step 5: Import SDK Styles
+
+Verify `app/globals.css` has the SDK imports (the generator patches this automatically):
+
+```css
+@import '@iblai/iblai-js/web-containers/styles';
+@source "../node_modules/@iblai/iblai-js/dist/web-containers/source";
+```
+
+If these lines are missing, add them near the top of `globals.css`.
+
+## Step 6: Verify
+
+```bash
+pnpm dev
+```
+
+1. Open http://localhost:3000
+2. You should be redirected to https://login.iblai.app
+3. Log in (or create a free account)
+4. You'll be returned to your app with a fully authenticated session
+5. Check browser localStorage -- you should see `axd_token`, `userData`, `tenants`
+
+## What Was Generated
+
+| File | Purpose |
+|------|---------|
+| `app/sso-login-complete/page.tsx` | SSO callback -- stores tokens from URL into localStorage |
+| `lib/iblai/config.ts` | Environment variable accessors (API URLs, tenant key, auth URL) |
+| `lib/iblai/storage-service.ts` | localStorage wrapper implementing the SDK's StorageService interface |
+| `lib/iblai/auth-utils.ts` | `redirectToAuthSpa()`, `hasNonExpiredAuthToken()`, `handleLogout()` |
+| `store/iblai-store.ts` | Redux store with `coreApiSlice`, `mentorReducer`, `mentorMiddleware` |
+| `providers/iblai-providers.tsx` | Provider chain: ReduxProvider > AuthProvider > TenantProvider |
+| `app/iblai-styles.css` | SDK style imports for Tailwind class scanning |
+
+## What Was Patched
+
+- **`next.config.mjs`** -- webpack `resolve.alias` to deduplicate `@reduxjs/toolkit`.
+  Without this, SDK components use a different `ReactReduxContext` and RTK Query
+  hooks silently return `undefined` with zero HTTP requests.
+- **`globals.css`** -- `@import` for SDK base styles + `@source` for Tailwind
+  class generation from SDK components.
+- **`.env.local`** -- API URLs, auth URL, tenant key, WebSocket URL.
+
+## Advanced: Route Groups
+
+For production apps, consider moving the SSO callback outside the auth
+providers using Next.js route groups:
+
+```
+app/
+├── (auth)/
+│   └── sso-login-complete/page.tsx   ← Outside providers (no AuthProvider wrapper)
+└── (app)/
+    ├── layout.tsx                     ← IblaiProviders wraps only this group
+    └── page.tsx
+```
+
+This prevents the SSO callback deadlock where `AuthProvider` blocks rendering
+before tokens are stored. The generator places the callback at
+`app/sso-login-complete/` (flat, no route group) which works for simple apps.
+
+For the route group pattern, see the reference implementation:
+  https://github.com/iblai/iblai-app-cli/tree/main/examples/iblai-agent-app
+
+## Troubleshooting
+
+### "Unknown server error" with custom-domains on localhost
+
+The SDK calls `/api/custom-domains?domain=localhost` as part of tenant detection.
+This fails on localhost but is **harmless** -- the tenant is resolved from
+`NEXT_PUBLIC_MAIN_TENANT_KEY` in `.env.local` instead. You can safely ignore
+this console error during local development.
+
+### SDK components show undefined / no API requests
+
+`@reduxjs/toolkit` must be deduplicated in `next.config.mjs`. Without the
+webpack alias, the SDK's components use a different `ReactReduxContext` than
+your app's `StoreProvider`, so RTK Query hooks silently return `undefined`.
+
+Verify your next.config has:
+```javascript
+config.resolve.alias['@reduxjs/toolkit'] = rtkDir;
+```
+
+### Auth redirect loops
+
+The SSO callback page (`app/sso-login-complete/page.tsx`) must NOT be wrapped
+by `AuthProvider`. If it is, `AuthProvider` detects "no tokens" and redirects
+to login before the callback can store the tokens -- creating an infinite loop.
+
+If this happens, use the route group pattern described above to separate the
+SSO callback from the authenticated routes.
+
+### Blank screen after login
+
+Check that `.env.local` has `NEXT_PUBLIC_MAIN_TENANT_KEY` set. Without it,
+the tenant resolution falls back to custom-domain detection which fails on
+localhost, leaving the app in a broken state.
+
+## Next Steps
+
+After auth is set up, add more features:
+
+```bash
+iblai add chat           # AI chat widget
+iblai add profile        # User profile + settings page
+iblai add account        # Organization/account settings
+iblai add analytics      # Analytics dashboard
+iblai add notifications  # Notification bell + center page
+```
+
+For the complete reference implementation with all features:
+  https://github.com/iblai/iblai-app-cli/tree/main/examples/iblai-agent-app

--- a/.claude/skills/vibe-add-feature.md
+++ b/.claude/skills/vibe-add-feature.md
@@ -12,7 +12,7 @@ Add pre-built iblai components to an existing Next.js app.
 
 | Command | What It Adds |
 |---------|-------------|
-| `iblai add auth` | SSO authentication -- redirects to ibl.ai login, returns with session. Adds Redux store, AuthProvider, TenantProvider, SSO callback page. |
+| `iblai add auth` | SSO authentication -- see `/vibe-add-auth` for detailed step-by-step walkthrough |
 | `iblai add chat` | AI chat widget -- `<mentor-ai>` web component. Full-screen or embedded chat with streaming, file upload, voice. |
 | `iblai add profile` | User profile dropdown -- avatar with dropdown menu, profile settings page. |
 | `iblai add account` | Organization/account settings -- tenant management, team settings. |

--- a/.claude/skills/vibe-setup-env.md
+++ b/.claude/skills/vibe-setup-env.md
@@ -1,0 +1,91 @@
+---
+description: Set up environment variables for your ibl.ai app
+globs:
+alwaysApply: false
+---
+
+# /vibe-setup-env
+
+Expand the simple `.env.example` into a full `.env.local` for your ibl.ai app.
+
+## Quick Setup
+
+1. Copy the example to your app root:
+   ```bash
+   cp .env.example .env.local
+   ```
+
+2. Set your platform key:
+   ```bash
+   iblai config set NEXT_PUBLIC_MAIN_TENANT_KEY your-actual-key
+   ```
+
+3. Verify:
+   ```bash
+   iblai config show
+   ```
+
+## How the Two Variables Map
+
+The `.env.example` has two simple values:
+
+| Variable | Default | What it is |
+|----------|---------|------------|
+| `DOMAIN` | `iblai.app` | Base domain for all ibl.ai services |
+| `PLATFORM` | `your-platform` | Your tenant/platform key |
+
+These map to the full environment your app needs:
+
+| App Variable | Derived From |
+|-------------|-------------|
+| `NEXT_PUBLIC_API_BASE_URL` | `https://api.{DOMAIN}` |
+| `NEXT_PUBLIC_AUTH_URL` | `https://login.{DOMAIN}` |
+| `NEXT_PUBLIC_BASE_WS_URL` | `wss://asgi.data.{DOMAIN}` |
+| `NEXT_PUBLIC_PLATFORM_BASE_DOMAIN` | `{DOMAIN}` |
+| `NEXT_PUBLIC_MAIN_TENANT_KEY` | `{PLATFORM}` |
+
+## Using the CLI
+
+The `iblai config` command manages `.env.local` for you:
+
+```bash
+# View current config (shows all variables with values and sources)
+iblai config show
+
+# Set your platform key
+iblai config set NEXT_PUBLIC_MAIN_TENANT_KEY my-org
+
+# Override the default domain (for custom deployments)
+iblai config set NEXT_PUBLIC_API_BASE_URL https://api.my-domain.com
+iblai config set NEXT_PUBLIC_AUTH_URL https://login.my-domain.com
+iblai config set NEXT_PUBLIC_BASE_WS_URL wss://asgi.data.my-domain.com
+iblai config set NEXT_PUBLIC_PLATFORM_BASE_DOMAIN my-domain.com
+```
+
+## Default (iblai.app)
+
+For the default free tenant, you only need to set your platform key:
+
+```bash
+iblai config set NEXT_PUBLIC_MAIN_TENANT_KEY my-org
+```
+
+Everything else defaults to iblai.app endpoints automatically.
+
+## Custom Domain
+
+If you have a custom domain (e.g., `my-company.com`), set all values:
+
+```
+DOMAIN=my-company.com
+PLATFORM=my-company
+```
+
+Then use `iblai config set` for each `NEXT_PUBLIC_*` variable, replacing
+`iblai.app` with your domain.
+
+## Getting a Tenant Key
+
+- Use `iblai` as the default free tenant for development
+- Register at https://iblai.app for your own tenant with custom branding
+- Your tenant key is shown in the iblai.app dashboard under Settings

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# ibl.ai Platform Configuration
+# Copy to .env.local in your app and replace PLATFORM with your tenant key.
+DOMAIN=iblai.app
+PLATFORM=your-platform

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+.env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ Invoke with `/` in Claude Code:
 | Skill | Description |
 |-------|-------------|
 | `/vibe-new-app` | Scaffold and configure a new iblai app |
+| `/vibe-add-auth` | Add ibl.ai SSO auth to a vanilla Next.js app (step-by-step) |
 | `/vibe-add-feature` | Add an iblai component to your app |
 | `/vibe-deploy` | Deploy to Vercel, Docker, or app stores |
 | `/vibe-customize` | Customize UI with shadcn + iblai brand |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ Invoke with `/` in Claude Code:
 |-------|-------------|
 | `/vibe-new-app` | Scaffold and configure a new iblai app |
 | `/vibe-add-auth` | Add ibl.ai SSO auth to a vanilla Next.js app (step-by-step) |
+| `/vibe-setup-env` | Set up environment variables from .env.example |
 | `/vibe-add-feature` | Add an iblai component to your app |
 | `/vibe-deploy` | Deploy to Vercel, Docker, or app stores |
 | `/vibe-customize` | Customize UI with shadcn + iblai brand |


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
## Summary

Add two new Claude Code skills and a `.env.example` to the vibe repo for guided auth integration and environment setup.

## Changes

### New Skill: `/vibe-add-auth`

Step-by-step guide for adding ibl.ai SSO authentication to a **vanilla Next.js 15 app** (not scaffolded by `iblai startapp` — a plain `create-next-app` project).

Covers:
- Prerequisites (Next.js App Router, `iblai` CLI, tenant key)
- Running `iblai add auth` (7 files generated + 3 patches)
- Installing dependencies (7 npm packages)
- Wiring `IblaiProviders` into layout — with and without existing providers (ThemeProvider, custom contexts). `IblaiProviders` must be outermost.
- Environment configuration (`.env.local` with iblai.app URLs)
- SDK style imports in `globals.css`
- Verification steps (redirect to login.iblai.app, check localStorage for tokens)
- Complete file and patch reference tables
- Advanced: route groups `(auth)/` pattern to prevent SSO callback deadlock
- Troubleshooting: custom-domains on localhost, RTK dedup, auth redirect loops, blank screen after login
- Next steps: `iblai add chat/profile/account/analytics/notifications`

### New Skill: `/vibe-setup-env`

Guide for expanding the simple `.env.example` into a full `.env.local`.

The `.env.example` has two human-readable variables:
```
DOMAIN=iblai.app
PLATFORM=your-platform
```

The skill explains how these map to `NEXT_PUBLIC_*` variables and shows `iblai config set` as the primary method to configure the environment. Covers default (iblai.app) setup, custom domains, and getting a tenant key.

### `.env.example`

Simple 2-variable config at the repo root:
- `DOMAIN=iblai.app` — base domain for all ibl.ai services
- `PLATFORM=your-platform` — tenant/platform key (replace with actual key)

### `.gitignore`

Ignores `.env` and `.env.local` to prevent committing secrets.

### Updated Files

- **`CLAUDE.md`** — added `/vibe-add-auth` and `/vibe-setup-env` to the skills table (7 skills total)
- **`.claude/skills/vibe-add-feature.md`** — auth row now references `/vibe-add-auth` for the detailed walkthrough instead of inline description

## Skills (After This PR)

| Skill | Description |
|-------|-------------|
| `/vibe-new-app` | Scaffold and configure a new iblai app |
| `/vibe-add-auth` | **New** — Add ibl.ai SSO auth to a vanilla Next.js app (step-by-step) |
| `/vibe-setup-env` | **New** — Set up environment variables from .env.example |
| `/vibe-add-feature` | Add an iblai component to your app |
| `/vibe-deploy` | Deploy to Vercel, Docker, or app stores |
| `/vibe-customize` | Customize UI with shadcn + iblai brand |
| `/vibe-connect-backend` | Connect to iblai.app or your own tenant |

## Files Changed

6 files changed, 318 insertions, 1 deletion

| File | Action |
|------|--------|
| `.claude/skills/vibe-add-auth.md` | New (175 lines) |
| `.claude/skills/vibe-setup-env.md` | New (82 lines) |
| `.claude/skills/vibe-add-feature.md` | Modified (1 line — auth reference) |
| `.env.example` | New (4 lines) |
| `.gitignore` | New (2 lines) |
| `CLAUDE.md` | Modified (2 lines — skills table) |
