### PR TITLE
chore: no dark mode by default, hide iblai-styles.css from user

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,14 @@
     "iblai": {
       "command": "npx",
       "args": ["-y", "@iblai/mcp"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    },
+    "shadcn": {
+      "command": "npx",
+      "args": ["-y", "shadcn@latest", "mcp"]
     }
   }
 }

--- a/BRAND.md
+++ b/BRAND.md
@@ -176,24 +176,6 @@ The SDK provides utility classes for common brand patterns:
 
 ---
 
-## Dark Mode
-
-The SDK supports dark mode via the `.dark-mode` CSS class. Dark mode
-overrides the CSS custom properties with a dark palette:
-
-| Token | Light | Dark |
-|-------|-------|------|
-| Background | `#ffffff` | `#1a1a2e` |
-| Surface | `#fafbfc` | `#16213e` |
-| Card BG | `#ffffff` | `#1e2a4a` |
-| Border | `#e5e7eb` | `#2a3a5c` |
-| Text Primary | `#616a76` | `#e0e0e0` |
-| Text Secondary | `#717985` | `#b0b0b0` |
-
-Toggle dark mode by adding/removing the `.dark-mode` class on the root element.
-
----
-
 ## Using with shadcn Components
 
 When adding shadcn UI components, the brand values above are already mapped

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,11 +103,11 @@ NEXT_PUBLIC_MAIN_TENANT_KEY=your-tenant-key
 NEXT_PUBLIC_DEFAULT_AGENT_ID=your-agent-id
 ```
 
-Register at https://iblai.app for your own tenant. Replace with your tenant key.
+Register at https://mentorai.iblai.app for your own tenant. Replace with your tenant key.
 
 > **AI Assistant:** Before running `iblai add auth`, you MUST ask the user for
 > their platform/tenant key. If `NEXT_PUBLIC_MAIN_TENANT_KEY` is set to a
-> placeholder (`your-tenant`, `your-platform`, `your-tenant-key`, `iblai`,
+> placeholder (`your-tenant`, `your-platform`, `your-tenant-key`,
 > `test-tenant`, `main`, or empty), ask the user for their real key.
 >
 > When adding chat (`/iblai-chat`), you MUST ask the user for their

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,27 +124,17 @@ iblai open              # Open localhost:3000 in browser
 
 ## Adding Features
 
-### CLI Commands (auth and chat)
-
 ```bash
+iblai add mcp            # MCP servers + skills (run first)
 iblai add auth           # SSO authentication + Redux store + providers
 iblai add chat           # AI chat widget (<mentor-ai> web component)
+iblai add profile        # User profile dropdown
+iblai add account        # Account/organization settings page
+iblai add analytics      # Analytics dashboard page
+iblai add notifications  # Notification bell
 iblai add builds         # Tauri v2 desktop/mobile shell
-iblai add mcp            # MCP server config + Claude/OpenCode/Cursor skills
 iblai init               # Alias for iblai add mcp
 ```
-
-### AI-Built Components (use skills)
-
-These features are built by the AI assistant using SDK components and the
-detailed code provided in each skill:
-
-| Skill | What It Adds |
-|-------|-------------|
-| `/iblai-profile` | User profile dropdown + settings page |
-| `/iblai-account` | Account/organization settings page |
-| `/iblai-analytics` | Analytics dashboard page |
-| `/iblai-notifications` | Notification bell + center page |
 
 All features require auth to be set up first (`iblai add auth`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,14 +99,19 @@ NEXT_PUBLIC_API_BASE_URL=https://api.iblai.app
 NEXT_PUBLIC_AUTH_URL=https://login.iblai.app
 NEXT_PUBLIC_BASE_WS_URL=wss://asgi.data.iblai.app
 NEXT_PUBLIC_PLATFORM_BASE_DOMAIN=iblai.app
-NEXT_PUBLIC_MAIN_TENANT_KEY=iblai
+NEXT_PUBLIC_MAIN_TENANT_KEY=your-tenant-key
 NEXT_PUBLIC_DEFAULT_AGENT_ID=your-agent-id
 ```
 
-Register at https://iblai.app for your own tenant. Replace `iblai` with your tenant key.
+Register at https://iblai.app for your own tenant. Replace with your tenant key.
 
