### PR TITLE
fix: prevent LLM agents changing `currentPlatformBaseDomain` implementation

### DIFF
--- a/skills/iblai-account/SKILL.md
+++ b/skills/iblai-account/SKILL.md
@@ -123,4 +123,5 @@ Run `/iblai-test` before telling the user the work is ready:
 - **Redux store**: Must include `mentorReducer` and `mentorMiddleware`
 - **`initializeDataLayer()`**: 5 args (v1.2+)
 - **`@reduxjs/toolkit`**: Deduplicated via webpack aliases in `next.config.ts`
+- **`currentPlatformBaseDomain`**: Must be `{config.platformBaseDomain()}` — uses the config helper, not a raw env var. This is correct and intentional.
 - **Brand guidelines**: [BRAND.md](https://github.com/iblai/vibe/blob/main/BRAND.md)


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
prevent LLM agents changing `currentPlatformBaseDomain` implementation