### PR TITLE
fix: make create-next-app command non-interactive and update stale refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,11 +38,11 @@ installation options (npx or build from source).
 ### Vanilla Next.js + ibl.ai Features
 
 ```bash
-npx create-next-app@latest my-app --typescript --tailwind --eslint --app --src-dir
+npx create-next-app@latest my-app --yes
 cd my-app
 iblai add auth
 iblai add chat
-pnpm install && pnpm dev
+npm run dev
 ```
 
 ### Full ibl.ai Agent App
@@ -90,7 +90,7 @@ import { SsoLogin, UserProfileDropdown } from "@iblai/iblai-js/web-containers/ne
 
 ### Redux Store
 
-`@reduxjs/toolkit` is deduplicated via webpack `resolve.alias` in `next.config.mjs`. Without deduplication, SDK components use a different `ReactReduxContext` and RTK Query hooks silently return `undefined`.
+`@reduxjs/toolkit` is deduplicated via webpack `resolve.alias` in `next.config.ts`. Without deduplication, SDK components use a different `ReactReduxContext` and RTK Query hooks silently return `undefined`.
 
 ## Environment (.env.local)
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ A developer toolkit for vibe coding with the [ibl.ai](https://ibl.ai) platform. 
 Create a standard Next.js app and add ibl.ai features as needed:
 
 ```bash
-npx create-next-app@latest my-app --typescript --tailwind --eslint --app --src-dir
+npx create-next-app@latest my-app --yes
 cd my-app
 iblai add auth           # SSO authentication
 iblai add chat           # AI chat widget
-pnpm install && pnpm dev
+npm run dev
 ```
 
 ### Or Scaffold a Full ibl.ai Agent App

--- a/skills/iblai-auth/SKILL.md
+++ b/skills/iblai-auth/SKILL.md
@@ -21,8 +21,7 @@ a session -- no API tokens to manage.
 > to get a full app with auth, chat, and everything pre-configured.
 >
 > **This skill** is for adding auth to a vanilla Next.js app
-> (`npx create-next-app@latest my-app --typescript --tailwind --eslint --app --src-dir`)
-> or an existing project.
+> (`npx create-next-app@latest my-app --yes`) or an existing project.
 
 - Next.js 14+ with App Router (`app/` directory)
 - Node.js 18+
@@ -102,7 +101,7 @@ The generator adds these to `package.json`:
 - `@reduxjs/toolkit` + `react-redux` -- state management (SDK uses RTK Query)
 - `sonner` -- toast notifications
 - `lucide-react` -- icons
-- `react-markdown` + `remark-gfm` -- markdown rendering
+
 
 ## Step 3: Wire Providers into Layout
 
@@ -204,9 +203,10 @@ pnpm dev
 
 ## What Was Patched
 
-- **`next.config.mjs`** -- webpack `resolve.alias` to deduplicate `@reduxjs/toolkit`.
-  Without this, SDK components use a different `ReactReduxContext` and RTK Query
-  hooks silently return `undefined` with zero HTTP requests.
+- **`next.config.ts`** -- webpack `resolve.alias` to deduplicate `@reduxjs/toolkit`,
+  `turbopack: {}` for Next.js 16+, and Tauri stub aliases. Without the dedup,
+  SDK components use a different `ReactReduxContext` and RTK Query hooks silently
+  return `undefined` with zero HTTP requests.
 - **`globals.css`** -- `@import` for SDK base styles + `@source` for Tailwind
   class generation from SDK components.
 - **`.env.local`** -- API URLs, auth URL, tenant key, WebSocket URL.
@@ -243,7 +243,7 @@ this console error during local development.
 
 ### SDK components show undefined / no API requests
 
-`@reduxjs/toolkit` must be deduplicated in `next.config.mjs`. Without the
+`@reduxjs/toolkit` must be deduplicated in `next.config.ts`. Without the
 webpack alias, the SDK's components use a different `ReactReduxContext` than
 your app's `StoreProvider`, so RTK Query hooks silently return `undefined`.
 

--- a/skills/iblai-components/SKILL.md
+++ b/skills/iblai-components/SKILL.md
@@ -16,11 +16,11 @@ Overview of all ibl.ai components and how to create a new app.
 Start with a standard Next.js app and add features as needed:
 
 ```bash
-npx create-next-app@latest my-app --typescript --tailwind --eslint --app --src-dir
+npx create-next-app@latest my-app --yes
 cd my-app
 iblai add auth --platform your-tenant
 iblai add chat
-pnpm install && pnpm dev
+npm run dev
 ```
 
 ### Full ibl.ai Agent App


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- Add --yes flag to all create-next-app commands (4 files) to suppress interactive prompts (e.g. React Compiler) that block AI agents and CI
- Simplify flags: TS, Tailwind, ESLint, App Router are all defaults in Next.js 16, so --yes alone is sufficient
- Remove react-markdown + remark-gfm from auth skill deps list (dropped from CLI AUTH_DEPS)
- Change next.config.mjs references to next.config.ts (Next.js 16 default)
- Change pnpm install/dev to npm run dev (create-next-app defaults to npm)
