### PR TITLE
chore: add name attribute to skills front matter

### DIFF
--- a/skills/vibe-add-auth/SKILL.md
+++ b/skills/vibe-add-auth/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vibe-add-auth
 description: Add ibl.ai SSO authentication to a vanilla Next.js app
 globs:
 alwaysApply: false

--- a/skills/vibe-add-feature/SKILL.md
+++ b/skills/vibe-add-feature/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vibe-add-feature
 description: Add an iblai component or feature to your app
 globs:
 alwaysApply: false

--- a/skills/vibe-connect-backend/SKILL.md
+++ b/skills/vibe-connect-backend/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vibe-connect-backend
 description: Connect your app to the iblai backend
 globs:
 alwaysApply: false

--- a/skills/vibe-customize/SKILL.md
+++ b/skills/vibe-customize/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vibe-customize
 description: Customize your app's UI with shadcn and iblai brand
 globs:
 alwaysApply: false

--- a/skills/vibe-deploy/SKILL.md
+++ b/skills/vibe-deploy/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vibe-deploy
 description: Deploy your iblai app to production
 globs:
 alwaysApply: false

--- a/skills/vibe-install-cli/SKILL.md
+++ b/skills/vibe-install-cli/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vibe-install-cli
 description: Install the iblai CLI (build from source or npx)
 globs:
 alwaysApply: false

--- a/skills/vibe-new-app/SKILL.md
+++ b/skills/vibe-new-app/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vibe-new-app
 description: Scaffold and configure a new iblai-powered app
 globs:
 alwaysApply: false

--- a/skills/vibe-setup-env/SKILL.md
+++ b/skills/vibe-setup-env/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: vibe-setup-env
 description: Set up environment variables for your ibl.ai app
 globs:
 alwaysApply: false


### PR DESCRIPTION
Added name: <skill-name> (no / prefix) to the YAML front matter of all 8 SKILL.md files: vibe-install-cli, vibe-new-app, vibe-add-auth, vibe-setup-env, vibe-add-feature, vibe-deploy, vibe-customize, vibe-connect-backend.


## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
add name attribute to skills front matter