### PR TITLE
chore: update the wording of "platforms" to not call them "tenants"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ NEXT_PUBLIC_API_BASE_URL=https://api.iblai.app
 NEXT_PUBLIC_AUTH_URL=https://login.iblai.app
 NEXT_PUBLIC_BASE_WS_URL=wss://asgi.data.iblai.app
 NEXT_PUBLIC_PLATFORM_BASE_DOMAIN=iblai.app
-NEXT_PUBLIC_MAIN_TENANT_KEY=your-platform
+NEXT_PUBLIC_MAIN_TENANT_KEY=your-main-platform
 NEXT_PUBLIC_DEFAULT_AGENT_ID=your-agent-id
 ```
 
@@ -139,7 +139,7 @@ NEXT_PUBLIC_DEFAULT_AGENT_ID=your-agent-id
 > template and fill in your values:
 > `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`"
 >
-> Do NOT ask the user for their tenant key directly. Guide them to populate
+> Do NOT ask the user for their platform key directly. Guide them to populate
 > `iblai.env` instead. The CLI reads these and derives all `NEXT_PUBLIC_*`
 > env vars into `.env.local` automatically.
 >

--- a/skills/iblai-account/SKILL.md
+++ b/skills/iblai-account/SKILL.md
@@ -185,8 +185,8 @@ get_component_info("Account")
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `tenant` | `string` | Tenant/org key |
-| `tenants` | `Tenant[]` | Full list of user tenants from localStorage |
+| `tenant` | `string` | Platform key |
+| `tenants` | `Tenant[]` | Full list of user platforms from localStorage |
 | `username` | `string` | Username |
 | `onInviteClick` | `() => void` | Called when "Invite user" is clicked |
 | `onClose` | `() => void` | Cancel/close callback |
@@ -203,7 +203,7 @@ get_component_info("Account")
 | `billingURL` | `string` | Stripe billing portal URL -- shows Billing tab |
 | `topUpURL` | `string` | Stripe top-up URL -- shows Billing tab |
 | `enableRbac` | `boolean` | Enable RBAC permission checks for Management |
-| `showPlatformName` | `boolean` | Show tenant name badge in sidebar |
+| `showPlatformName` | `boolean` | Show platform name badge in sidebar |
 | `useGravatarPicFallback` | `boolean` | Use Gravatar when no org logo |
 
 ## Tabs

--- a/skills/iblai-auth/SKILL.md
+++ b/skills/iblai-auth/SKILL.md
@@ -11,7 +11,7 @@ Add ibl.ai SSO authentication to a vanilla Next.js app. After completion,
 unauthenticated users are redirected to login.iblai.app and returned with
 a session -- no API tokens to manage.
 
-Do NOT ask the user for their tenant key. The CLI
+Do NOT ask the user for their platform key. The CLI
 reads `PLATFORM` from `iblai.env` automatically. If `iblai.env` exists
 with a real `PLATFORM` value, just run `iblai add auth` (no flag needed).
 Otherwise use the placeholder:
@@ -20,7 +20,7 @@ iblai add auth --platform your-platform
 ```
 
 If `.env.local` already has `NEXT_PUBLIC_MAIN_TENANT_KEY` set to a real
