### PR TITLE
chore: remove all iblai add references except auth and chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,11 @@ pnpm dev
 ```bash
 iblai add auth           # SSO authentication
 iblai add chat           # AI chat widget
-iblai add profile        # User profile page
-iblai add account        # Account settings
-iblai add analytics      # Analytics dashboard
-iblai add notifications  # Notification bell
 ```
+
+Other features (profile, account, analytics, notifications) are built using
+skills -- see `/iblai-profile`, `/iblai-account`, `/iblai-analytics`,
+`/iblai-notifications`.
 
 ## Architecture
 
@@ -137,7 +137,7 @@ iblai init               # Alias for iblai add mcp
 ### AI-Built Components (use skills)
 
 These features are built by the AI assistant using SDK components and the
-detailed code provided in each skill. Do NOT use `iblai add` for these:
+detailed code provided in each skill:
 
 | Skill | What It Adds |
 |-------|-------------|

--- a/skills/iblai-account/SKILL.md
+++ b/skills/iblai-account/SKILL.md
@@ -13,8 +13,8 @@ User Management, Integrations, Advanced settings, and Billing.
 ![Account Page](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-account/account-page.png)
 
 > **AI Assistant:** Build this component directly using the code and MCP tools
-> below. Do NOT run `iblai add account` -- you are building this feature
-> yourself using the SDK components documented here.
+> below. Do NOT use the CLI for this -- you are building this feature yourself
+> using the SDK components documented here.
 >
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.

--- a/skills/iblai-analytics/SKILL.md
+++ b/skills/iblai-analytics/SKILL.md
@@ -14,8 +14,8 @@ Users, Topics, Financial, Transcripts, and Reports.
 ![Analytics Page](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-analytics/analytics-page.png)
 
 > **AI Assistant:** Build this component directly using the code and MCP tools
-> below. Do NOT run `iblai add analytics` -- you are building this feature
-> yourself using the SDK components documented here.
+> below. Do NOT use the CLI for this -- you are building this feature yourself
+> using the SDK components documented here.
 >
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.

--- a/skills/iblai-auth/SKILL.md
+++ b/skills/iblai-auth/SKILL.md
@@ -272,12 +272,18 @@ localhost, leaving the app in a broken state.
 After auth is set up, add more features:
 
 ```bash
-iblai add chat           # AI chat widget
-iblai add profile        # User profile + settings page
-iblai add account        # Organization/account settings
-iblai add analytics      # Analytics dashboard
-iblai add notifications  # Notification bell + center page
+iblai add chat           # AI chat widget (requires agent ID)
 ```
+
+Other features are built using skills -- ask your AI assistant to use:
+
+| Skill | What It Adds |
+|-------|-------------|
+| `/iblai-chat` | AI chat widget |
+| `/iblai-profile` | User profile dropdown + settings page |
+| `/iblai-account` | Account/organization settings page |
+| `/iblai-analytics` | Analytics dashboard page |
+| `/iblai-notifications` | Notification bell + center page |
 
 For the complete reference implementation with all features:
   https://github.com/iblai/iblai-app-cli/tree/main/examples/iblai-agent-app

--- a/skills/iblai-notifications/SKILL.md
+++ b/skills/iblai-notifications/SKILL.md
@@ -13,8 +13,8 @@ navbar and a full notification center page with Inbox and Alerts tabs.
 ![Notifications Page](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-notifications/notifications-page.png)
 
 > **AI Assistant:** Build this component directly using the code and MCP tools
-> below. Do NOT run `iblai add notifications` -- you are building this feature
-> yourself using the SDK components documented here.
+> below. Do NOT use the CLI for this -- you are building this feature yourself
+> using the SDK components documented here.
 >
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.

--- a/skills/iblai-profile/SKILL.md
+++ b/skills/iblai-profile/SKILL.md
@@ -14,8 +14,8 @@ Experience, Resume, and Security.
 ![Profile Page](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-profile/profile-page.png)
 
 > **AI Assistant:** Build this component directly using the code and MCP tools
-> below. Do NOT run `iblai add profile` -- you are building this feature
-> yourself using the SDK components documented here.
+> below. Do NOT use the CLI for this -- you are building this feature yourself
+> using the SDK components documented here.
 >
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
Only iblai add auth and iblai add chat remain as CLI commands. All references to iblai add profile/account/analytics/notifications have been removed or replaced with skill references.

- AI-built component skills: changed 'Do NOT run iblai add <x>' to 'Do NOT use the CLI for this'
- Auth skill: replaced iblai add list with skills table
- CLAUDE.md: trimmed Add Features block to auth + chat only, cleaned up AI-Built Components section
