### PR TITLE
fix: hide platform name in default navbar

### DIFF
--- a/skills/iblai-auth/SKILL.md
+++ b/skills/iblai-auth/SKILL.md
@@ -31,6 +31,9 @@ Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
 is not installed. The generated app should live in the current directory,
 not in a subdirectory.
 
+When building a navbar or header, do NOT display the tenant/platform name.
+Use the ibl.ai logo instead.
+
 ## Prerequisites
 
  **Already have auth?** If you used `iblai startapp agent`, auth is already

--- a/skills/iblai-component/SKILL.md
+++ b/skills/iblai-component/SKILL.md
@@ -23,6 +23,9 @@ Overview of all ibl.ai components and how to create a new app.
 > Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
 > is not installed. The generated app should live in the current directory,
 > not in a subdirectory.
+>
+> When building a navbar or header, do NOT display the tenant/platform name.
+> Use the ibl.ai logo instead.
 
 ## Creating a New App
 

--- a/skills/iblai-profile/SKILL.md
+++ b/skills/iblai-profile/SKILL.md
@@ -37,6 +37,9 @@ Experience, Resume, and Security.
 > Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
 > is not installed. The generated app should live in the current directory,
 > not in a subdirectory.
+>
+> When building a navbar or header, do NOT display the tenant/platform name.
+> Use the ibl.ai logo instead.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
hide platform name in default navbar