-value (not a placeholder like `your-tenant`, `your-platform`,
+value (not a placeholder like `your-main-platform`, `your-tenant`, `your-platform`,
 `your-tenant-key`, `test-tenant`, `main`, or empty), keep that value.
 
 `iblai.env` is NOT a `.env.local` replacement — it only holds the 3
@@ -31,7 +31,7 @@ Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
 is not installed. The generated app should live in the current directory,
 not in a subdirectory.
 
-When building a navbar or header, do NOT display the tenant/platform name.
+When building a navbar or header, do NOT display the platform name.
 Use the ibl.ai logo instead.
 
 Always use shadcn/ui components for all custom UI -- buttons, forms,
@@ -79,7 +79,7 @@ pip install iblai-app-cli
 
 ```bash
 npx @iblai/cli --version
-# Use npx @iblai/cli as prefix: npx @iblai/cli add auth --platform your-tenant
+# Use npx @iblai/cli as prefix: npx @iblai/cli add auth --platform your-main-platform
 ```
 
 **Build from source -- macOS / Linux** (Python 3.11+, pip, git, make):
@@ -130,7 +130,7 @@ If the file does not exist or is missing these variables, tell the user:
 template and fill in your values:
 `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`"
 
-If `PLATFORM` is set to a real value (not `your-platform`), the CLI
+If `PLATFORM` is set to a real value (not `your-platform` or `your-main-platform`), the CLI
 will read it automatically — no `--platform` flag needed in Step 3.
 Otherwise use the placeholder.
 
@@ -388,7 +388,7 @@ inside it.
 
 ## Step 6: Configure Environment
 
-If the CLI read `PLATFORM` from `iblai.env` or you passed `--platform`, the tenant key is already set in `.env.local`.
+If the CLI read `PLATFORM` from `iblai.env` or you passed `--platform`, the platform key is already set in `.env.local`.
 Verify with:
 
 ```bash
@@ -398,7 +398,7 @@ iblai config show
 Otherwise, edit `.env.local` (created by the generator) or use the CLI:
 
 ```bash
-iblai config set NEXT_PUBLIC_MAIN_TENANT_KEY your-tenant
+iblai config set NEXT_PUBLIC_MAIN_TENANT_KEY your-main-platform
 ```
 
 The default API URLs point to `iblai.app` and are set automatically.
@@ -445,7 +445,7 @@ pnpm dev
 | File | Purpose |
 |------|---------|
 | `app/sso-login-complete/page.tsx` | SSO callback -- stores tokens from URL into localStorage |
-| `lib/iblai/config.ts` | Environment variable accessors (API URLs, tenant key, auth URL) |
+| `lib/iblai/config.ts` | Environment variable accessors (API URLs, platform key, auth URL) |
 | `lib/iblai/storage-service.ts` | localStorage wrapper implementing the SDK's StorageService interface |
 | `lib/iblai/auth-utils.ts` | `redirectToAuthSpa()`, `hasNonExpiredAuthToken()`, `handleLogout()` |
 | `store/iblai-store.ts` | Redux store with `coreApiSlice`, `mentorReducer`, `mentorMiddleware` |
@@ -458,7 +458,7 @@ pnpm dev
   SDK components use a different `ReactReduxContext` and RTK Query hooks silently
   return `undefined` with zero HTTP requests.
 - **`globals.css`** -- SDK base styles import.
-- **`.env.local`** -- API URLs, auth URL, tenant key, WebSocket URL.
+- **`.env.local`** -- API URLs, auth URL, platform key, WebSocket URL.
 
 ## Advanced: Route Groups
 
@@ -485,8 +485,8 @@ For the route group pattern, see the reference implementation:
 
 ### "Unknown server error" with custom-domains on localhost
 
-The SDK calls `/api/custom-domains?domain=localhost` as part of tenant detection.
-This fails on localhost but is **harmless** -- the tenant is resolved from
+The SDK calls `/api/custom-domains?domain=localhost` as part of platform detection.
+This fails on localhost but is **harmless** -- the platform is resolved from
 `NEXT_PUBLIC_MAIN_TENANT_KEY` in `.env.local` instead. You can safely ignore
 this console error during local development.
 
@@ -513,7 +513,7 @@ SSO callback from the authenticated routes.
 ### Blank screen after login
 
 Check that `.env.local` has `NEXT_PUBLIC_MAIN_TENANT_KEY` set. Without it,
-the tenant resolution falls back to custom-domain detection which fails on
+the platform resolution falls back to custom-domain detection which fails on
 localhost, leaving the app in a broken state.
 
 ## Next Steps

--- a/skills/iblai-chat/SKILL.md
+++ b/skills/iblai-chat/SKILL.md
@@ -130,7 +130,7 @@ import { ChatWidget } from "@/components/iblai/chat-widget";
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `mentorId` | `string` | (required) | Agent/mentor UUID -- ask the user for this |
-| `tenantKey` | `string` | from `.env` | Override tenant key (defaults to `NEXT_PUBLIC_MAIN_TENANT_KEY`) |
+| `tenantKey` | `string` | from `.env` | Override platform key (defaults to `NEXT_PUBLIC_MAIN_TENANT_KEY`) |
 | `theme` | `"light" \| "dark"` | `"light"` | Color theme |
 | `width` | `number \| string` | `720` | Widget width -- use `vh`/`vw` strings (e.g., `"100vw"`) |
 | `height` | `number \| string` | `600` | Widget height -- use `vh`/`vw` strings (e.g., `"100vh"`) |

--- a/skills/iblai-component/SKILL.md
+++ b/skills/iblai-component/SKILL.md
@@ -197,13 +197,13 @@ import { SsoLogin } from "@iblai/iblai-js/web-containers/next";
 | `ExperienceDialog` | root | Dialog for adding/editing experience |
 | `ExperienceTab` | root | Professional experience management |
 | `InstitutionDialog` | root | Institution selection dialog |
-| `InviteUserDialog` | root | Dialog to invite users to a tenant |
+| `InviteUserDialog` | root | Dialog to invite users to a platform |
 | `InvitedUsersDialog` | root | Dialog showing pending invitations |
 | `LocalLLMTab` | root | Local LLM model management (Tauri desktop) |
 | `OrganizationTab` | next | Organization settings tab |
 | `Profile` | root | Full inline profile management (use for `/profile` page) |
 | `ResumeTab` | root | Resume upload and display |
-| `UserProfileDropdown` | next | Avatar dropdown with profile, organization, tenant switcher, logout |
+| `UserProfileDropdown` | next | Avatar dropdown with profile, organization, platform switcher, logout |
 | `UserProfileModal` | next | Profile editing modal/dialog (use for overlay, NOT for a page) |
 
 ```typescript
@@ -215,11 +215,11 @@ import { Profile, CompanyDialog, EducationDialog, EducationTab, ExperienceDialog
 > `UserProfileModal` renders as a dialog overlay. Use `Profile` for a
 > dedicated `/profile` route. Use `UserProfileModal` for a quick-edit overlay.
 
-### Tenant & Organization
+### Platform & Organization
 
 | Export | Import | Description |
 |--------|--------|-------------|
-| `TenantSwitcher` | root | Switch between tenants/organizations with RBAC support |
+| `TenantSwitcher` | root | Switch between platforms/organizations with RBAC support |
 
 ```typescript
 import { TenantSwitcher } from "@iblai/iblai-js/web-containers";

--- a/skills/iblai-invite/SKILL.md
+++ b/skills/iblai-invite/SKILL.md
@@ -7,7 +7,7 @@ alwaysApply: false
 
 # /iblai-invite
 
-Add user invitation features -- a dialog to invite new users to a tenant by
+Add user invitation features -- a dialog to invite new users to a platform by
 email/username and a dialog showing pending invitations with status tracking.
 
 ![Invite Page](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-invite/iblai-invite.png)
@@ -45,7 +45,7 @@ not in a subdirectory.
 
 - Auth must be set up first (`/iblai-auth`)
 - MCP and skills must be set up: `iblai add mcp`
-- User must have admin privileges on the tenant to send invitations
+- User must have admin privileges on the platform to send invitations
 
 ## Step 0: Check for CLI Updates
 
@@ -84,13 +84,13 @@ get_component_info("InvitedUsersDialog")
 
 ## `<InviteUserDialog>` Props
 
-Dialog to invite a user to the current tenant by email or username.
+Dialog to invite a user to the current platform by email or username.
 
 | Prop | Type | Description |
 |------|------|-------------|
 | `isOpen` | `boolean` | Whether the dialog is visible |
 | `onClose` | `() => void` | Close callback |
-| `org` | `string` | Tenant/org key |
+| `org` | `string` | Platform key |
 
 ## `<InvitedUsersDialog>` Props
 
@@ -100,7 +100,7 @@ Dialog showing pending invitations with their status (accepted, pending, expired
 |------|------|-------------|
 | `isOpen` | `boolean` | Whether the dialog is visible |
 | `onClose` | `() => void` | Close callback |
-| `org` | `string` | Tenant/org key |
+| `org` | `string` | Platform key |
 
 ## Example Usage
 
@@ -153,7 +153,7 @@ Run `/iblai-test` before telling the user the work is ready:
 ## Important Notes
 
 - **Import**: `@iblai/iblai-js/web-containers` -- framework-agnostic
-- **Admin only**: Invitation features require admin privileges on the tenant
+- **Admin only**: Invitation features require admin privileges on the platform
 - **Redux store**: Must include `mentorReducer` and `mentorMiddleware`
 - **`initializeDataLayer()`**: 5 args (v1.2+)
 - **`@reduxjs/toolkit`**: Deduplicated via webpack aliases in `next.config.ts`

--- a/skills/iblai-notification/SKILL.md
+++ b/skills/iblai-notification/SKILL.md
@@ -91,7 +91,7 @@ get_component_info("NotificationDropdown")
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `org` | `string` | Tenant/org key |
+| `org` | `string` | Platform key |
 | `userId` | `string` | Username |
 | `onViewNotifications` | `(id?) => void?` | "View all" callback |
 | `className` | `string?` | Additional CSS class |
@@ -100,7 +100,7 @@ get_component_info("NotificationDropdown")
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `org` | `string` | Tenant/org key |
+| `org` | `string` | Platform key |
 | `userId` | `string` | Username |
 | `isAdmin` | `boolean?` | Shows Alerts tab + Send button |
 | `selectedNotificationId` | `string?` | Pre-select a notification |

--- a/skills/iblai-profile/SKILL.md
+++ b/skills/iblai-profile/SKILL.md
@@ -42,7 +42,7 @@ Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
 is not installed. The generated app should live in the current directory,
 not in a subdirectory.
 
-When building a navbar or header, do NOT display the tenant/platform name.
+When building a navbar or header, do NOT display the platform name.
 Use the ibl.ai logo instead.
 
 ## Prerequisites
@@ -79,14 +79,14 @@ iblai add profile
 
 | File | Purpose |
 |------|---------|
-| `components/iblai/profile-dropdown.tsx` | Avatar dropdown for navbar with profile, organization, tenant switcher, and logout |
+| `components/iblai/profile-dropdown.tsx` | Avatar dropdown for navbar with profile, organization, platform switcher, and logout |
 
 The dropdown reads `userData`, `tenant`/`current_tenant`, and `tenants` from
 localStorage. Admin status is derived from the `tenants` array by matching
-the current tenant key against `is_admin`.
+the current platform key against `is_admin`.
 
 The dropdown shows: **Profile** (links to `/profile`),
-**Organization** (links to `/account`), **Tenant Switcher**, and **Logout**.
+**Organization** (links to `/account`), **Platform Switcher**, and **Logout**.
 
 ## Step 3: Add a Full Profile Page
 
@@ -176,9 +176,9 @@ export default function ProfilePage() {
   dedicated `/profile` route.
 - **Import path**: `@iblai/iblai-js/web-containers` (NOT `/next`).
 
-## Step 4: Enable Tenant Switcher in the Dropdown
+## Step 4: Enable Platform Switcher in the Dropdown
 
-The generator does NOT enable the tenant switcher by default. You must pass
+The generator does NOT enable the platform switcher by default. You must pass
 the `userTenants` prop and set `showTenantSwitcher` to `true`:
 
 ```tsx
@@ -202,7 +202,7 @@ const userTenants = useMemo(() => {
 />
 ```
 
-Without `userTenants`, the tenant switcher will not appear even when
+Without `userTenants`, the platform switcher will not appear even when
 `showTenantSwitcher` is `true`.
 
 ## Step 5: Use MCP Tools for Customization
@@ -219,18 +219,18 @@ The generated dropdown component. Import from `@iblai/iblai-js/web-containers/ne
 | Prop | Type | Description |
 |------|------|-------------|
 | `username` | `string` | Username |
-| `tenantKey` | `string` | Tenant/org key |
+| `tenantKey` | `string` | Platform key |
 | `userIsAdmin` | `boolean` | Shows admin badge + settings |
-| `userTenants` | `Tenant[]` | **Required for tenant switcher** -- full tenant list from localStorage |
+| `userTenants` | `Tenant[]` | **Required for platform switcher** -- full platform list from localStorage |
 | `showProfileTab` | `boolean` | Show profile link |
 | `showAccountTab` | `boolean` | Show account settings link |
-| `showTenantSwitcher` | `boolean` | Show tenant switcher (needs `userTenants`) |
+| `showTenantSwitcher` | `boolean` | Show platform switcher (needs `userTenants`) |
 | `showLogoutButton` | `boolean` | Show logout button |
 | `showHelpLink` | `boolean` | Show help link |
 | `authURL` | `string` | Auth service URL |
 | `onLogout` | `() => void` | Logout callback |
-| `onTenantChange` | `(tenant: string) => void` | Called when user switches tenant -- must set `app_tenant` in localStorage |
-| `onTenantUpdate` | `(tenant: Tenant) => void` | Called when tenant data updates -- must set `app_tenant` in localStorage |
+| `onTenantChange` | `(tenant: string) => void` | Called when user switches platform -- must set `app_tenant` in localStorage |
+| `onTenantUpdate` | `(tenant: Tenant) => void` | Called when platform data updates -- must set `app_tenant` in localStorage |
 | `className` | `string?` | Additional CSS class |
 
 ## `<Profile>` Props (Full-Page Profile)
@@ -239,7 +239,7 @@ Import from `@iblai/iblai-js/web-containers`.
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `tenant` | `string` | Tenant/org key |
+| `tenant` | `string` | Platform key |
 | `username` | `string` | Username |
 | `isAdmin` | `boolean` | Admin flag |
 | `onClose` | `() => void` | Close callback |
@@ -267,11 +267,11 @@ dialog that combines profile editing and account settings in one overlay.
 |------|------|-------------|
 | `tenants` | `Tenant[]` | Full list of user tenants from localStorage |
 | `targetTab` | `string` | Initial tab: `basic`, `social`, `education`, `experience`, `resume`, `security` |
-| `showPlatformName` | `boolean` | Show tenant name badge |
+| `showPlatformName` | `boolean` | Show platform name badge |
 | `useGravatarPicFallback` | `boolean` | Use Gravatar when no profile pic |
 | `currentSPA` | `string` | Current app identifier (e.g., `"agent"`) |
 | `currentPlatformBaseDomain` | `string` | Base domain for custom domain settings |
-| `onTenantUpdate` | `(tenant: Tenant) => void` | Called when tenant is updated |
+| `onTenantUpdate` | `(tenant: Tenant) => void` | Called when platform is updated |
 | `onAccountDeleted` | `() => void` | Called after account deletion |
 
 ## Step 6: Verify


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
 update the wording of "platforms" to not call them "tenants"