### PR TITLE
feat: add /vibe-install-cli skill with Windows support, reference fro…

### DIFF
--- a/.claude/skills/vibe-install-cli.md
+++ b/.claude/skills/vibe-install-cli.md
@@ -1,0 +1,1 @@
+../../skills/vibe-install-cli/SKILL.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,25 +24,34 @@ get_playwright_helper_info("createConfig")    # E2E test utilities
 - The `@iblai/iblai-js` SDK with auth, chat, UI components, and data layer
 - Connection to iblai.app -- a production backend with SSO auth, AI agents, analytics, and multi-tenancy
 
+## Installing the CLI
+
+```bash
+iblai --version    # Check if already available
+```
+
+If not available, see `/vibe-install-cli` for installation options (npx or build from source).
+
 ## Getting Started
 
 ```bash
 # Scaffold a new app
-npx @iblai/cli startapp agent
+iblai startapp agent
+# or: npx @iblai/cli startapp agent
 
 # Non-interactive (CI/CD)
-npx @iblai/cli startapp agent --yes --platform acme --app-name my-app
+iblai startapp agent --yes --platform acme --app-name my-app
 
 # Add AI skills to an existing project
-npx @iblai/cli init
+iblai init
 
 # Add features to an existing Next.js app
-npx @iblai/cli add auth
-npx @iblai/cli add chat
-npx @iblai/cli add profile
-npx @iblai/cli add account
-npx @iblai/cli add analytics
-npx @iblai/cli add notifications
+iblai add auth
+iblai add chat
+iblai add profile
+iblai add account
+iblai add analytics
+iblai add notifications
 ```
 
 ## Architecture
@@ -146,6 +155,7 @@ Invoke with `/` in Claude Code:
 
 | Skill | Description |
 |-------|-------------|
+| `/vibe-install-cli` | Install the iblai CLI (npx or build from source) |
 | `/vibe-new-app` | Scaffold and configure a new iblai app |
 | `/vibe-add-auth` | Add ibl.ai SSO auth to a vanilla Next.js app (step-by-step) |
 | `/vibe-setup-env` | Set up environment variables from .env.example |

--- a/skills/vibe-add-auth/SKILL.md
+++ b/skills/vibe-add-auth/SKILL.md
@@ -14,15 +14,19 @@ a session -- no API tokens to manage.
 
 - Next.js 14+ with App Router (`app/` directory)
 - Node.js 18+