-> **AI Assistant:** When adding chat (`/iblai-chat`), you MUST ask the user for
-> their agent/mentor ID (a UUID). Do not use the placeholder value above.
+> **AI Assistant:** Before running `iblai add auth`, you MUST ask the user for
+> their platform/tenant key. If `NEXT_PUBLIC_MAIN_TENANT_KEY` is set to a
+> placeholder (`your-tenant`, `your-platform`, `your-tenant-key`, `iblai`,
+> `test-tenant`, `main`, or empty), ask the user for their real key.
+>
+> When adding chat (`/iblai-chat`), you MUST ask the user for their
+> agent/mentor ID (a UUID). Do not use placeholder values.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,36 @@ npx skills add iblai/vibe
 
 This installs 7 skills that teach your AI agent how to build with the ibl.ai platform -- authentication, AI chat, profiles, analytics, and more. Works with [Claude Code, Cursor, OpenCode, Copilot, and 15+ other agents](https://skills.sh).
 
+### Skills Usage Guide
+
+After installing the skills, use them directly in your AI agent with `/` commands:
+
+```text
+/iblai-auth
+/iblai-chat
+/iblai-profile
+/iblai-account
+/iblai-analytics
+/iblai-notifications
+/iblai-test
+```
+
+Recommended flow for a new or existing app:
+
+1. Ask the user for their **tenant/platform key**.
+2. Run `iblai add mcp` to set up MCP servers for the project.
+3. Run `/iblai-auth` to add authentication with `iblai add auth --platform <tenant-key>`.
+4. Run `/iblai-chat` to add chat with `iblai add chat` and ask the user for their agent ID.
+5. Use `/iblai-profile`, `/iblai-account`, `/iblai-analytics`, and `/iblai-notifications` to add the remaining components with the CLI.
+6. Run `/iblai-test` before presenting the app to the user.
+
+What each skill does:
+
+- `/iblai-auth` -- installs or checks the CLI, asks for the tenant key, then adds auth.
+- `/iblai-chat` -- asks for the agent ID, then adds the chat widget.
+- `/iblai-profile`, `/iblai-account`, `/iblai-analytics`, `/iblai-notifications` -- guide the AI assistant in using the matching `iblai add` command and customizing the generated component.
+- `/iblai-test` -- requires `npm run build`, `npm run test`, and page touch tests to pass before the work is shown to the user.
+
 ## What You Get
 
 | Feature | Description |

--- a/README.md
+++ b/README.md
@@ -96,9 +96,17 @@ Already have a project? Install the skills and let your AI agent add features:
 npx skills add iblai/vibe
 ```
 
-Then ask your AI agent to use `/iblai-auth` to add authentication, `/iblai-chat`
-for AI chat, `/iblai-profile` for user profiles, and so on. The skills provide
-complete code, SDK imports, and MCP tool references.
+Then use the CLI to add features:
+
+```bash
+iblai add mcp            # MCP servers + skills (run first)
+iblai add auth           # SSO authentication
+iblai add chat           # AI chat with streaming
+iblai add profile        # User profile dropdown
+iblai add account        # Account/organization settings
+iblai add analytics      # Analytics dashboard
+iblai add notifications  # Notification bell
+```
 
 ### CI/CD
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000). You will be redirected to [iblai.app](https://iblai.app) for login -- sign in or create a free account, and you are back in your app with a fully authenticated session.
 
-To get your own branded tenant (custom domain, your logo, your users), register at [iblai.app](https://iblai.app).
+To get your own branded tenant (custom domain, your logo, your users), register at [mentorai.iblai.app](https://mentorai.iblai.app).
 
 ### Install Skills
 
@@ -127,7 +127,7 @@ npx @iblai/cli startapp agent --yes --platform acme --agent my-id --app-name my-
 - **Analytics** -- track user activity, conversation metrics, and engagement across your app
 - **Tenant Management** -- each tenant gets its own users, agents, branding, and configuration
 
-A free tier is available. Register at [iblai.app](https://iblai.app) to get your own tenant with custom branding and domain.
+A free tier is available. Register at [mentorai.iblai.app](https://mentorai.iblai.app) to get your own tenant with custom branding and domain.
 
 ## AI-Assisted Development
 
@@ -213,7 +213,7 @@ iblai builds ci-workflow --all  # GitHub Actions for all platforms
 - [@iblai/iblai-js](https://www.npmjs.com/package/@iblai/iblai-js) -- unified SDK for data, UI components, and auth utilities
 - [@iblai/iblai-api](https://www.npmjs.com/package/@iblai/iblai-api) -- auto-generated API types
 - [@iblai/mcp](https://www.npmjs.com/package/@iblai/mcp) -- MCP server for AI-assisted development
-- [iblai.app](https://iblai.app) -- the backend platform (register for a free tenant)
+- [mentorai.iblai.app](https://mentorai.iblai.app) -- register for a free tenant
 - [skills.sh/iblai/vibe](https://skills.sh/iblai/vibe) -- install skills with `npx skills add iblai/vibe`
 - [Skills Reference](https://github.com/iblai/iblai-app-cli#skills) -- documentation for all bundled Claude Code skills
 

--- a/README.md
+++ b/README.md
@@ -89,21 +89,15 @@ After installing the skills, use them directly in your AI agent with `/` command
 /iblai-test
 ```
 
-Recommended flow for a new or existing app:
-
-1. Ask the user for their **tenant/platform key**.
-2. Run `iblai add mcp` to set up MCP servers for the project.
-3. Run `/iblai-auth` to add authentication with `iblai add auth --platform <tenant-key>`.
-4. Run `/iblai-chat` to add chat with `iblai add chat` and ask the user for their agent ID.
-5. Use `/iblai-profile`, `/iblai-account`, `/iblai-analytics`, and `/iblai-notifications` to add the remaining components with the CLI.
-6. Run `/iblai-test` before presenting the app to the user.
-
 What each skill does:
 
-- `/iblai-auth` -- installs or checks the CLI, asks for the tenant key, then adds auth.
-- `/iblai-chat` -- asks for the agent ID, then adds the chat widget.
-- `/iblai-profile`, `/iblai-account`, `/iblai-analytics`, `/iblai-notifications` -- guide the AI assistant in using the matching `iblai add` command and customizing the generated component.
-- `/iblai-test` -- requires `npm run build`, `npm run test`, and page touch tests to pass before the work is shown to the user.
+- `/iblai-auth` -- adds authentication and configures the app for ibl.ai login.
+- `/iblai-chat` -- adds the AI chat experience and agent integration.
+- `/iblai-profile` -- adds profile UI and profile settings flows.
+- `/iblai-account` -- adds account and organization settings.
+- `/iblai-analytics` -- adds analytics dashboards and reporting views.
+- `/iblai-notifications` -- adds notifications UI and notification center flows.
+- `/iblai-test` -- validates the app before it is presented to the user.
 
 ## What You Get
 

--- a/skills/iblai-account/SKILL.md
+++ b/skills/iblai-account/SKILL.md
@@ -18,6 +18,7 @@ User Management, Integrations, Advanced settings, and Billing.
 >
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.
+> Do NOT implement dark mode unless the user explicitly asks for it.
 >
 > When building custom UI around SDK components, use the ibl.ai brand:
 > - **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`

--- a/skills/iblai-account/SKILL.md
+++ b/skills/iblai-account/SKILL.md
@@ -97,7 +97,8 @@ get_component_info("Account")
 Run `/iblai-test` before telling the user the work is ready:
 
 1. `npm run build` -- must pass with zero errors
-2. Start dev server and touch test:
+2. `npm run test` -- vitest must pass
+3. Start dev server and touch test:
    ```bash
    npm run dev &
    npx playwright screenshot http://localhost:3000/account /tmp/account.png

--- a/skills/iblai-account/SKILL.md
+++ b/skills/iblai-account/SKILL.md
@@ -12,10 +12,7 @@ User Management, Integrations, Advanced settings, and Billing.
 
 ![Account Page](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-account/account-page.png)
 
-> **AI Assistant:** Build this component directly using the code and MCP tools
-> below. Do NOT use the CLI for this -- you are building this feature yourself
-> using the SDK components documented here.
->
+> **AI Assistant:**
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.
 > Do NOT implement dark mode unless the user explicitly asks for it.
@@ -32,115 +29,31 @@ User Management, Integrations, Advanced settings, and Billing.
 ## Prerequisites
 
 - Auth must be set up first (`/iblai-auth`)
-- The following packages are already installed by `iblai add auth`:
-  `@iblai/iblai-js`, `@reduxjs/toolkit`, `react-redux`
+- MCP and skills must be set up: `iblai add mcp`
 
-## Step 1: Use MCP Tools
+## Step 1: Run the Generator
+
+```bash
+iblai add account
+```
+
+## What Was Generated
+
+| File | Purpose |
+|------|---------|
+| `app/(app)/account/page.tsx` | Account/organization settings page with tabs |
+
+The page reads `userData`, `tenant`/`current_tenant`, and `tenants` from
+localStorage. Admin status is derived from the `tenants` array.
+
+> **Note:** The `Account` component uses `next/image` internally -- it is
+> imported from `@iblai/iblai-js/web-containers/next`.
+
+## Step 2: Use MCP Tools for Customization
 
 ```
 get_component_info("Account")
 ```
-
-## Step 2: Create Account Settings Page
-
-Create `app/account/page.tsx` (or `src/app/account/page.tsx` if using `src/` layout):
-
-> **Note:** The `Account` component uses `next/image` internally -- always
-> import from `@iblai/iblai-js/web-containers/next`, not from
-> `@iblai/iblai-js/web-containers`.
-
-```tsx
-"use client";
-
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { Account } from "@iblai/iblai-js/web-containers/next";
-import config from "@/lib/iblai/config";
-
-function resolveTenantKey(raw: string | null): string {
-  if (!raw || raw === "[object Object]") return "";
-  try {
-    const p = JSON.parse(raw);
-    if (typeof p === "string") return p;
-    if (p?.key) return p.key;
-  } catch {}
-  return raw;
-}
-
-export default function AccountPage() {
-  const router = useRouter();
-  const [username, setUsername] = useState("");
-  const [tenantKey, setTenantKey] = useState("");
-  const [tenants, setTenants] = useState<any[]>([]);
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem("userData");
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        setUsername(parsed.user_nicename ?? parsed.username ?? "");
-      }
-    } catch {}
-
-    const stored =
-      localStorage.getItem("current_tenant") ??
-      localStorage.getItem("tenant");
-    const resolved = resolveTenantKey(stored) || config.mainTenantKey();
-    setTenantKey(resolved);
-
-    try {
-      const tenantsRaw = localStorage.getItem("tenants");
-      if (tenantsRaw) {
-        const parsed = JSON.parse(tenantsRaw);
-        setTenants(parsed);
-        const match = parsed.find((t: any) => t.key === resolved);
-        if (match) setIsAdmin(!!match.is_admin);
-      }
-    } catch {}
-
-    setReady(true);
-  }, []);
-
-  if (!ready || !username || !tenantKey) {
-    return (
-      <div className="flex h-screen w-screen items-center justify-center">
-        <p className="text-sm text-gray-400">Loading account settings...</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="h-screen w-screen overflow-auto">
-      <Account
-        tenant={tenantKey}
-        tenants={tenants}
-        username={username}
-        isAdmin={isAdmin}
-        authURL={config.authUrl()}
-        currentPlatformBaseDomain={config.platformBaseDomain()}
-        currentSPA="agent"
-        onInviteClick={() => {/* open invite dialog if needed */}}
-        onClose={() => router.push("/")}
-        targetTab="organization"
-        showPlatformName={true}
-        useGravatarPicFallback={true}
-      />
-    </div>
-  );
-}
-```
-
-## Tabs
-
-| Tab | Requires |
-|-----|---------|
-| **Organization** | `isAdmin === true` -- edit org name, logos, support email |
-| **Management** | RBAC permissions -- manage users, groups, roles |
-| **Integrations** | `isAdmin === true` -- LLMs, API keys, data sources |
-| **Advanced** | `isAdmin === true` -- SMTP, custom domains, auth SPA config |
-| **Billing** | `billingURL` or `topUpURL` prop set -- Stripe billing/top-up |
 
 ## `<Account>` Props
 
@@ -153,7 +66,7 @@ export default function AccountPage() {
 | `username` | `string` | Username |
 | `onInviteClick` | `() => void` | Called when "Invite user" is clicked |
 | `onClose` | `() => void` | Cancel/close callback |
-| `authURL` | `string` | Auth service URL (from `config.authUrl()`) |
+| `authURL` | `string` | Auth service URL |
 | `isAdmin` | `boolean` | Controls tab visibility -- most tabs require `true` |
 
 ### Optional
@@ -169,12 +82,15 @@ export default function AccountPage() {
 | `showPlatformName` | `boolean` | Show tenant name badge in sidebar |
 | `useGravatarPicFallback` | `boolean` | Use Gravatar when no org logo |
 
-## How `isAdmin` Is Determined
+## Tabs
 
-```typescript
-const match = tenants.find((t) => t.key === tenantKey);
-const isAdmin = !!match?.is_admin;
-```
+| Tab | Requires |
+|-----|---------|
+| **Organization** | `isAdmin === true` |
+| **Management** | RBAC permissions |
+| **Integrations** | `isAdmin === true` |
+| **Advanced** | `isAdmin === true` |
+| **Billing** | `billingURL` or `topUpURL` prop set |
 
 ## Step 3: Verify
 
@@ -193,5 +109,4 @@ Run `/iblai-test` before telling the user the work is ready:
 - **Redux store**: Must include `mentorReducer` and `mentorMiddleware`
 - **`initializeDataLayer()`**: 5 args (v1.2+)
 - **`@reduxjs/toolkit`**: Deduplicated via webpack aliases in `next.config.ts`
-- **Config import**: Use `@/lib/iblai/config` (generated by `iblai add auth`)
 - **Brand guidelines**: [BRAND.md](https://github.com/iblai/vibe/blob/main/BRAND.md)

--- a/skills/iblai-analytics/SKILL.md
+++ b/skills/iblai-analytics/SKILL.md
@@ -13,10 +13,7 @@ Users, Topics, Financial, Transcripts, and Reports.
 
 ![Analytics Page](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-analytics/analytics-page.png)
 
-> **AI Assistant:** Build this component directly using the code and MCP tools
-> below. Do NOT use the CLI for this -- you are building this feature yourself
-> using the SDK components documented here.
->
+> **AI Assistant:**
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.
 > Do NOT implement dark mode unless the user explicitly asks for it.
@@ -33,82 +30,27 @@ Users, Topics, Financial, Transcripts, and Reports.
 ## Prerequisites
 
 - Auth must be set up first (`/iblai-auth`)
-- The following packages are already installed by `iblai add auth`:
-  `@iblai/iblai-js`, `@reduxjs/toolkit`, `react-redux`
+- MCP and skills must be set up: `iblai add mcp`
 
-## Step 1: Use MCP Tools
+## Step 1: Run the Generator
+
+```bash
+iblai add analytics
+```
+
+## What Was Generated
+
+| File | Purpose |
+|------|---------|
+| `app/(app)/analytics/page.tsx` | Analytics dashboard page with `AnalyticsOverview` |
+
+The page reads `tenant`/`current_tenant` from localStorage and renders
+the analytics overview for the current tenant.
+
+## Step 2: Use MCP Tools for Customization
 
 ```
 get_component_info("AnalyticsOverview")
-```
-
-## Step 2: Create Analytics Page
-
-Create `app/analytics/page.tsx` (or `src/app/analytics/page.tsx` if using `src/` layout):
-
-```tsx
-"use client";
-
-import { useCallback, useEffect, useState } from "react";
-import {
-  AnalyticsOverview,
-  ChartFiltersProvider,
-} from "@iblai/iblai-js/web-containers";
-import type { ChartFilters } from "@iblai/iblai-js/web-containers";
-import config from "@/lib/iblai/config";
-
-function resolveTenantKey(raw: string | null): string {
-  if (!raw || raw === "[object Object]") return "";
-  try {
-    const p = JSON.parse(raw);
-    if (typeof p === "string") return p;
-    if (p?.key) return p.key;
-  } catch {}
-  return raw;
-}
-
-export default function AnalyticsPage() {
-  const [tenantKey, setTenantKey] = useState("");
-  const [username, setUsername] = useState("");
-  const [ready, setReady] = useState(false);
-
-  const handleOutsideFilters = useCallback(
-    (_filters: Partial<ChartFilters>) => {},
-    []
-  );
-
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem("userData");
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        setUsername(parsed.user_nicename ?? parsed.username ?? "");
-      }
-    } catch {}
-
-    const stored =
-      localStorage.getItem("current_tenant") ??
-      localStorage.getItem("tenant");
-    setTenantKey(resolveTenantKey(stored) || config.mainTenantKey());
-    setReady(true);
-  }, []);
-
-  if (!ready || !tenantKey) {
-    return (
-      <div className="flex h-screen w-screen items-center justify-center">
-        <p className="text-sm text-gray-400">Loading analytics...</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="h-screen w-screen overflow-auto">
-      <ChartFiltersProvider setOutsideFilters={handleOutsideFilters}>
-        <AnalyticsOverview tenantKey={tenantKey} mentorId="" />
-      </ChartFiltersProvider>
-    </div>
-  );
-}
 ```
 
 ## `<AnalyticsOverview>` Props
@@ -119,41 +61,6 @@ export default function AnalyticsPage() {
 | `mentorId` | `string` | Mentor UUID. Pass `""` for org-wide analytics. |
 | `selectedMentorId` | `string?` | Filter analytics to a specific mentor |
 | `usergroupIds` | `string[]?` | Filter analytics to specific user groups |
-
-## `<ChartFiltersProvider>` (Required Wrapper)
-
-All analytics components must be wrapped in `ChartFiltersProvider` -- it provides
-time-range filter state to all charts via context.
-
-| Prop | Type | Description |
-|------|------|-------------|
-| `children` | `ReactNode` | Analytics components to wrap |
-| `setOutsideFilters` | `(next: Partial<ChartFilters>) => void` | Required callback. Use a no-op `useCallback(() => {}, [])` if you don't need external filter sync. |
-
-## Advanced: Full Tabbed Layout
-
-For the full multi-tab experience (Overview, Users, Topics, Financial,
-Transcripts, Reports), create a layout with sub-routes using `AnalyticsLayout`:
-
-```tsx
-import { AnalyticsLayout } from "@iblai/iblai-js/web-containers";
-
-<AnalyticsLayout
-  currentPath={pathname}
-  basePath="/analytics"
-  onTabChange={(tabValue) =>
-    router.push(tabValue ? `/analytics/${tabValue}` : "/analytics")
-  }
-  excludeTabs={["courses", "programs"]}
->
-  {children}
-</AnalyticsLayout>
-```
-
-Then create sub-pages (`analytics/users/page.tsx`, `analytics/topics/page.tsx`,
-etc.) using `AnalyticsUsersStats`, `AnalyticsTopicsStats`,
-`AnalyticsFinancialStats`, `AnalyticsTranscriptsStats`, `AnalyticsReports` --
-each wrapped in `ChartFiltersProvider`.
 
 ## Step 3: Verify
 
@@ -173,5 +80,4 @@ Run `/iblai-test` before telling the user the work is ready:
 - **`initializeDataLayer()`**: 5 args (v1.2+)
 - **`@reduxjs/toolkit`**: Deduplicated via webpack aliases in `next.config.ts`
 - **`mentorId` empty string**: For org-wide analytics pass `""` not `undefined`
-- **Config import**: Use `@/lib/iblai/config` (generated by `iblai add auth`)
 - **Brand guidelines**: [BRAND.md](https://github.com/iblai/vibe/blob/main/BRAND.md)

--- a/skills/iblai-analytics/SKILL.md
+++ b/skills/iblai-analytics/SKILL.md
@@ -67,7 +67,8 @@ get_component_info("AnalyticsOverview")
 Run `/iblai-test` before telling the user the work is ready:
 
 1. `npm run build` -- must pass with zero errors
-2. Start dev server and touch test:
+2. `npm run test` -- vitest must pass
+3. Start dev server and touch test:
    ```bash
    npm run dev &
    npx playwright screenshot http://localhost:3000/analytics /tmp/analytics.png

--- a/skills/iblai-analytics/SKILL.md
+++ b/skills/iblai-analytics/SKILL.md
@@ -19,6 +19,7 @@ Users, Topics, Financial, Transcripts, and Reports.
 >
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.
+> Do NOT implement dark mode unless the user explicitly asks for it.
 >
 > When building custom UI around SDK components, use the ibl.ai brand:
 > - **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`

--- a/skills/iblai-auth/SKILL.md
+++ b/skills/iblai-auth/SKILL.md
@@ -123,20 +123,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-**If you have existing providers** (e.g., ThemeProvider, custom contexts):
+**If you have existing providers** (e.g., custom contexts):
 
 ```tsx
 import { IblaiProviders } from "@/providers/iblai-providers";
-import { ThemeProvider } from "next-themes";
+import { MyProvider } from "./my-provider";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
         <IblaiProviders>
-          <ThemeProvider attribute="class" defaultTheme="system">
+          <MyProvider>
             {children}
-          </ThemeProvider>
+          </MyProvider>
         </IblaiProviders>
       </body>
     </html>
@@ -199,7 +199,6 @@ pnpm dev
 | `lib/iblai/auth-utils.ts` | `redirectToAuthSpa()`, `hasNonExpiredAuthToken()`, `handleLogout()` |
 | `store/iblai-store.ts` | Redux store with `coreApiSlice`, `mentorReducer`, `mentorMiddleware` |
 | `providers/iblai-providers.tsx` | Provider chain: ReduxProvider > AuthProvider > TenantProvider |
-| `app/iblai-styles.css` | SDK style imports for Tailwind class scanning |
 
 ## What Was Patched
 
@@ -207,8 +206,7 @@ pnpm dev
   `turbopack: {}` for Next.js 16+, and Tauri stub aliases. Without the dedup,
   SDK components use a different `ReactReduxContext` and RTK Query hooks silently
   return `undefined` with zero HTTP requests.
-- **`globals.css`** -- `@import` for SDK base styles + `@source` for Tailwind
-  class generation from SDK components.
+- **`globals.css`** -- SDK base styles import.
 - **`.env.local`** -- API URLs, auth URL, tenant key, WebSocket URL.
 
 ## Advanced: Route Groups

--- a/skills/iblai-auth/SKILL.md
+++ b/skills/iblai-auth/SKILL.md
@@ -17,10 +17,10 @@ a session -- no API tokens to manage.
 >
 > Check `.env.local` first -- if `NEXT_PUBLIC_MAIN_TENANT_KEY` is already set
 > to a real value, use it. Treat these as placeholders that require asking:
-> `your-tenant`, `your-platform`, `your-tenant-key`, `iblai`, `test-tenant`,
+> `your-tenant`, `your-platform`, `your-tenant-key`, `test-tenant`,
 > `main`, or empty string.
 >
-> If the user does not have a tenant key, direct them to https://iblai.app
+> If the user does not have a tenant key, direct them to https://mentorai.iblai.app
 > to register for a free account.
 >
 > Pass the key to the generator:
@@ -43,7 +43,7 @@ a session -- no API tokens to manage.
 - Next.js 14+ with App Router (`app/` directory)
 - Node.js 18+
 - `iblai` CLI available (`iblai --version`)
-- An ibl.ai tenant key (register at https://iblai.app)
+- An ibl.ai tenant key (register at https://mentorai.iblai.app)
 
 ### Installing the CLI
 
@@ -180,7 +180,7 @@ iblai config set NEXT_PUBLIC_MAIN_TENANT_KEY your-tenant
 ```
 
 The default API URLs point to `iblai.app` and are set automatically.
-Register at https://iblai.app for your own tenant key.
+Register at https://mentorai.iblai.app for your own tenant key.
 
 ## Step 5: Import SDK Styles
 

--- a/skills/iblai-auth/SKILL.md
+++ b/skills/iblai-auth/SKILL.md
@@ -11,13 +11,30 @@ Add ibl.ai SSO authentication to a vanilla Next.js app. After completion,
 unauthenticated users are redirected to login.iblai.app and returned with
 a session -- no API tokens to manage.
 
+> **AI Assistant:** Before running `iblai add auth`, you MUST ask the user for
+> their **platform/tenant key**. This identifies their ibl.ai organization
+> (e.g., `acme`, `mycompany`).
+>
+> Check `.env.local` first -- if `NEXT_PUBLIC_MAIN_TENANT_KEY` is already set
+> to a real value, use it. Treat these as placeholders that require asking:
+> `your-tenant`, `your-platform`, `your-tenant-key`, `iblai`, `test-tenant`,
+> `main`, or empty string.
+>
+> If the user does not have a tenant key, direct them to https://iblai.app
+> to register for a free account.
+>
+> Pass the key to the generator:
+> ```
+> iblai add auth --platform <tenant-key-from-user>
+> ```
+
 ## Prerequisites
 
 > **Already have auth?** If you used `iblai startapp agent`, auth is already
 > set up -- skip this skill.
 >
 > **Want a complete app from scratch?** Run:
-> `iblai startapp agent --platform your-tenant`
+> `iblai startapp agent --platform <your-tenant-key>`
 > to get a full app with auth, chat, and everything pre-configured.
 >
 > **This skill** is for adding auth to a vanilla Next.js app
@@ -26,7 +43,7 @@ a session -- no API tokens to manage.
 - Next.js 14+ with App Router (`app/` directory)
 - Node.js 18+
 - `iblai` CLI available (`iblai --version`)
-- An ibl.ai tenant key (use `iblai` for the free default tenant, or register at https://iblai.app)
+- An ibl.ai tenant key (register at https://iblai.app)
 
 ### Installing the CLI
 
@@ -73,18 +90,17 @@ Typically at `%APPDATA%\Python\Python311\Scripts\`.
 ```bash
 cd your-nextjs-app
 
-# Pass your platform key directly
-iblai add auth --platform your-tenant
+# Pass the user's platform key directly
+iblai add auth --platform <tenant-key-from-user>
 
 # Or interactively (will prompt for platform key)
 iblai add auth
 
 # Or via npx (when published)
-npx @iblai/cli add auth --platform your-tenant
+npx @iblai/cli add auth --platform <tenant-key-from-user>
 ```
 
 The `--platform` argument sets `NEXT_PUBLIC_MAIN_TENANT_KEY` in `.env.local`.
-Use `iblai` as the default free tenant for development.
 
 The generator creates 7 files and patches `next.config`, `globals.css`, and `.env.local`.
 It auto-detects `src/` directory layout and places files accordingly.

--- a/skills/iblai-chat/SKILL.md
+++ b/skills/iblai-chat/SKILL.md
@@ -25,6 +25,7 @@ automatically.
 >
 > Do NOT add custom styles, colors, or CSS overrides to the ChatWidget.
 > It ships with its own styling. Keep the component as-is.
+> Do NOT implement dark mode unless the user explicitly asks for it.
 >
 > When building custom UI around the chat widget, use the ibl.ai brand:
 > - **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
@@ -89,9 +90,6 @@ import { ChatWidget } from "@/components/iblai/chat-widget";
 
 // Custom dimensions
 <ChatWidget mentorId="..." width={900} height={700} />
-
-// Dark theme
-<ChatWidget mentorId="..." theme="dark" />
 ```
 
 ## Props

--- a/skills/iblai-chat/SKILL.md
+++ b/skills/iblai-chat/SKILL.md
@@ -107,7 +107,8 @@ import { ChatWidget } from "@/components/iblai/chat-widget";
 Run `/iblai-test` before telling the user the work is ready:
 
 1. `npm run build` -- must pass with zero errors
-2. Start dev server and touch test:
+2. `npm run test` -- vitest must pass
+3. Start dev server and touch test:
    ```bash
    npm run dev &
    npx playwright screenshot http://localhost:3000 /tmp/home.png

--- a/skills/iblai-chat/SKILL.md
+++ b/skills/iblai-chat/SKILL.md
@@ -82,14 +82,14 @@ and passes them to the MentorAI iframe via `authrelyonhost` mode.
 ```tsx
 import { ChatWidget } from "@/components/iblai/chat-widget";
 
-// Basic -- use the agent ID from .env.local or pass directly
-<ChatWidget mentorId={process.env.NEXT_PUBLIC_DEFAULT_AGENT_ID!} />
+// Full viewport (recommended)
+<ChatWidget mentorId={process.env.NEXT_PUBLIC_DEFAULT_AGENT_ID!} width="100vw" height="100vh" />
 
-// Or hardcode (useful for multi-agent pages)
-<ChatWidget mentorId="3f8a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c" />
+// Custom viewport-relative dimensions
+<ChatWidget mentorId="..." width="80vw" height="90vh" />
 
-// Custom dimensions
-<ChatWidget mentorId="..." width={900} height={700} />
+// Or hardcode an agent ID (useful for multi-agent pages)
+<ChatWidget mentorId="3f8a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c" width="100vw" height="100vh" />
 ```
 
 ## Props
@@ -97,10 +97,10 @@ import { ChatWidget } from "@/components/iblai/chat-widget";
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `mentorId` | `string` | (required) | Agent/mentor UUID -- ask the user for this |
-| `tenantKey` | `string` | from localStorage | Override tenant key |
+| `tenantKey` | `string` | from `.env` | Override tenant key (defaults to `NEXT_PUBLIC_MAIN_TENANT_KEY`) |
 | `theme` | `"light" \| "dark"` | `"light"` | Color theme |
-| `width` | `number \| string` | `720` | Widget width |
-| `height` | `number \| string` | `600` | Widget height |
+| `width` | `number \| string` | `720` | Widget width -- use `vh`/`vw` strings (e.g., `"100vw"`) |
+| `height` | `number \| string` | `600` | Widget height -- use `vh`/`vw` strings (e.g., `"100vh"`) |
 
 ## Step 4: Verify
 

--- a/skills/iblai-chat/SKILL.md
+++ b/skills/iblai-chat/SKILL.md
@@ -15,8 +15,8 @@ automatically.
 > their **agent/mentor ID** (a UUID like `3f8a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c`).
 > This is required for the chat widget to connect to an AI agent.
 >
-> If the user does not have an agent ID, direct them to https://iblai.app to
-> create an AI agent. They can find the agent ID in the agent settings page.
+> If the user does not have an agent ID, direct them to https://mentorai.iblai.app
+> to create an AI agent. They can find the agent ID in the agent settings page.
 >
 > Once you have the ID, set it in `.env.local`:
 > ```
@@ -40,7 +40,7 @@ automatically.
 
 - Auth must be set up first (`/iblai-auth`)
 - `iblai` CLI available (`iblai --version`). See `/iblai-auth` prerequisites for installation.
-- An agent/mentor ID from the user's ibl.ai platform (a UUID -- get one at https://iblai.app)
+- An agent/mentor ID from the user's ibl.ai platform (a UUID -- get one at https://mentorai.iblai.app)
 
 ## Step 1: Get Agent ID from User
 

--- a/skills/iblai-components/SKILL.md
+++ b/skills/iblai-components/SKILL.md
@@ -48,32 +48,16 @@ iblai startapp agent --platform acme --anthropic-key sk-ant-... \
 
 ## Available Components
 
-### CLI-Generated (use the CLI)
-
-| Command | What It Adds |
-|---------|-------------|
-| `iblai add auth` | SSO authentication -- see `/iblai-auth` |
-| `iblai add chat` | AI chat widget -- see `/iblai-chat` (requires agent ID from user) |
-
-### AI-Built (you build these using the skill documentation)
-
-| Skill | What It Adds |
-|-------|-------------|
-| `/iblai-profile` | User profile dropdown + settings page |
-| `/iblai-account` | Account/organization settings page |
-| `/iblai-analytics` | Analytics dashboard page |
-| `/iblai-notifications` | Notification bell + center page |
-
-These components are built by the AI assistant using SDK components and the
-detailed code provided in each skill. The MCP tools (`get_component_info`,
-`get_hook_info`) provide props references and usage examples.
-
-### Other CLI Commands
-
-| Command | What It Adds |
-|---------|-------------|
-| `iblai add builds` | Tauri v2 shell -- desktop and mobile builds |
-| `iblai add mcp` | MCP + skills -- @iblai/mcp server config, Claude/OpenCode/Cursor skill files |
+| Command | What It Adds | Skill |
+|---------|-------------|-------|
+| `iblai add mcp` | MCP servers + skills (run first) | |
+| `iblai add auth` | SSO authentication | `/iblai-auth` |
+| `iblai add chat` | AI chat widget (requires agent ID) | `/iblai-chat` |
+| `iblai add profile` | User profile dropdown | `/iblai-profile` |
+| `iblai add account` | Account/organization settings | `/iblai-account` |
+| `iblai add analytics` | Analytics dashboard | `/iblai-analytics` |
+| `iblai add notifications` | Notification bell | `/iblai-notifications` |
+| `iblai add builds` | Tauri v2 desktop/mobile shell | |
 
 ## Component Priority
 
@@ -93,7 +77,8 @@ ibl.ai and shadcn components share the same Tailwind theme and are visually seam
 
 - Next.js App Router project (app/ directory)
 - Node.js 18+
-- `iblai` CLI available for auth and chat (`iblai --version`). See `/iblai-auth` prerequisites for installation.
+- `iblai` CLI available (`iblai --version`). See `/iblai-auth` prerequisites for installation.
+- Run `iblai add mcp` first to set up MCP servers and skills
 - If you started with `npx create-next-app@latest`, run `iblai add auth` first -- other components depend on the auth providers
 - If you used `iblai startapp agent`, auth is already set up
 - **Brand guidelines**: [BRAND.md](https://github.com/iblai/vibe/blob/main/BRAND.md)

--- a/skills/iblai-components/SKILL.md
+++ b/skills/iblai-components/SKILL.md
@@ -18,7 +18,7 @@ Start with a standard Next.js app and add features as needed:
 ```bash
 npx create-next-app@latest my-app --yes
 cd my-app
-iblai add auth --platform your-tenant
+iblai add auth --platform <your-tenant-key>
 iblai add chat
 npm run dev
 ```
@@ -28,7 +28,7 @@ npm run dev
 Scaffold a complete app with auth, chat, and everything pre-configured:
 
 ```bash
-iblai startapp agent --platform your-tenant
+iblai startapp agent --platform <your-tenant-key>
 cd <app-name> && pnpm install
 cp .env.example .env.local && pnpm dev
 ```

--- a/skills/iblai-notifications/SKILL.md
+++ b/skills/iblai-notifications/SKILL.md
@@ -86,7 +86,8 @@ get_component_info("NotificationDropdown")
 Run `/iblai-test` before telling the user the work is ready:
 
 1. `npm run build` -- must pass with zero errors
-2. Start dev server and touch test:
+2. `npm run test` -- vitest must pass
+3. Start dev server and touch test:
    ```bash
    npm run dev &
    npx playwright screenshot http://localhost:3000/notifications /tmp/notifications.png

--- a/skills/iblai-notifications/SKILL.md
+++ b/skills/iblai-notifications/SKILL.md
@@ -12,10 +12,7 @@ navbar and a full notification center page with Inbox and Alerts tabs.
 
 ![Notifications Page](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-notifications/notifications-page.png)
 
-> **AI Assistant:** Build this component directly using the code and MCP tools
-> below. Do NOT use the CLI for this -- you are building this feature yourself
-> using the SDK components documented here.
->
+> **AI Assistant:**
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.
 > Do NOT implement dark mode unless the user explicitly asks for it.
@@ -32,105 +29,38 @@ navbar and a full notification center page with Inbox and Alerts tabs.
 ## Prerequisites
 
 - Auth must be set up first (`/iblai-auth`)
-- The following packages are already installed by `iblai add auth`:
-  `@iblai/iblai-js`, `@reduxjs/toolkit`, `react-redux`
+- MCP and skills must be set up: `iblai add mcp`
 
-## Step 1: Use MCP Tools
+## Step 1: Run the Generator
+
+```bash
+iblai add notifications
+```
+
+## What Was Generated
+
+| File | Purpose |
+|------|---------|
+| `components/iblai/notification-bell.tsx` | Bell icon with unread badge for navbar |
+
+The bell reads `userData` and `tenant` from localStorage. Returns `null`
+gracefully if no user is authenticated.
+
+## Step 2: Use MCP Tools for Customization
 
 ```
 get_component_info("NotificationDisplay")
 get_component_info("NotificationDropdown")
 ```
 
-## Step 2: Create Notification Center Page
+## `<NotificationDropdown>` Props (Bell Icon)
 
-Create `app/notifications/page.tsx` (or `src/app/notifications/page.tsx` if using `src/` layout):
-
-```tsx
-"use client";
-
-import { useEffect, useState } from "react";
-import { NotificationDisplay } from "@iblai/iblai-js/web-containers";
-import config from "@/lib/iblai/config";
-
-function resolveTenantKey(raw: string | null): string {
-  if (!raw || raw === "[object Object]") return "";
-  try {
-    const p = JSON.parse(raw);
-    if (typeof p === "string") return p;
-    if (p?.key) return p.key;
-  } catch {}
-  return raw;
-}
-
-export default function NotificationsPage() {
-  const [tenantKey, setTenantKey] = useState("");
-  const [username, setUsername] = useState("");
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem("userData");
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        setUsername(parsed.user_nicename ?? parsed.username ?? "");
-      }
-    } catch {}
-
-    const stored =
-      localStorage.getItem("current_tenant") ??
-      localStorage.getItem("tenant");
-    const resolved = resolveTenantKey(stored) || config.mainTenantKey();
-    setTenantKey(resolved);
-
-    try {
-      const tenantsRaw = localStorage.getItem("tenants");
-      if (tenantsRaw) {
-        const tenants = JSON.parse(tenantsRaw);
-        const match = tenants.find((t: any) => t.key === resolved);
-        if (match) setIsAdmin(!!match.is_admin);
-      }
-    } catch {}
-
-    setReady(true);
-  }, []);
-
-  if (!ready || !tenantKey || !username) {
-    return (
-      <div className="flex h-screen w-screen items-center justify-center">
-        <p className="text-sm text-gray-400">Loading notifications...</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="h-screen w-screen overflow-auto">
-      <NotificationDisplay
-        org={tenantKey}
-        userId={username}
-        isAdmin={isAdmin}
-      />
-    </div>
-  );
-}
-```
-
-## Step 3: Create Notification Bell (Navbar Component)
-
-Create `components/iblai/notification-bell.tsx`:
-
-1. Call `get_component_info("NotificationDropdown")` for the full props reference
-2. Import from `@iblai/iblai-js/web-containers`
-3. Read username and tenant from localStorage (same pattern as above)
-
-Place in your navbar:
-
-```tsx
-import { IblaiNotificationBell } from "@/components/iblai/notification-bell";
-
-<IblaiNotificationBell onViewAll={() => router.push("/notifications")} />
-```
+| Prop | Type | Description |
+|------|------|-------------|
+| `org` | `string` | Tenant/org key |
+| `userId` | `string` | Username |
+| `onViewNotifications` | `(id?) => void?` | "View all" callback |
+| `className` | `string?` | Additional CSS class |
 
 ## `<NotificationDisplay>` Props (Full Page)
 
@@ -142,14 +72,6 @@ import { IblaiNotificationBell } from "@/components/iblai/notification-bell";
 | `selectedNotificationId` | `string?` | Pre-select a notification |
 | `enableRbac` | `boolean?` | Enable RBAC permission checks |
 
-## `<NotificationDropdown>` Props (Bell Icon)
-
-| Prop | Type | Description |
-|------|------|-------------|
-| `org` | `string` | Tenant/org key |
-| `userId` | `string` | Username |
-| `onViewNotifications` | `(id?) => void?` | "View all" callback |
-
 ## Roles
 
 | Feature | Everyone | Admin only |
@@ -159,13 +81,7 @@ import { IblaiNotificationBell } from "@/components/iblai/notification-bell";
 | Send notification | | Yes |
 | Alerts tab | | Yes |
 
-## Deep-Linking
-
-Add `app/notifications/[notificationId]/page.tsx` with
-`selectedNotificationId={notificationId}` prop to deep-link to a specific
-notification.
-
-## Step 4: Verify
+## Step 3: Verify
 
 Run `/iblai-test` before telling the user the work is ready:
 
@@ -183,5 +99,4 @@ Run `/iblai-test` before telling the user the work is ready:
 - **`initializeDataLayer()`**: 5 args (v1.2+)
 - **`@reduxjs/toolkit`**: Deduplicated via webpack aliases in `next.config.ts`
 - **Admin detection**: Derive from `tenants` array in localStorage
-- **Config import**: Use `@/lib/iblai/config` (generated by `iblai add auth`)
 - **Brand guidelines**: [BRAND.md](https://github.com/iblai/vibe/blob/main/BRAND.md)

--- a/skills/iblai-notifications/SKILL.md
+++ b/skills/iblai-notifications/SKILL.md
@@ -18,6 +18,7 @@ navbar and a full notification center page with Inbox and Alerts tabs.
 >
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.
+> Do NOT implement dark mode unless the user explicitly asks for it.
 >
 > When building custom UI around SDK components, use the ibl.ai brand:
 > - **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`

--- a/skills/iblai-profile/SKILL.md
+++ b/skills/iblai-profile/SKILL.md
@@ -13,10 +13,7 @@ Experience, Resume, and Security.
 
 ![Profile Page](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-profile/profile-page.png)
 
-> **AI Assistant:** Build this component directly using the code and MCP tools
-> below. Do NOT use the CLI for this -- you are building this feature yourself
-> using the SDK components documented here.
->
+> **AI Assistant:**
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.
 > Do NOT implement dark mode unless the user explicitly asks for it.
@@ -33,118 +30,47 @@ Experience, Resume, and Security.
 ## Prerequisites
 
 - Auth must be set up first (`/iblai-auth`)
-- The following packages are already installed by `iblai add auth`:
-  `@iblai/iblai-js`, `@reduxjs/toolkit`, `react-redux`
+- MCP and skills must be set up: `iblai add mcp`
 
-## Step 1: Use MCP Tools
+## Step 1: Run the Generator
 
-Call these MCP tools for the full props reference:
+```bash
+iblai add profile
+```
+
+## What Was Generated
+
+| File | Purpose |
+|------|---------|
+| `components/iblai/profile-dropdown.tsx` | Avatar dropdown for navbar with profile link and logout |
+
+The dropdown reads `userData`, `tenant`/`current_tenant`, and `tenants` from
+localStorage. Admin status is derived from the `tenants` array by matching
+the current tenant key against `is_admin`.
+
+## Step 2: Use MCP Tools for Customization
 
 ```
 get_component_info("Profile")
 get_component_info("UserProfileDropdown")
 ```
 
-## Step 2: Create Profile Settings Page
+## `<UserProfileDropdown>` Props
 
-Create `app/profile/page.tsx` (or `src/app/profile/page.tsx` if using `src/` layout):
+| Prop | Type | Description |
+|------|------|-------------|
+| `username` | `string` | Username |
+| `tenantKey` | `string` | Tenant/org key |
+| `userIsAdmin` | `boolean` | Shows admin badge + settings |
+| `showProfileTab` | `boolean` | Show profile link |
+| `showAccountTab` | `boolean` | Show account settings link |
+| `showTenantSwitcher` | `boolean` | Show tenant switcher |
+| `showLogoutButton` | `boolean` | Show logout button |
+| `authURL` | `string` | Auth service URL |
+| `onLogout` | `() => void` | Logout callback |
+| `className` | `string?` | Additional CSS class |
 
-```tsx
-"use client";
-
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { Profile } from "@iblai/iblai-js/web-containers";
-import config from "@/lib/iblai/config";
-
-function resolveTenantKey(raw: string | null): string {
-  if (!raw || raw === "[object Object]") return "";
-  try {
-    const p = JSON.parse(raw);
-    if (typeof p === "string") return p;
-    if (p?.key) return p.key;
-  } catch {}
-  return raw;
-}
-
-export default function ProfilePage() {
-  const router = useRouter();
-  const [username, setUsername] = useState("");
-  const [tenantKey, setTenantKey] = useState("");
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem("userData");
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        setUsername(parsed.user_nicename ?? parsed.username ?? "");
-      }
-    } catch {}
-
-    const stored =
-      localStorage.getItem("current_tenant") ??
-      localStorage.getItem("tenant");
-    const resolved = resolveTenantKey(stored) || config.mainTenantKey();
-    setTenantKey(resolved);
-
-    try {
-      const tenantsRaw = localStorage.getItem("tenants");
-      if (tenantsRaw) {
-        const tenants = JSON.parse(tenantsRaw);
-        const match = tenants.find((t: any) => t.key === resolved);
-        if (match) setIsAdmin(!!match.is_admin);
-      }
-    } catch {}
-
-    setReady(true);
-  }, []);
-
-  if (!ready || !username || !tenantKey) {
-    return (
-      <div className="flex h-screen w-screen items-center justify-center">
-        <p className="text-sm text-gray-400">Loading profile...</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="h-screen w-screen overflow-auto">
-      <Profile
-        tenant={tenantKey}
-        username={username}
-        isAdmin={isAdmin}
-        onClose={() => router.push("/")}
-        customization={{
-          showUsernameField: false,
-          showPlatformName: true,
-          useGravatarPicFallback: true,
-        }}
-        targetTab="basic"
-      />
-    </div>
-  );
-}
-```
-
-## Step 3: Create Profile Dropdown (Navbar Component)
-
-Create `components/iblai/profile-dropdown.tsx`:
-
-1. Call `get_component_info("UserProfileDropdown")` for the full props reference
-2. Import from `@iblai/iblai-js/web-containers/next`
-3. Read username and tenant from localStorage (same pattern as above)
-
-Place in your navbar:
-
-```tsx
-import { ProfileDropdown } from "@/components/iblai/profile-dropdown";
-
-<ProfileDropdown />
-```
-
-## `<Profile>` Props
+## `<Profile>` Props (Full Settings Page)
 
 | Prop | Type | Description |
 |------|------|-------------|
@@ -155,7 +81,7 @@ import { ProfileDropdown } from "@/components/iblai/profile-dropdown";
 | `targetTab` | `string` | Initial tab: `basic`, `social`, `education`, `experience`, `resume`, `security` |
 | `customization` | `object` | `showUsernameField`, `showPlatformName`, `useGravatarPicFallback` |
 
-## Step 4: Verify
+## Step 3: Verify
 
 Run `/iblai-test` before telling the user the work is ready:
 
@@ -171,6 +97,5 @@ Run `/iblai-test` before telling the user the work is ready:
 - **Redux store**: Must include `mentorReducer` and `mentorMiddleware`
 - **`initializeDataLayer()`**: 5 args (v1.2+)
 - **`@reduxjs/toolkit`**: Deduplicated via webpack aliases in `next.config.ts`
-- **Admin detection**: Derive from `tenants` array in localStorage
-- **Config import**: Use `@/lib/iblai/config` (generated by `iblai add auth`)
+- **Admin detection**: Derived from `tenants` array in localStorage
 - **Brand guidelines**: [BRAND.md](https://github.com/iblai/vibe/blob/main/BRAND.md)

--- a/skills/iblai-profile/SKILL.md
+++ b/skills/iblai-profile/SKILL.md
@@ -19,6 +19,7 @@ Experience, Resume, and Security.
 >
 > Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
 > They ship with their own styling. Keep the components as-is.
+> Do NOT implement dark mode unless the user explicitly asks for it.
 >
 > When building custom UI around SDK components, use the ibl.ai brand:
 > - **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`

--- a/skills/iblai-profile/SKILL.md
+++ b/skills/iblai-profile/SKILL.md
@@ -104,7 +104,8 @@ dialog that combines profile editing and account settings in one overlay.
 Run `/iblai-test` before telling the user the work is ready:
 
 1. `npm run build` -- must pass with zero errors
-2. Start dev server and touch test:
+2. `npm run test` -- vitest must pass
+3. Start dev server and touch test:
    ```bash
    npm run dev &
    npx playwright screenshot http://localhost:3000/profile /tmp/profile.png

--- a/skills/iblai-profile/SKILL.md
+++ b/skills/iblai-profile/SKILL.md
@@ -51,11 +51,12 @@ the current tenant key against `is_admin`.
 ## Step 2: Use MCP Tools for Customization
 
 ```
-get_component_info("Profile")
 get_component_info("UserProfileDropdown")
 ```
 
 ## `<UserProfileDropdown>` Props
+
+The generated dropdown component. Import from `@iblai/iblai-js/web-containers/next`.
 
 | Prop | Type | Description |
 |------|------|-------------|
@@ -70,16 +71,33 @@ get_component_info("UserProfileDropdown")
 | `onLogout` | `() => void` | Logout callback |
 | `className` | `string?` | Additional CSS class |
 
-## `<Profile>` Props (Full Settings Page)
+## `<UserProfileModal>` Props (Profile + Account Modal)
+
+For a profile editing modal (used by the MentorAI reference app), import
+`UserProfileModal` from `@iblai/iblai-js/web-containers/next`. This is a
+dialog that combines profile editing and account settings in one overlay.
+
+### Required
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `tenant` | `string` | Tenant/org key |
-| `username` | `string` | Username |
-| `isAdmin` | `boolean` | Shows admin badge + settings |
-| `onClose` | `() => void` | Cancel/close callback |
+| `isOpen` | `boolean` | Whether the modal is visible |
+| `onClose` | `() => void` | Close callback |
+| `params` | `{ tenantKey: string; mentorId?: string; isAdmin?: boolean }` | Tenant key, optional mentor ID and admin flag |
+| `authURL` | `string` | Auth service URL (from `config.authUrl()`) |
+
+### Optional
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `tenants` | `Tenant[]` | Full list of user tenants from localStorage |
 | `targetTab` | `string` | Initial tab: `basic`, `social`, `education`, `experience`, `resume`, `security` |
-| `customization` | `object` | `showUsernameField`, `showPlatformName`, `useGravatarPicFallback` |
+| `showPlatformName` | `boolean` | Show tenant name badge |
+| `useGravatarPicFallback` | `boolean` | Use Gravatar when no profile pic |
+| `currentSPA` | `string` | Current app identifier (e.g., `"agent"`) |
+| `currentPlatformBaseDomain` | `string` | Base domain for custom domain settings |
+| `onTenantUpdate` | `(tenant: Tenant) => void` | Called when tenant is updated |
+| `onAccountDeleted` | `() => void` | Called after account deletion |
 
 ## Step 3: Verify
 

--- a/skills/iblai-test/SKILL.md
+++ b/skills/iblai-test/SKILL.md
@@ -22,7 +22,22 @@ npm run build    # or: pnpm build
 Fix all errors. A failed build means broken code -- do not proceed until
 the build passes cleanly.
 
-## Step 2: Touch Test Pages
+## Step 2: Run Unit Tests
+
+```bash
+npm run test    # or: pnpm test
+```
+
+This runs vitest to verify:
+- All `@source` paths in CSS files resolve to existing directories
+- The `lib/iblai/sdk` symlink is valid and targets the SDK dist
+- `lib/iblai/sdk/web-containers/source` contains compiled JS for
+  Tailwind class generation
+
+If tests fail, the SDK symlink may be broken. Run `ls -la lib/iblai/sdk`
+to check. If it's missing, run `iblai add auth` again to recreate it.
+
+## Step 3: Touch Test Pages
 
 ### If this is an agent app (from `iblai startapp agent`)
 
@@ -92,9 +107,10 @@ Kill the dev server when done.
 ## Summary
 
 1. `npm run build` (or `pnpm build`) -- must pass with zero errors
-2. Touch test every page -- `pnpm test:e2e` for agent apps, or
+2. `npm run test` (or `pnpm test`) -- vitest must pass
+3. Touch test every page -- `pnpm test:e2e` for agent apps, or
    `npx playwright screenshot` for vanilla apps
-3. Fix any failures before showing work to the user
+4. Fix any failures before showing work to the user
 
 ## Full E2E Reference
 


### PR DESCRIPTION



## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
- Remove Dark Mode section from BRAND.md
- Remove ThemeProvider/next-themes example from auth skill
- Remove iblai-styles.css from auth skill's generated files table
- Simplify globals.css description in auth skill (internal detail)
- Remove theme="dark" example from chat skill
- Add 'Do NOT implement dark mode unless the user explicitly asks' directive to all 5 component skills (chat, profile, account, analytics, notifications)

SDK components use default light theme styling out of the box. Dark mode remains available via the theme prop but is not showcased or recommended by default.