-- `iblai` CLI available (`iblai --version` to verify)
-- If `iblai` is not available, install from: https://github.com/iblai/iblai-app-cli
+- `iblai` CLI available (`iblai --version`). If not available, run `/vibe-install-cli`
 - An ibl.ai tenant key (use `iblai` for the free default tenant, or register at https://iblai.app)
 
 ## Step 1: Run the Generator
 
 ```bash
 cd your-nextjs-app
+
+# If iblai is installed globally
 iblai add auth
+
+# Or via npx (when published)
+npx @iblai/cli add auth
 ```
 
 The generator creates 7 files and patches `next.config`, `globals.css`, and `.env.local`.

--- a/skills/vibe-add-feature/SKILL.md
+++ b/skills/vibe-add-feature/SKILL.md
@@ -25,8 +25,12 @@ Add pre-built iblai components to an existing Next.js app.
 
 1. **Navigate to your Next.js project root**
 
-2. **Run the add command**:
+2. **Run the add command** (choose one):
    ```bash
+   # If iblai is installed globally
+   iblai add auth
+
+   # Or via npx (when published)
    npx @iblai/cli add auth
    ```
 
@@ -55,4 +59,5 @@ ibl.ai and shadcn components share the same Tailwind theme and are visually seam
 
 - Next.js App Router project (app/ directory)
 - Node.js 18+
+- `iblai` CLI available (`iblai --version`). If not available, run `/vibe-install-cli`
 - The `auth` component should be added first if you need authentication (other components depend on the auth providers)

--- a/skills/vibe-install-cli/SKILL.md
+++ b/skills/vibe-install-cli/SKILL.md
@@ -1,0 +1,113 @@
+---
+description: Install the iblai CLI (build from source or npx)
+globs:
+alwaysApply: false
+---
+
+# /vibe-install-cli
+
+Install the iblai CLI for scaffolding and managing ibl.ai apps.
+
+## Quick Check
+
+```bash
+iblai --version
+```
+
+If this works, you're all set -- skip to the skill you need.
+
+## Option 1: npx (When Published)
+
+```bash
+npx @iblai/cli --version
+```
+
+This downloads and runs the CLI without a global install.
+Use `npx @iblai/cli` as a prefix for any command:
+
+```bash
+npx @iblai/cli startapp agent
+npx @iblai/cli add auth
+npx @iblai/cli config show
+```
+
+## Option 2: Build from Source
+
+### macOS / Linux
+
+Requires: Python 3.11+, pip, git, make
+
+```bash
+git clone https://github.com/iblai/iblai-app-cli.git
+cd iblai-app-cli
+make -C .iblai install
+```
+
+Verify:
+
+```bash
+iblai --version
+```
+
+If the command is not found, add `~/.local/bin` to your PATH:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+To make this permanent:
+
+```bash
+# bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+
+# zsh
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+```
+
+Then return to your project:
+
+```bash
+cd -   # back to your project directory
+```
+
+### Windows
+
+Requires: Python 3.11+, pip, git
+
+```powershell
+git clone https://github.com/iblai/iblai-app-cli.git
+cd iblai-app-cli
+pip install -e .iblai/
+```
+
+Verify:
+
+```powershell
+iblai --version
+```
+
+If the command is not found, ensure Python Scripts is in your PATH.
+It is typically at `%APPDATA%\Python\Python311\Scripts\` or
+`%LOCALAPPDATA%\Programs\Python\Python311\Scripts\`.
+
+```powershell
+# Check where pip installs scripts
+python -m site --user-site
+# The Scripts directory is a sibling of the site-packages directory shown
+```
+
+Then return to your project:
+
+```powershell
+cd -
+```
+
+## Which Option to Use
+
+| Method | When to use |
+|--------|------------|
+| `npx @iblai/cli` | Easiest, no install needed. Requires npm package to be published. |
+| Build from source | Always works. Gives you the latest version from GitHub. |
+
+If `npx @iblai/cli` returns "not found" or an error, use the build-from-source method.

--- a/skills/vibe-new-app/SKILL.md
+++ b/skills/vibe-new-app/SKILL.md
@@ -11,14 +11,18 @@ Scaffold a new AI-powered app using the iblai CLI.
 ## Steps
 
 1. **Check prerequisites**: Node.js 18+, pnpm (recommended)
+   - `iblai` CLI: `iblai --version` (if not available, run `/vibe-install-cli`)
 
-2. **Scaffold the app**:
+2. **Scaffold the app** (choose one):
    ```bash
+   # If iblai is installed globally
+   iblai startapp agent --platform <tenant> --agent <agent-id>
+
+   # Or via npx (when published)
    npx @iblai/cli startapp agent --platform <tenant> --agent <agent-id>
    ```
    - If the user doesn't have a tenant yet, use `iblai` as the default
    - If they don't have an agent ID, omit `--agent` (will prompt or use default)
-   - For a minimal app without the chat UI, use `startapp base` instead
 
 3. **Install dependencies**:
    ```bash

--- a/skills/vibe-setup-env/SKILL.md
+++ b/skills/vibe-setup-env/SKILL.md
@@ -8,6 +8,10 @@ alwaysApply: false
 
 Expand the simple `.env.example` into a full `.env.local` for your ibl.ai app.
 
+## Prerequisites
+
+- `iblai` CLI available (`iblai --version`). If not available, run `/vibe-install-cli`
+
 ## Quick Setup
 
 1. Copy the example to your app root:
@@ -17,12 +21,17 @@ Expand the simple `.env.example` into a full `.env.local` for your ibl.ai app.
 
 2. Set your platform key:
    ```bash
+   # If iblai is installed globally
    iblai config set NEXT_PUBLIC_MAIN_TENANT_KEY your-actual-key
+
+   # Or via npx (when published)
+   npx @iblai/cli config set NEXT_PUBLIC_MAIN_TENANT_KEY your-actual-key
    ```
 
 3. Verify:
    ```bash
    iblai config show
+   # or: npx @iblai/cli config show
    ```
 
 ## How the Two Variables Map


### PR DESCRIPTION
…m other skills

New skill /vibe-install-cli covering CLI installation:
  - Quick check (iblai --version)
  - Option 1: npx @iblai/cli (when published)
  - Option 2: Build from source — macOS/Linux (make -C .iblai install) and Windows (pip install -e .iblai/)
  - PATH troubleshooting (~/.local/bin on Unix, Python Scripts on Windows)
  - Permanent PATH setup for bash and zsh

Updated 4 skills to reference /vibe-install-cli instead of inline install instructions, and to show both 'iblai' and 'npx @iblai/cli' command options:
  - /vibe-new-app: prerequisites + scaffold step
  - /vibe-add-auth: prerequisites + step 1
  - /vibe-add-feature: requirements + how to use step
  - /vibe-setup-env: new prerequisites section + steps

Updated CLAUDE.md:
  - Added 'Installing the CLI' section with /vibe-install-cli reference
  - Changed Getting Started examples from npx-only to iblai-first
  - Added /vibe-install-cli to skills table (8 skills total)


## Checklist
- [ ] Tests were added/updated according to the feature/bugfix/change made
- [ ] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [ ] API endpoints openapi schema was updated if applicable

## Changes
