### PR TITLE
Add crm vibe skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 .env.local
+
+# Personal daily work log — never commit
+.daily-work-log/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,12 @@ Invoke with `/` in Claude Code:
 | `/iblai-agent-prompt` | Add the agent Prompts tab (system prompts and suggested prompts) |
 | `/iblai-agent-safety` | Add the agent Safety tab (moderation prompts and flagged content) |
 | `/iblai-agent-tool` | Add the agent Tools tab (enable/disable agent tools) |
+| `/iblai-crm-overview` | Reference + family index for the CRM API (auth, seeded defaults, RBAC roles, sub-skill map) |
+| `/iblai-crm-lead-flow` | Add the CRM top-of-funnel surface (lead capture, contacts table, person detail, link/invite/merge) |
+| `/iblai-crm-deal-flow` | Add the CRM revenue surface (pipelines, stages, lead sources, kanban deal board, move-stage/won/lost) |
+| `/iblai-crm-activity` | Add the CRM activity timeline panel for persons and deals (calls, meetings, notes, tasks, reminders, mark-done) |
+| `/iblai-crm-tag` | Add the CRM tag manager + chips + attach/detach controls + tag filters across persons/orgs/deals |
+| `/iblai-crm-notification` | Reference for the three CRM notification types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) and recipient routing |
 
 ### Marketing Skills
 

--- a/adapters/codex/iblai-crm-activity.md
+++ b/adapters/codex/iblai-crm-activity.md
@@ -1,0 +1,285 @@
+# iblai-crm-activity
+
+> Build the CRM activity timeline panel that mounts inside a Person or a Deal detail surface — list calls, meetings, emails, notes, tasks, lunches, and deadlines, schedule them, set reminders, mark them done idempotently, and render server-emitted stage-change audit rows distinctly. Use when the user mentions CRM activity, activities, timeline, log a call, schedule a meeting, sales notes, tasks, deadlines, reminders, or mark done. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-lead-flow for the person host, /iblai-crm-deal-flow for the deal host and stage-change audit rows, /iblai-notification for the bell that surfaces reminders, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring.
+
+# /iblai-crm-activity
+
+Build the activity timeline panel that lives inside a Person or Deal detail
+surface: list activities, create them (call, meeting, email, note, task,
+lunch, deadline), schedule + remind, mark done, and render server-emitted
+audit rows distinctly.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for activity CRUD and the
+  `done/` action. See `/iblai-rbac` for the full matrix.
+- A host surface must already exist. The timeline is a **panel**, not a
+  standalone page. Either:
+  - `/iblai-crm-lead-flow` — for the Person detail timeline, OR
+  - `/iblai-crm-deal-flow` — for the Deal detail timeline (which is
+    also the source of the server-emitted `Stage changed` audit rows
+    you will render).
+
+## What you'll build
+
+- A **timeline panel** that mounts inside the existing Person detail
+  page (filtered by `person=<uuid>`) and inside the existing Deal
+  detail page (filtered by `deal=<id>`), backed by
+  `GET /api/crm/activities/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **create-activity form** with a type selector covering all seven
+  types — `call`, `meeting`, `email`, `note`, `task`, `lunch`,
+  `deadline` — plus `title`, `comment`, optional `location`,
+  `schedule_from`, `schedule_to`, `reminder_at`, and free-form
+  `metadata`.
+- A **done checkbox** on each open user row that calls
+  `POST /api/crm/activities/{id}/done/` — idempotent, safe to retry.
+- A **system-row renderer** that visually de-emphasizes
+  server-emitted stage-change audit rows
+  (`type === "note" && title === "Stage changed"`) and suppresses
+  their edit / delete / done controls per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently).
+
+Reference tables for every endpoint and field live in:
+
+- `references/activities-api.md`
+- `references/timeline-rendering.md`
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date. Run
+`iblai --version` to check the current version, then upgrade directly:
+
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+This is safe to run even if already at the latest version.
+
+## Step 1: Install shadcn primitives
+
+There is no dedicated `iblai add` generator for the timeline panel — it is
+plain shadcn/ui glued to the CRM REST API. Install the primitives you need:
+
+```bash
+npx shadcn@latest add card select input textarea checkbox button dialog calendar popover badge
+```
+
+You will use `card` for each row, `select` for the type picker, `input`
+and `textarea` for title/comment, `calendar` + `popover` for date
+pickers, `checkbox` for the done toggle, `dialog` for the create form,
+and `badge` for the type chip.
+
+## Step 2: Wrap the activities REST API
+
+Create `lib/iblai/crm-activities.ts`. Read the token and base URL the way
+`/iblai-auth` already wired them — do not introduce a parallel auth layer.
+
+Endpoints (every activity row is scoped to your Platform; cross-Platform
+rows return 404):
+
+| Verb | Path | Use |
+|---|---|---|
+| `GET` | `/api/crm/activities/?person={uuid}` | List a person's timeline |
+| `GET` | `/api/crm/activities/?deal={id}` | List a deal's timeline |
+| `POST` | `/api/crm/activities/` | Create — body MUST set EXACTLY one of `person`/`deal` (or both, where the person equals the deal's person). Neither = 400. |
+| `PATCH` | `/api/crm/activities/{id}/` | Edit user-authored rows. Do NOT call on system rows. |
+| `DELETE` | `/api/crm/activities/{id}/` | Delete user-authored rows. Do NOT call on system rows. |
+| `POST` | `/api/crm/activities/{id}/done/` | Mark done — idempotent, no body |
+
+Every list call uses the standard pagination envelope
+`{count, next_page, previous_page, results[]}`. Default ordering is
+newest-first by `created_at`.
+
+Server-managed fields you MUST NOT write from the client:
+
+- `done_at` — stamped server-side the first time `is_done` flips true
+- `reminder_sent` — flipped server-side after reminder dispatch
+
+See `references/activities-api.md` for the full field list, every
+filter, the attachment-rule errors, and curl examples.
+
+## Step 3: Activity-type selector
+
+Render a shadcn `select` whose values map 1:1 to the `type` field on the
+POST body. All seven types are first-class — none are aliases.
+
+| Value | Suggested chip color | Suggested icon |
+|---|---|---|
+| `call` | sky | Phone |
+| `meeting` | indigo | CalendarClock |
+| `email` | violet | Mail |
+| `note` | slate | StickyNote |
+| `task` | amber | CheckSquare |
+| `lunch` | rose | Utensils |
+| `deadline` | red | AlarmClock |
+
+The chip color is cosmetic — drive it from a small lookup table next to
+your renderer. The `type` you POST must be one of the seven strings
+above verbatim.
+
+## Step 4: Scheduling and reminders
+
+Collect three ISO-8601 datetime fields in the create form. Match the
+shape to the intent — do not invent dates to fill empty slots:
+
+| `schedule_from` | `schedule_to` | Read as |
+|---|---|---|
+| null | null | A past log entry recorded after the fact (a logged call, a written note) |
+| set | null | A scheduled task or deadline with a start time but no fixed end |
+| set | set | A meeting or other time-bounded event |
+
+Add an optional `reminder_at` — typically a fixed offset before
+`schedule_from` (15 minutes before is a common meeting default). The
+server stamps `reminder_sent` after dispatch — DO NOT set it from the
+client. The server also stamps `done_at` on completion — DO NOT set it
+from the client.
+
+> Reminder delivery is not yet dispatched server-side (see [Reminders](../../../docs/developer/applications/crm.md#105-reminders)).
+> `reminder_at` round-trips and you can surface a local in-app prompt
+> from it today; `reminder_sent` will stay `false` until the dispatcher
+> ships.
+
+## Step 5: Mark-done checkbox
+
+Render a shadcn `checkbox` on every open user row. When checked, POST
+to `/api/crm/activities/{id}/done/` with no body. The response is the
+full updated activity object — splice it into your local list so the
+row re-renders with `is_done=true` and `done_at` populated without a
+follow-up GET.
+
+This action is **idempotent**: repeat calls on an already-done activity
+return the SAME `done_at` the server stamped on the first call. That
+makes the checkbox safe to retry from a flaky network without drifting
+completion timestamps that downstream reports depend on.
+
+Do not render the checkbox on system rows — see Step 7.
+
+## Step 6: Render the timeline
+
+Order rows newest-first. Default to `created_at` desc (which is what
+the API returns); when you want a calendar-style view (e.g. an
+upcoming-meetings panel), sort by `schedule_from` instead and filter
+`?is_done=false` to hide completed entries.
+
+Each row should show, at minimum: the type chip (with the color +
+icon from Step 3), `title`, `comment`, the relative time, the owner,
+and — for scheduled rows — `schedule_from` (and `schedule_to` when
+present). Combine list filters to drive panel variants — for example
+`?deal=314&type=call&is_done=false` powers an "upcoming calls" panel
+on a deal.
+
+## Step 7: Render system audit rows distinctly
+
+Per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently), the CRM writes a system Activity every time a deal moves
+stage, wins, or is lost. Detect them client-side with one predicate:
+
+```ts
+const isStageChangeAudit = (a: Activity): boolean =>
+  a.type === "note" && a.title === "Stage changed";
+```
+
+For rows where that returns true:
+
+- Use a distinct system icon (a small arrow / system glyph)
+- Render at smaller size with muted text
+- Suppress edit, delete, and done controls — the row is server-authored
+  and arrives already complete (`is_done: true`, `done_at` set to the
+  transition timestamp)
+- Use the `comment` body (e.g. `"Discovery → Proposal"`) as the line
+  of record
+
+See `references/timeline-rendering.md` for the full rationale and the
+schedule / reminder / attachment semantics.
+
+## Filters
+
+The list endpoint accepts a focused set of query parameters useful for
+the panel variants you will build. The most commonly used here:
+
+| Param | Type | Use |
+|---|---|---|
+| `person` | UUID | Person timeline (mount on person detail) |
+| `deal` | integer | Deal timeline (mount on deal detail) |
+| `type` | string | One of the seven types — narrow to a single kind |
+| `is_done` | boolean | Hide completed / show only open |
+| `owner` | integer | Filter by owning user id |
+| `schedule_from__gte` | datetime | Calendar window start |
+| `schedule_from__lte` | datetime | Calendar window end |
+| `metadata__has_key` | string | Activities whose `metadata` JSON contains this top-level key |
+| `page`, `page_size` | integer | Standard pagination |
+
+The full list — including `metadata__has_key` semantics and combining
+rules — lives in `references/activities-api.md`.
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and open the relevant detail pages:
+   - Open a Person detail page from `/iblai-crm-lead-flow`. Create an
+     activity with `type=call`, no schedule, a short comment. Confirm
+     it appears at the top of the timeline. Mark it done with the
+     checkbox; confirm `is_done` flips and `done_at` populates.
+   - Open a Deal detail page from `/iblai-crm-deal-flow`. Create a
+     `meeting` with `schedule_from` and `schedule_to` set 30 minutes
+     apart, and `reminder_at` 15 minutes before `schedule_from`.
+     Confirm the row renders with the type chip, scheduled time, and
+     reminder.
+   - From the deal kanban, move the deal to a new stage. Reload the
+     deal timeline and confirm a server-emitted row appears with
+     `type="note"`, `title="Stage changed"`, `is_done=true`, and is
+     rendered distinctly (smaller, muted, system icon, no edit /
+     delete / done controls).
+3. Screenshot the timeline so the user can see it:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals/<id> /tmp/deal-timeline.png
+   npx playwright screenshot http://localhost:3000/crm/contacts/<uuid> /tmp/person-timeline.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — person timeline host
+- `/iblai-crm-deal-flow` — deal timeline host + audit row source (stage moves emit notes)
+- `/iblai-notification` — bell UI for activity reminders + CRM events
+- `/iblai-rbac` — CRM User role
+- `/iblai-auth` — token wiring

--- a/adapters/codex/iblai-crm-deal-flow.md
+++ b/adapters/codex/iblai-crm-deal-flow.md
@@ -1,0 +1,383 @@
+# iblai-crm-deal-flow
+
+> Build the revenue funnel CRM surface — pipelines, stages, lead sources, and the kanban deal board with move-stage / won / lost transitions. Use when the user mentions deals, kanban, pipeline, stages, lead sources, move stage, mark won, mark lost, lost reason, deal status, or sales funnel. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for persons (deals require one), /iblai-crm-activity for the timeline + audit rows, and /iblai-crm-notification for CRM_DEAL_STAGE_CHANGED routing.
+
+# /iblai-crm-deal-flow
+
+Build the revenue funnel: a pipeline selector, a kanban deal board (columns = stages, cards = deals), and the move-stage / won / lost state machine with `lost_reason` collection.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — reuse the same token wiring
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- A Person already exists in the CRM. Deals REQUIRE a `person` UUID — if
+  you have not built the lead capture surface yet, do `/iblai-crm-lead-flow`
+  first and come back.
+- RBAC role on the caller:
+  - `CRM User` — list, read, create, update, delete deals; call
+    `move-stage/`, `won/`, `lost/`. This is what 95% of sales reps need.
+  - `CRM Manager` — additionally lets you CRUD pipelines, stages, and
+    lead sources. Only needed if you're building the admin UI in Step 8.
+  - See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+1. **Pipeline selector** — defaults to the seeded `default` pipeline; lets
+   the user switch when more than one exists.
+2. **Kanban board** — one column per stage in `sort_order`, cards grouped
+   by `deal.stage`. Card shows title, `lead_value` + `currency`, person
+   name, and days-in-stage.
+3. **Drag-drop → `move-stage`** — using `@dnd-kit`, fires
+   `POST /deals/{id}/move-stage/` with `{stage_code}`.
+4. **Deal detail panel** — clicking a card opens a slide-over with full
+   deal fields and **Won** / **Lost** buttons.
+5. **Lost modal** — collects required `lost_reason` before hitting
+   `POST /deals/{id}/lost/`.
+6. **(Optional) Admin UI** — pipeline + stage + lead source CRUD for
+   `CRM Manager` users.
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date.
+Run `iblai --version`, then upgrade directly:
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+## Step 1: Install shadcn primitives + dnd-kit
+
+```bash
+npx shadcn@latest add card badge dialog select button input textarea form sheet skeleton
+pnpm add @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+`@dnd-kit` is the recommended dnd primitive — accessible, headless, plays
+well with shadcn `card`. Do not write a custom drag layer.
+
+## Step 2: Typed API client wrappers
+
+Reuse the auth token wiring from `/iblai-auth` — do NOT introduce a new
+token-management layer. Read the same `Token` value the rest of the app
+uses (the SDK persists it; client code can grab it from `localStorage` or
+from the auth context).
+
+Create `lib/iblai/crm.ts` with thin typed fetchers:
+
+```ts
+// lib/iblai/crm.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+type Stage = {
+  id: number; pipeline: number; code: string; name: string;
+  probability: number; sort_order: number;
+  is_won: boolean; is_lost: boolean; metadata: Record<string, unknown>;
+};
+
+type Pipeline = {
+  id: number; name: string; code: string; is_default: boolean;
+  rotten_days: number; stages: Stage[]; metadata: Record<string, unknown>;
+};
+
+type Deal = {
+  id: number; title: string; description: string;
+  lead_value: string; currency: string;
+  status: "open" | "won" | "lost"; lost_reason: string;
+  expected_close_date: string | null; closed_at: string | null;
+  person: string; organization: string | null;
+  pipeline: number; stage: number;
+  source: number | null; owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string; updated_at: string;
+};
+
+const h = (token: string) => ({
+  Authorization: `Token ${token}`,
+  "Content-Type": "application/json",
+});
+
+export const crm = {
+  listPipelines: (token: string, params = "") =>
+    fetch(`${BASE}/pipelines/${params}`, { headers: h(token) }).then(r => r.json()),
+  listLeadSources: (token: string) =>
+    fetch(`${BASE}/lead-sources/`, { headers: h(token) }).then(r => r.json()),
+  listDeals: (token: string, pipelineId: number) =>
+    fetch(`${BASE}/deals/?pipeline=${pipelineId}&status=open`, { headers: h(token) })
+      .then(r => r.json()),
+  createDeal: (token: string, body: Partial<Deal>) =>
+    fetch(`${BASE}/deals/`, { method: "POST", headers: h(token), body: JSON.stringify(body) })
+      .then(r => r.json()),
+  moveStage: (token: string, id: number, stage_code: string) =>
+    fetch(`${BASE}/deals/${id}/move-stage/`, {
+      method: "POST", headers: h(token), body: JSON.stringify({ stage_code }),
+    }).then(r => r.json()),
+  won: (token: string, id: number, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/won/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify(stage_code ? { stage_code } : {}),
+    }).then(r => r.json()),
+  lost: (token: string, id: number, lost_reason: string, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/lost/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify({ lost_reason, ...(stage_code ? { stage_code } : {}) }),
+    }).then(r => r.json()),
+};
+```
+
+Full endpoint catalogs and field tables live in
+[`references/pipelines-api.md`](./references/pipelines-api.md),
+[`references/lead-sources-api.md`](./references/lead-sources-api.md), and
+[`references/deals-api.md`](./references/deals-api.md).
+
+## Step 3: Fetch the default pipeline once on mount
+
+Every Platform is seeded with a default pipeline (`code=default`) carrying
+six stages — `new`, `qualified`, `proposal`, `negotiation`, `won`, `lost`.
+The list response embeds the ordered `stages` array inline, so you do not
+need a second roundtrip.
+
+```ts
+const { results } = await crm.listPipelines(token, "?is_default=true");
+const pipeline = results[0];
+// Index stages by CODE — not id. Codes are stable across environments;
+// ids differ between dev / staging / prod (see the CRM doc's [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)).
+const stagesByCode = Object.fromEntries(pipeline.stages.map((s) => [s.code, s]));
+const stagesById = Object.fromEntries(pipeline.stages.map((s) => [s.id, s]));
+```
+
+Cache `pipeline.id` and the stages object in your store (Zustand, Redux,
+or React state). The board only needs to re-fetch when the user switches
+pipelines.
+
+## Step 4: Render the kanban board
+
+```ts
+const { results: deals } = await crm.listDeals(token, pipeline.id);
+const columns = pipeline.stages
+  .filter((s) => !s.is_won && !s.is_lost)        // hide terminal columns on the open board
+  .sort((a, b) => a.sort_order - b.sort_order);
+const byStage = Object.groupBy(deals, (d) => d.stage); // group cards by Deal.stage (the stage id)
+```
+
+Card content:
+- `title` — bold, truncated to 1 line
+- `lead_value` formatted with `Intl.NumberFormat` + `currency`
+- Person name (look up via `/iblai-crm-lead-flow` person store)
+- Days-in-stage = `dayjs().diff(deal.updated_at, "day")`; flag in red when
+  it exceeds `pipeline.rotten_days` (default 30)
+
+Use shadcn `card` for cards, `badge` for the stage chip, `skeleton` for
+the initial loading state.
+
+## Step 5: Drag-drop → move-stage
+
+Wire `@dnd-kit`'s `DndContext` around the columns. On drop, derive the
+destination stage CODE (never raw id — see [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)) and call:
+
+```ts
+async function onDragEnd(deal: Deal, destStageCode: string) {
+  const dest = stagesByCode[destStageCode];
+  if (!dest) return;
+  if (dest.id === deal.stage) return;      // no-op guard — see [Idempotency](../../../docs/developer/applications/crm.md#96-idempotency)
+  const updated = await crm.moveStage(token, deal.id, destStageCode);
+  setDeals((prev) => prev.map((d) => (d.id === deal.id ? updated : d)));
+}
+```
+
+**Server side effects to call out in the UI:**
+
+- The server appends an audit Activity (`type=note`,
+  `title="Stage changed"`, `comment="<from> → <to>"`,
+  `is_done=true`). This row will appear in the deal timeline — render it
+  with a distinct icon and no edit controls per
+  `/iblai-crm-activity` ([best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- A `CRM_DEAL_STAGE_CHANGED` notification fires. See
+  `/iblai-crm-notification` for recipient routing and channel config.
+- `Deal.status` is recomputed from the destination stage's `is_won` /
+  `is_lost` flags. Do **not** echo the optimistic status — re-read from
+  the server response.
+- Dragging onto the same column is **suppressed server-side** (no write,
+  no notification, no audit row). Gate the call client-side too so the
+  UI does not flash. See `references/state-machine.md`.
+
+## Step 6: Won / Lost buttons
+
+On the deal detail panel, add two buttons:
+
+```ts
+// Won — picks the first is_won stage by sort_order automatically
+const updated = await crm.won(token, deal.id);
+
+// Won — disambiguate when the pipeline has multiple is_won stages
+const updated = await crm.won(token, deal.id, "closed-won-expansion");
+```
+
+**Lost** requires `lost_reason` — the API returns `400` if missing or
+blank (see [best practice: always provide a lost_reason](../../../docs/developer/applications/crm.md#164-always-provide-a-lost_reason)). Always collect it in a modal:
+
+```tsx
+<Dialog open={lostOpen} onOpenChange={setLostOpen}>
+  <DialogContent>
+    <DialogTitle>Mark as Lost</DialogTitle>
+    <Textarea
+      placeholder="Why did this deal slip?"
+      value={reason}
+      onChange={(e) => setReason(e.target.value)}
+      maxLength={255}
+      required
+    />
+    <Button
+      disabled={!reason.trim()}
+      onClick={async () => {
+        const updated = await crm.lost(token, deal.id, reason.trim());
+        setLostOpen(false);
+        // refresh board — deal is now status="lost"
+      }}
+    >
+      Confirm Lost
+    </Button>
+  </DialogContent>
+</Dialog>
+```
+
+**Re-opening a deal.** Won/lost are not one-way doors. To re-open, call
+`crm.moveStage(token, dealId, "<non-terminal-stage-code>")`. The server
+clears `closed_at`, flips `status` back to `open`, writes an audit
+Activity, and fires `CRM_DEAL_STAGE_CHANGED` again. There is no dedicated
+"reopen" endpoint — the stage move IS the reopen.
+
+## Step 7: Client-side footguns (must enforce in the UI)
+
+- **Never PATCH `status` or `closed_at`.** Both are server-managed; sending
+  either on PUT/PATCH returns 400 with the message
+  *"Service-managed — write via move-stage/, won/, or lost/."* Do not
+  surface these fields on a deal edit form.
+- **`Deal.stage` must belong to `Deal.pipeline`.** If you let the user
+  switch a deal's pipeline, also force them to pick a stage from the new
+  pipeline before submit. Mismatch returns 400.
+- **`Deal.organization` must match `Person.organization`** when the person
+  already has one. Pre-fill the organization field from the selected
+  person and disable it when set, or you will hit a 400.
+- **`owner` defaults to the calling user.** Only send it when you are
+  explicitly reassigning the deal.
+
+## Step 8 (optional): Pipeline, Stage, and Lead Source admin
+
+Only build this when the user has the `CRM Manager` role. Gate the menu
+entry behind that role — see `/iblai-rbac`.
+
+Destructive-delete behavior differs across these resources — surface a
+confirmation dialog that explains the consequence:
+
+| Resource | DELETE behavior |
+|---|---|
+| Pipeline | `409 Conflict` if any Deal references it. Migrate deals first. |
+| Stage | `409 Conflict` if any Deal references it. Move those deals to another stage first. |
+| Lead Source | **Not blocked.** SETs `Deal.source = NULL` on every referencing deal. Historical attribution is lost. Treat as destructive. |
+
+Other admin guardrails:
+
+- Pipeline `code` is unique per Platform (duplicate → 400).
+- At most one pipeline can have `is_default=true` per Platform — un-flag
+  the existing default first.
+- Stage `code` is unique within its pipeline.
+- A stage cannot be both `is_won` and `is_lost` (400 if you try).
+- `probability` is 0–100 (400 otherwise).
+
+Full tables, error payloads, and curl examples live in
+[`references/pipelines-api.md`](./references/pipelines-api.md) and
+[`references/lead-sources-api.md`](./references/lead-sources-api.md).
+
+## State machine
+
+A Deal's `status` is **derived** from the stage it currently sits in —
+never written directly. Three endpoints change the stage:
+
+- `POST /deals/{id}/move-stage/` — go anywhere in the pipeline.
+- `POST /deals/{id}/won/` — go to the first `is_won` stage (or a specific
+  one via `stage_code`).
+- `POST /deals/{id}/lost/` — go to the first `is_lost` stage; **requires**
+  `lost_reason`.
+
+Every successful, non-no-op transition:
+1. Recomputes `status` (`is_won` → `won`, `is_lost` → `lost`, else `open`).
+2. Stamps or clears `closed_at`.
+3. Writes a `type=note`, `title="Stage changed"` audit Activity.
+4. Fires `CRM_DEAL_STAGE_CHANGED`.
+
+Idempotency: moving to the current stage is a no-op (no write, no signal,
+no audit row, no notification). `lost/` is the one exception — it overwrites
+`lost_reason` unconditionally even when the stage move is a no-op, so
+pass the original reason on retries.
+
+Concurrency: transitions serialize on a row lock. Two simultaneous
+requests cannot both observe the same `from_stage`. Refresh the deal
+after a transition so the UI matches reality.
+
+Full diagrams + edge cases: [`references/state-machine.md`](./references/state-machine.md).
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and drive the board:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals /tmp/deals.png
+   ```
+3. Drag a card from `qualified` → `negotiation`. Confirm:
+   - The card lands and `updated_at` advances.
+   - The deal timeline (via `/iblai-crm-activity`) shows a new system
+     row: title `"Stage changed"`, comment `"Qualified → Negotiation"`.
+   - The notification bell (via `/iblai-crm-notification` →
+     `/iblai-notification`) shows a fresh `CRM_DEAL_STAGE_CHANGED` entry.
+4. Click **Lost** with an empty textarea → submit button is disabled (or
+   the server returns 400 with `{"lost_reason": ["This field is required."]}`).
+5. Click **Won** on an open deal → confirm `status` flips to `won`,
+   `closed_at` is stamped, and the card moves off the open board.
+
+## Related skills
+
+- `/iblai-crm-overview` — auth, Platform scoping, seeded defaults, RBAC matrix.
+- `/iblai-crm-lead-flow` — deals REQUIRE a person; build that flow first.
+- `/iblai-crm-activity` — deal timeline rendering; system audit rows look
+  different from user-logged activities (see [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- `/iblai-crm-tag` — attach tags to deals; filter the kanban board by tag.
+- `/iblai-crm-notification` — `CRM_DEAL_STAGE_CHANGED` fires from every
+  transition in this skill.
+- `/iblai-rbac` — `CRM User` (deals) vs `CRM Manager` (pipelines, stages,
+  lead sources) permission matrix.
+- `/iblai-auth` — token wiring; do not introduce a parallel token layer.

--- a/adapters/codex/iblai-crm-lead-flow.md
+++ b/adapters/codex/iblai-crm-lead-flow.md
@@ -1,0 +1,430 @@
+# iblai-crm-lead-flow
+
+> Build the CRM top-of-funnel surface — lead-capture form, contacts table with lifecycle filter, organization records, and the three person onboarding actions (link existing Platform user, invite by email, merge duplicates). Use when the user mentions CRM leads, contacts, people, persons, organizations, lead capture, contact intake, link to user, invite by email, merge duplicates, or lifecycle stage. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-deal-flow to open a deal once a person exists, /iblai-crm-activity for the timeline, /iblai-crm-tag for tag chips, /iblai-crm-notification for the events this flow fires, /iblai-rbac for CRM Inviter/User/Manager roles, and /iblai-auth for token wiring.
+
+# /iblai-crm-lead-flow
+
+Build the people-and-organizations surface of the CRM: capture leads, list
+contacts, view person detail, manage organizations, and run the three
+onboarding actions (link, invite, merge).
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for person and organization
+  CRUD. Add the **CRM Inviter** role on top if you need
+  `POST /persons/{id}/invite/`. See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+- A **lead-capture form** that POSTs to `/api/crm/persons/` with
+  `name`, `primary_email`, `lifecycle_stage`, optional `organization`,
+  and free-form `metadata`.
+- A **contacts table** at `/crm/contacts` with a lifecycle-stage
+  filter, owner filter, and tag filter, backed by
+  `GET /api/crm/persons/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **person detail panel** that loads `GET /api/crm/persons/{id}/`
+  and exposes three onboarding action buttons: **Link to user**,
+  **Invite by email**, **Merge duplicates**.
+- An **organizations table + form** at `/crm/organizations` for
+  `GET`/`POST /api/crm/organizations/`.
+- An **action-result toast** layer so the silent-refusal footgun on
+  `link-user/` is surfaced loudly.
+
+Reference tables for every endpoint live in:
+
+- `references/persons-api.md`
+- `references/organizations-api.md`
+- `references/onboarding-flows.md`
+
+## Step 1: Install shadcn primitives
+
+The contacts table, lead form, detail panel, and the link/invite/merge
+dialogs use only shadcn primitives. Install once:
+
+```bash
+npx shadcn@latest add form table dialog select badge input textarea
+```
+
+Do not write custom replacements for these — they share the ibl.ai
+Tailwind theme automatically.
+
+## Step 2: Add a typed CRM API client
+
+Reuse the auth token that `/iblai-auth` wrote into `.env.local`
+(`NEXT_PUBLIC_API_BASE_URL`, and the user token read from localStorage
+under the same key `/iblai-auth` uses). Do NOT introduce a new
+token-management layer.
+
+Create `lib/iblai/crm-client.ts`:
+
+```ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+function token() {
+  // /iblai-auth stores the access token in localStorage. Reuse it.
+  return typeof window !== "undefined"
+    ? localStorage.getItem("ibl_access_token") ?? ""
+    : "";
+}
+
+async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Token ${token()}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw Object.assign(new Error(res.statusText), { status: res.status, body });
+  }
+  return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+}
+
+export type Page<T> = {
+  count: number;
+  next_page: number | null;
+  previous_page: number | null;
+  results: T[];
+};
+
+export type LifecycleStage =
+  | "lead"
+  | "qualified"
+  | "opportunity"
+  | "customer"
+  | "churned";
+
+export type Person = {
+  id: string;
+  platform: number | string;
+  name: string;
+  primary_email: string | null;
+  emails: { label: string; email: string }[];
+  contact_numbers: { label: string; number: string }[];
+  job_title: string;
+  organization: string | null;
+  owner: number | null;
+  platform_user: number | null;
+  lifecycle_stage: LifecycleStage;
+  unique_id: string;
+  active: boolean;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Organization = {
+  id: string;
+  platform: number | string;
+  name: string;
+  address: Record<string, unknown>;
+  owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export const crm = {
+  // Persons
+  listPersons: (q: URLSearchParams) =>
+    call<Page<Person>>(`/persons/?${q.toString()}`),
+  getPerson: (id: string) => call<Person>(`/persons/${id}/`),
+  createPerson: (body: Partial<Person>) =>
+    call<Person>(`/persons/`, { method: "POST", body: JSON.stringify(body) }),
+  patchPerson: (id: string, body: Partial<Person>) =>
+    call<Person>(`/persons/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+  deletePerson: (id: string) =>
+    call<void>(`/persons/${id}/`, { method: "DELETE" }),
+  linkUser: (id: string, user_id: number) =>
+    call<Person>(`/persons/${id}/link-user/`, {
+      method: "POST",
+      body: JSON.stringify({ user_id }),
+    }),
+  invite: (
+    id: string,
+    body: {
+      is_admin?: boolean;
+      is_staff?: boolean;
+      enrollment_config?: Record<string, unknown>;
+      redirect_to?: string;
+    },
+  ) =>
+    call<{
+      person_id: string;
+      invitation_id: number;
+      invitation_email: string;
+      platform_key: string;
+      auto_accept: boolean;
+      active: boolean;
+      redirect_to: string | null;
+      created: string | null;
+    }>(`/persons/${id}/invite/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  merge: (primary_id: string, duplicate_ids: string[]) =>
+    call<{
+      primary_id: string;
+      merged_ids: string[];
+      reparented: { deals: number; activities: number; tags: number };
+    }>(`/persons/merge/`, {
+      method: "POST",
+      body: JSON.stringify({ primary_id, duplicate_ids }),
+    }),
+
+  // Organizations
+  listOrgs: (q: URLSearchParams) =>
+    call<Page<Organization>>(`/organizations/?${q.toString()}`),
+  getOrg: (id: string) => call<Organization>(`/organizations/${id}/`),
+  createOrg: (body: Partial<Organization>) =>
+    call<Organization>(`/organizations/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+};
+```
+
+All examples in the references send `Authorization: Token …` — this
+client does the same.
+
+## Step 3: Lead-capture form
+
+Page route: `app/crm/leads/new/page.tsx`. Fields:
+
+- `name` — required, text input.
+- `primary_email` — recommended; auto-link binds on Platform signup.
+- `lifecycle_stage` — `Select` defaulting to `lead`
+  (`lead | qualified | opportunity | customer | churned`).
+- `organization` — `Select` populated from
+  `crm.listOrgs(new URLSearchParams())`.
+- `metadata` — `textarea`, parsed as JSON before submit.
+
+Submit calls `crm.createPerson({...})`. On `201` redirect to
+`/crm/contacts/{id}`. Handle:
+
+- `400` with a `unique_id` array → show the server message under the
+  `unique_id` field (duplicate import key).
+- `403` → "You need the CRM User role to create contacts" (cross-ref
+  `/iblai-rbac`).
+
+Full field table: [`POST /persons/` in the Persons API reference](references/persons-api.md#post-persons).
+
+## Step 4: Contacts table
+
+Page route: `app/crm/contacts/page.tsx`. Fetch via
+`crm.listPersons(query)` where `query` is built from URL search params:
+
+- `lifecycle_stage` — `Select` with the five stages plus "All".
+- `owner` — numeric input or owner picker.
+- `tags` — multi-select; emit `?tags=1&tags=2` (OR semantics, results
+  de-duplicated server-side).
+- `page` / `page_size` — pagination, max `page_size=100`.
+
+Render rows in a shadcn `Table`. Columns: name, primary_email,
+lifecycle stage (`Badge`), owner, tags (chip per item). Wire pagination
+off the `{count, next_page, previous_page, results}` envelope — do not
+assume cursor pagination.
+
+Each row links to `/crm/contacts/{id}`.
+
+## Step 5: Person detail panel + onboarding actions
+
+Page route: `app/crm/contacts/[id]/page.tsx`. Load via
+`crm.getPerson(id)`. Display name, email, lifecycle stage,
+organization, owner, `platform_user` (when set), tags, metadata, and
+the three action buttons described below.
+
+### 5a. Link to existing Platform user
+
+Dialog with a single `user_id` numeric input. On submit:
+
+```ts
+const linked = await crm.linkUser(person.id, Number(userId));
+
+// SILENT-REFUSAL FOOTGUN: a 200 response whose platform_user
+// does NOT equal the requested user_id means the person was already
+// bound to a different user and the existing binding was preserved.
+// You MUST assert equality client-side before claiming success.
+if (linked.platform_user !== Number(userId)) {
+  toast.error(
+    `This person is already linked to user ${linked.platform_user}. ` +
+      `The existing binding was preserved.`,
+  );
+} else {
+  toast.success("Linked to Platform user.");
+}
+```
+
+Status codes to handle: `400` (missing/wrong `user_id`), `403` (target
+user has no active `UserPlatformLink` — surface "issue an invitation
+instead"), `404` (person or user does not exist). Full table:
+[the Link flow in the onboarding reference](references/onboarding-flows.md#1-link-an-existing-platform-user).
+
+### 5b. Invite by email
+
+Dialog with `is_admin` and `is_staff` checkboxes, optional
+`enrollment_config` (textarea, JSON), and optional `redirect_to` URL.
+Requires the person to have a `primary_email`.
+
+Status codes:
+
+| Code | Meaning |
+|------|---------|
+| `201` | Invitation queued. Show success toast. |
+| `400` | Person has no `primary_email`. Disable the button when null. |
+| `403` | Caller missing `Ibl.CRM/Invite/action` (CRM Inviter role). |
+| `404` | Person not found. |
+| `409` | Active invitation already exists. Body contains `invitation_id` — treat as "already done", offer a "resend" affordance. |
+| `422` | Person already linked to a Platform user. Hide the button when `platform_user` is set. |
+
+Full body and field list: [the Invite flow in the onboarding reference](references/onboarding-flows.md#2-invite-by-email).
+
+### 5c. Merge duplicates
+
+Dialog with a multi-select of duplicate person rows to merge into the
+current (primary) person. Submit:
+
+```ts
+const result = await crm.merge(primaryId, duplicateIds);
+// result.reparented = { deals, activities, tags }
+toast.success(
+  `Merged ${result.merged_ids.length} duplicates. ` +
+    `Reparented ${result.reparented.deals} deals, ` +
+    `${result.reparented.activities} activities, ` +
+    `${result.reparented.tags} tag assignments.`,
+);
+```
+
+Status codes: `400` (primary in `duplicate_ids`, empty
+`duplicate_ids`, cross-Platform duplicate), `403`, `404`. Duplicates
+are **soft-deleted** (`active=false`); their rows are still
+retrievable by id, so list views must filter on `active=true`.
+
+## Step 6: Organizations table + form
+
+Page route: `app/crm/organizations/page.tsx`. Use
+`crm.listOrgs(query)` with `?name=<substring>&owner=<id>&tags=…`.
+Render in a shadcn `Table` with name, owner, tags, created_at.
+
+Create form at `app/crm/organizations/new/page.tsx`:
+
+- `name` — required, must be unique within the Platform
+  (case-sensitive, trimmed). Handle `400 {"name": ["… already exists …"]}`
+  by surfacing the message inline.
+- `address` — free-form JSON `textarea` (the recommended shape
+  `{street, city, state, zip, country}` is a hint, not enforced).
+- `owner` — optional numeric.
+- `metadata` — free-form JSON.
+
+Deleting an organization sets `Person.organization` and
+`Deal.organization` to `null` on every referencing row — there is no
+cascade-delete. Tag assignments on the organization are removed. Full
+shape: `references/organizations-api.md`.
+
+## Auto-link signal
+
+You do not need to call any endpoint for this — but you must build for
+it. When a Platform user is created (signup, invitation acceptance,
+admin) and their email matches a Person's `primary_email`
+(case-insensitive) on a Platform they belong to, the system
+asynchronously sets `platform_user`, flips `active` from `true` to
+`false`, and fires a `CRM_PERSON_LINKED_TO_USER` notification.
+
+Two UI consequences:
+
+- A `GET /persons/{id}/` issued seconds after signup may still show
+  `active: true` and `platform_user: null`. Build polling or a
+  notification-driven refresh into any view that surfaces this state.
+- A row can disappear from an "active people" list between page loads
+  with no operator action in between. Tolerate the transition; do not
+  crash on missing rows.
+
+The notification fires regardless of whether your CRM UI is open.
+Cross-ref `/iblai-crm-notification` for recipient routing and how to
+subscribe an inbox.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done.
+
+```bash
+pnpm build         # must pass with zero errors
+pnpm typecheck
+pnpm dev &
+npx playwright screenshot http://localhost:3000/crm/leads/new       /tmp/crm-lead.png
+npx playwright screenshot http://localhost:3000/crm/contacts        /tmp/crm-contacts.png
+npx playwright screenshot http://localhost:3000/crm/organizations   /tmp/crm-orgs.png
+```
+
+Smoke checklist:
+
+- [ ] Create a Person via the lead form → row appears in contacts table.
+- [ ] Filter the contacts table by `lifecycle_stage=qualified`.
+- [ ] Open the detail panel; click **Link to user** with a known
+      `user_id` and confirm `platform_user === user_id`.
+- [ ] Repeat **Link to user** with the same `user_id` on a person
+      already bound elsewhere — confirm the silent-refusal toast fires
+      (response is 200, but `platform_user` differs).
+- [ ] **Invite by email** a person with a `primary_email`; the second
+      attempt returns 409 with the same `invitation_id`.
+- [ ] **Merge** two duplicates into a primary; confirm
+      `reparented.{deals,activities,tags}` counts are returned.
+- [ ] Create an Organization; deleting it does not cascade-delete
+      Persons that referenced it.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults, links to every sibling skill.
+- `/iblai-crm-deal-flow` — once a person exists, open a deal on the kanban.
+- `/iblai-crm-activity` — log timeline events (calls, meetings, notes, tasks) on a person.
+- `/iblai-crm-tag` — tag CRUD and chip components for people and organizations.
+- `/iblai-crm-notification` — `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER` fire from this flow.
+- `/iblai-rbac` — CRM Inviter / CRM User / CRM Manager roles and the action-definitions endpoint.
+- `/iblai-auth` — token wiring this skill reuses.

--- a/adapters/codex/iblai-crm-notification.md
+++ b/adapters/codex/iblai-crm-notification.md
@@ -1,0 +1,185 @@
+# iblai-crm-notification
+
+> Reference for the three CRM notification event types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) the ibl.ai CRM dispatches after a write commits — payload shapes, recipient routing modes (default / per-Platform configured), and how to surface them in your app. Use when the user mentions CRM notifications, lead/deal alerts, "who gets notified when a deal moves stages", recipient mode configuration, or wiring a CRM-only inbox; see /iblai-crm-overview for setup, /iblai-crm-lead-flow and /iblai-crm-deal-flow for the events' source skills, and /iblai-notification for the bell UI that actually renders these events. This is a REFERENCE skill — it documents the contract; it does NOT build the bell UI.
+
+# /iblai-crm-notification
+
+Reference skill for the three CRM notification event types. Documents
+when each one fires, the context keys included in the payload, the
+recipient-routing modes available per Platform, and where the developer
+goes next to surface these events in the UI. This skill does NOT build
+the notification bell — that is `/iblai-notification`.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth set up (`/iblai-auth`)
+- MCP and skills set up (`iblai add mcp`)
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user holds a CRM role (`CRM Viewer` is enough to read
+  inbox entries that target them; see `/iblai-rbac`)
+
+## The three CRM notification types
+
+Every CRM write that produces a notification routes through exactly one
+of these three event types. Full payload tables (every `context` key)
+live in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+| `event_type` | Fires when | Source skill | Default recipients |
+|---|---|---|---|
+| `CRM_PERSON_CREATED` | A person row is created via any path — REST `POST /persons/`, the Django admin, or bulk import | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+| `CRM_DEAL_STAGE_CHANGED` | A deal moves between stages via `POST /deals/{id}/move-stage/`, `POST /deals/{id}/won/`, or `POST /deals/{id}/lost/`. No-op transitions (destination stage equals current stage) are SUPPRESSED — no notification | `/iblai-crm-deal-flow` | Platform admins + `deal.owner` |
+| `CRM_PERSON_LINKED_TO_USER` | A person is bound to a Platform user — either by explicit `POST /persons/{id}/link-user/` or implicitly by the auto-link signal when a new user registers with a matching email | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+
+"Object owner" is `person.owner` for the two person-scoped events and
+`deal.owner` for the stage-change event. If the owner field is unset on
+the triggering object, the configured recipient mode decides whether to
+fall back to admins or drop the notification — see `## Recipient routing`
+below.
+
+## After-commit dispatch
+
+All three event types dispatch **asynchronously after the writing
+transaction commits**. The CRM signal is observed inside the request, but
+the actual notification send fires from a post-commit hook on the
+database transaction. The practical consequences:
+
+- A write that rolls back — failed validation, database constraint, a
+  `move-stage` call that raises mid-transition — produces no
+  notification. The signal is observed, the dispatch is not.
+- By the time a recipient sees the email, push entry, or inbox row, the
+  underlying record is durably on disk. There are no ghost notifications
+  for state that never persisted.
+- Context keys are snapshotted at signal time from the live object. A
+  template that references `{{ deal_lead_value }}` reads the value as it
+  stood the moment the stage transition committed; later edits to the
+  deal do not re-render or re-send.
+
+Cross-reference: this is the same after-commit rule the [System Overview](../../../docs/developer/applications/crm.md#2-system-overview) "Side
+Effects" block describes, and it is shared with the audit `Activity` row
+that `move-stage`/`won`/`lost` writes alongside the notification (see
+`/iblai-crm-activity`).
+
+## Recipient routing
+
+Every CRM notification template — and any notification type that opts
+into the shared recipients pipeline — can be configured per Platform
+with one of five recipient modes:
+
+| Mode | Effect |
+|---|---|
+| `platform_admins_only` | Deliver to active Platform admins only. The object's owner is ignored. |
+| `object_owner_only` | Deliver to the object's owner. If the owner field is unset, fall back to Platform admins so nothing is silently dropped. |
+| `object_owner_only_strict` | Deliver to the object's owner only. If the owner is unset, no one is notified. Use when the notification is meaningless without an owner. |
+| `platform_admins_and_object_owner` | **Default.** Both audiences receive the notification, deduplicated so an admin who is also the owner does not get two copies. |
+| `custom` | Deliver to a hand-picked list of users, user groups, or RBAC role-policy holders. Admins and the owner are NOT implicitly included. |
+
+When the mode is `custom`, the template's `recipients_custom_recipients`
+field holds a list of dicts. Each entry takes one of three shapes:
+
+```json
+{ "type": "user",        "id": 123 }
+{ "type": "user_group",  "id": 7 }
+{ "type": "rbac_policy", "policy_name": "CRM Manager" }
+```
+
+Entries compose freely — a single list can mix individual users, groups,
+and policy holders. The resolver expands each entry, unions the results,
+deduplicates, and runs the active-Platform-membership filter as a final
+gate. Stale entries (departed users, reassigned policies, drained
+groups) simply contribute zero recipients on that dispatch.
+
+Recipient configuration lives on the **notification template, not the
+CRM models**. Changing it for `CRM_DEAL_STAGE_CHANGED` on a given
+Platform is a `PATCH` against that Platform's template for that type,
+setting `recipients_recipient_mode` and (if `custom`) populating
+`recipients_custom_recipients`. The CRM does not add a separate API
+surface for this — the same template-management endpoints documented in
+`/iblai-notification` handle these three types alongside every other
+notification type on the platform. This skill does NOT modify those
+endpoints; it just documents which event types route through them.
+
+Full mode table, custom-shape examples, the change-recipients workflow,
+and the active-membership filter rules are in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+## Channels
+
+Email delivery is wired by default for all three CRM event types.
+Per-user notification preferences are honored by the underlying delivery
+machinery — the CRM does not bypass them. Additional channels (in-app
+inbox feed, push notification) follow the template's channel
+configuration, inspected and changed via the same templates API.
+
+The **in-app bell + notification center** that surfaces inbox entries is
+NOT in scope for this skill. Send the developer to `/iblai-notification`
+for the drop-in `<NotificationDropdown>` and `<NotificationDisplay>`
+components.
+
+## Consuming the events in your UI
+
+This is a reference skill. To actually show a user the three CRM event
+types in the browser:
+
+1. Install the bell + center via `/iblai-notification`. That skill ships
+   `components/iblai/notification-bell.tsx` and the
+   `<NotificationDisplay>` page surface (Inbox + Alerts tabs).
+2. The bell's inbox list is a standard notification feed — every
+   delivered notification carries an `event_type` matching one of the
+   three values from the table above. Filter the inbox query to those
+   three values (or any subset) when you want a CRM-only inbox view.
+3. For deeper drill-down (clicking an inbox entry that says "Deal moved
+   to Negotiation" and jumping to the kanban card), wire the
+   `onViewNotifications` callback on `<NotificationDropdown>` to route
+   to the deal detail page built by `/iblai-crm-deal-flow`.
+
+## Verify
+
+End-to-end smoke once the bell is wired:
+
+1. From the kanban built in `/iblai-crm-deal-flow`, move a deal from one
+   stage to another via `POST /deals/{id}/move-stage/`. Make sure the
+   destination stage actually differs from the current one (same-stage
+   moves are suppressed and produce nothing).
+2. Within a few seconds, confirm a `CRM_DEAL_STAGE_CHANGED` row appears
+   in the inbox bell installed by `/iblai-notification` for the deal's
+   owner.
+3. Open the deal's activity timeline (`/iblai-crm-activity`) and confirm
+   the corresponding audit `Activity` row exists with `type=note`,
+   `done=true`, `title="Stage changed"`. The notification and the audit
+   row are written together — if one is missing while the other is
+   present, the transaction split unexpectedly and is worth filing.
+4. Re-run the same `move-stage` call with `stage_code` set to the
+   destination it just reached. The API should return the deal
+   unchanged, no new audit row, and no new notification.
+
+Run `/iblai-ops-test` before reporting done.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — source of `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER`
+- `/iblai-crm-deal-flow` — source of `CRM_DEAL_STAGE_CHANGED`
+- `/iblai-notification` — bell UI + notification center that consumes these events
+- `/iblai-rbac` — required CRM roles
+- `/iblai-auth` — token wiring

--- a/adapters/codex/iblai-crm-overview.md
+++ b/adapters/codex/iblai-crm-overview.md
@@ -1,0 +1,138 @@
+# iblai-crm-overview
+
+> Reference and family index for the ibl.ai Platform-scoped CRM REST API at /api/crm/ — auth, seeded defaults (default Pipeline + 6 stages + 4 Lead Sources), the four CRM RBAC roles (Viewer/User/Manager/Inviter), and the workflow sub-skill map. Use when the user mentions CRM, leads, pipelines, deals, contacts, or asks where a CRM workflow lives. See /iblai-crm-lead-flow for people + onboarding, /iblai-crm-deal-flow for pipelines + kanban, /iblai-crm-activity for the timeline, /iblai-crm-tag for tags, /iblai-crm-notification for CRM event routing, /iblai-auth for token wiring, /iblai-rbac for role assignment.
+
+# /iblai-crm-overview
+
+Reference skill for the ibl.ai CRM. Covers authentication, seeded
+defaults, the four CRM RBAC roles, and points to every sub-skill in
+the `iblai-crm-*` family. This skill builds no UI — open it first when
+you need orientation, then jump to the workflow skill that matches the
+surface you are building.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Authentication
+
+Every CRM endpoint lives under `/api/crm/` and requires a
+Platform-scoped token:
+
+```
+Authorization: Token <your-access-token>
+```
+
+Tokens bind to exactly one Platform at the moment of issue. The
+Platform is inferred from the token on every request — there is no
+`?platform_key=` query parameter on the consumer surface, and supplying
+one will not change the Platform a request resolves to.
+
+Records belonging to a different Platform return **`404 Not Found`,
+never `403 Forbidden`**. This is intentional: returning `403` would
+leak the existence of cross-Platform records. Treat a `404` on a
+record you just created as a sign you are pointing at the wrong
+Platform; a `403` always means "authenticated but the role does not
+grant this action."
+
+The full REST contract (base URL, pagination envelope, ID types per
+resource, side effects) is in
+[`references/api-overview.md`](./references/api-overview.md). For
+token wiring inside a Next.js app see `/iblai-auth`.
+
+## Seeded defaults
+
+The first time a Platform is provisioned, the CRM seeds a working
+configuration. You do not need to create any of these yourself — they
+exist on every Platform and back-fill into existing Platforms via a
+data migration.
+
+- **One default Pipeline** with `code="default"`, `is_default=true`,
+  `rotten_days=30`.
+- **Six default Stages** on that Pipeline, referenced by stable `code`:
+  `new` → `qualified` → `proposal` → `negotiation` → `won` (terminal,
+  `is_won=true`) and `lost` (terminal, `is_lost=true`).
+- **Four default Lead Sources**: `web`, `referral`, `cold_call`,
+  `advertisement`.
+
+The stage and lead-source `code` fields are stable across environments
+(dev / staging / prod) and across renames. Numeric `id` values are not
+— always reference seeds by `code` in client code, save the pipeline
+`id` only for the immediate deal payload.
+
+Full seeded tables (every stage's `probability` / `sort_order` /
+terminal flags, every lead source `name`) are in
+[`references/seeded-defaults.md`](./references/seeded-defaults.md).
+
+## RBAC
+
+The CRM ships four roles per Platform. Roles are seeded automatically
+on Platform provisioning and assigned through the standard
+role-management surface — the CRM does not expose its own
+role-assignment endpoints. A user may hold more than one role;
+effective permissions are the union.
+
+| Role | One-line mandate |
+|---|---|
+| **CRM Viewer** | Read everything across the CRM. Write nothing. |
+| **CRM User** | Day-to-day operator — full CRUD on people, organizations, deals, activities, tags. Pipelines are read-only. No invitations. |
+| **CRM Manager** | Wildcard CRM access — pipeline / stage / lead-source administration plus invitations. |
+| **CRM Inviter** | Narrow role — read people and send invitations only. Cannot edit or create people. |
+
+Two non-obvious rules worth a second look:
+- **Invitation is its own bucket.** `Ibl.CRM/Persons/write` does not
+  imply `Ibl.CRM/Invite/action`. Gate the "Invite" affordance
+  independently.
+- **Tag attach/detach requires `Ibl.CRM/Tags/write`.** A role with
+  `Ibl.CRM/Persons/write` cannot tag a person without it.
+
+Full HTTP-verb → action-code mapping and the action-by-action matrix
+are in [`references/rbac-matrix.md`](./references/rbac-matrix.md). For
+the management UI that lists and binds roles, see `/iblai-rbac`.
+
+## The CRM skill family
+
+Every CRM skill is prefixed `iblai-crm-*`. There is no bare umbrella
+skill — this skill is the index. Pick the one that matches the
+surface you are building.
+
+| Skill | Role | Covers |
+|---|---|---|
+| `/iblai-crm-overview` | Reference / index (this skill) | Auth, seeded defaults, RBAC roles, family map |
+| `/iblai-crm-lead-flow` | Build UI | People + Organizations + lifecycle stage + onboarding (link / invite / merge) |
+| `/iblai-crm-deal-flow` | Build UI | Pipelines + Stages + Lead Sources + Deals (kanban + move-stage / won / lost state machine) |
+| `/iblai-crm-activity` | Build UI | Activity timeline (calls, meetings, notes, tasks; schedule / remind / done) on persons and deals |
+| `/iblai-crm-tag` | Build UI | Tag CRUD + attach / detach for persons, organizations, deals |
+| `/iblai-crm-notification` | Reference | Three CRM notification types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) + recipient routing |
+
+When in doubt, start with `/iblai-crm-lead-flow` (a deal needs a
+person), then `/iblai-crm-deal-flow`, then layer `/iblai-crm-activity`
+and `/iblai-crm-tag` on the detail pages.
+
+## Related skills
+
+- `/iblai-crm-lead-flow` — People + Organizations + onboarding
+- `/iblai-crm-deal-flow` — Pipelines + Stages + Lead Sources + Deals
+- `/iblai-crm-activity` — Activity timeline for persons and deals
+- `/iblai-crm-tag` — Tag CRUD + attach / detach
+- `/iblai-crm-notification` — CRM notification types and recipient routing
+- `/iblai-auth` — Token wiring; every CRM call uses the same
+  `Authorization: Token <token>` header.
+- `/iblai-rbac` — Role-management UI (`<Admin>` → Roles + Policies
+  tabs) and the action-definitions endpoint. The four CRM roles are
+  assigned here.
+- **Brand guidelines**: [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md)

--- a/adapters/codex/iblai-crm-tag.md
+++ b/adapters/codex/iblai-crm-tag.md
@@ -1,0 +1,349 @@
+# iblai-crm-tag
+
+> Build the CRM tag manager — CRUD on /api/crm/tags/ with hex color picker, a reusable tag chip, attach/detach controls on Person/Organization/Deal detail pages, and tag filters on list views with OR semantics. Use when the user mentions CRM tags, labels, tagging, color chips, tag manager, attach tag, detach tag, filter by tag, or wants to add segmentation labels to people/orgs/deals. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for the person/org host pages, /iblai-crm-deal-flow for the deal host pages, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring.
+
+# /iblai-crm-tag
+
+Build the CRM tag surface — tag CRUD dialog, color chip, attach/detach
+controls on Person, Organization, and Deal pages, plus a `?tags=` filter
+on every CRM list view.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — provides the platform
+  `Authorization: Token <token>` header used by every call below.
+- MCP and skills must be set up: `iblai add mcp`.
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user must hold the **CRM User** role (or higher) on the
+  Platform. CRM User unlocks `Ibl.CRM/Tags/list`, `read`, `action`,
+  `write`, and `delete`. CRM Viewer can only see tags, not write or
+  attach them. See `/iblai-rbac` for the role matrix and how to assign
+  CRM roles to a user.
+- At least one host surface should already exist so there is something
+  to tag. Run `/iblai-crm-lead-flow` (people + organizations) or
+  `/iblai-crm-deal-flow` (deals) first if you have not yet.
+
+## What you'll build
+
+1. A **tag manager dialog** — list, create, edit, and delete tags. Color
+   input is validated client-side against `^#[0-9A-Fa-f]{6}$` before
+   submit so the user sees errors immediately (the server applies the
+   same regex).
+2. A **tag chip** component — renders `{id, name, color}` with the hex
+   color as background. Optional `x` button for detach.
+3. **Attach / detach controls** on Person, Organization, and Deal detail
+   pages. The contract is uniform: `POST /{host}/{id}/tags/` with
+   `{tag_id}`, `DELETE /{host}/{id}/tags/{tag_id}/`.
+4. A **tag filter** on Person, Organization, and Deal list views —
+   `?tags=<id>&tags=<id2>` with **OR** semantics. Results are
+   de-duplicated by the backend.
+
+## Step 0: Check for CLI updates
+
+```bash
+iblai --version    # upgrade if outdated: pip install --upgrade iblai-app-cli OR npm i -g @iblai/cli@latest
+```
+
+## Step 1: Install shadcn primitives
+
+```bash
+npx shadcn@latest add dialog input form popover command badge button
+```
+
+`dialog` powers the tag manager and the delete-confirmation modal.
+`popover` + `command` together make a searchable tag combobox for the
+attach control. `badge` is the visual base for the tag chip. `input`
++ `form` cover the create/edit form. `button` covers actions.
+
+## Step 2: Typed API client wrapper
+
+Reuse the auth token wired in `/iblai-auth`. Create
+`lib/iblai/crm-tags.ts` with one wrapper per route. Base URL is
+`${NEXT_PUBLIC_API_BASE_URL}/api/crm`.
+
+```typescript
+// lib/iblai/crm-tags.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+const HEX = /^#[0-9A-Fa-f]{6}$/;
+
+export type Tag = {
+  id: number;
+  platform: number;
+  name: string;
+  color: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TagChip = Pick<Tag, "id" | "name" | "color">;
+
+export type Assignment = { assignment_id: number; tag: TagChip };
+
+function authHeaders(token: string) {
+  return {
+    Authorization: `Token ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+// Tag CRUD
+export async function listTags(token: string, params: { name?: string; page?: number } = {}) {
+  const qs = new URLSearchParams();
+  if (params.name) qs.set("name", params.name);
+  if (params.page) qs.set("page", String(params.page));
+  const r = await fetch(`${BASE}/tags/?${qs}`, { headers: authHeaders(token) });
+  if (!r.ok) throw new Error(`listTags ${r.status}`);
+  return r.json() as Promise<{ count: number; results: Tag[]; next_page: number | null; previous_page: number | null }>;
+}
+
+export async function createTag(token: string, body: { name: string; color?: string; metadata?: Record<string, unknown> }) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/`, { method: "POST", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function patchTag(token: string, id: number, body: Partial<Pick<Tag, "name" | "color" | "metadata">>) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "PATCH", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function deleteTag(token: string, id: number) {
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "DELETE", headers: authHeaders(token) });
+  if (!r.ok && r.status !== 204) throw new Error(`deleteTag ${r.status}`);
+}
+
+// Uniform host attach / detach. `host` is "persons" | "organizations" | "deals".
+export type Host = "persons" | "organizations" | "deals";
+
+export async function attachTag(token: string, host: Host, hostId: string | number, tagId: number): Promise<Assignment> {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ tag_id: tagId }),
+  });
+  // 201 = created; 409 = already attached, body still carries assignment_id + tag.
+  if (r.status === 201 || r.status === 409) return r.json();
+  throw await r.json();
+}
+
+export async function detachTag(token: string, host: Host, hostId: string | number, tagId: number) {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/${tagId}/`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+  // 204 = removed; 404 = not attached (treat as no-op success).
+  if (r.status !== 204 && r.status !== 404) throw new Error(`detachTag ${r.status}`);
+}
+```
+
+See `references/tags-api.md` for full endpoint table, error shapes, and
+filter semantics.
+
+## Step 3: Tag manager dialog
+
+Create `components/crm/tag-manager-dialog.tsx`. It is a single dialog
+that lists all tags from `GET /tags/`, lets the user create a new tag,
+edit an existing tag, or delete one.
+
+Requirements:
+
+- **Create form**: `name` (required, ≤ 64 chars, unique-per-Platform —
+  server-enforced) and `color` (`<input type="color">` is fine; on
+  submit, validate the value against `^#[0-9A-Fa-f]{6}$` before
+  calling `createTag`). Surface the server's 400 errors verbatim —
+  duplicate name, blank name, > 64 chars, bad hex.
+- **Edit**: inline rename + recolor calls `patchTag`. Renames take
+  effect immediately on every host chip — the chip renders from the
+  Tag row, not from the assignment.
+- **Delete**: opens a confirmation modal — see the destructive cascade
+  callout below. Disable the delete button until the user types the
+  tag name to confirm, or at minimum require a second click.
+
+The dialog reads the token from the auth store wired by `/iblai-auth`.
+
+## Step 4: Tag chip component
+
+Create `components/crm/tag-chip.tsx`. Renders `{id, name, color}` as a
+shadcn `Badge` with `style={{ backgroundColor: tag.color, color: '#fff' }}`.
+Accept an optional `onDetach: () => void` prop — when supplied, render
+a small `x` icon button inside the chip; otherwise render the chip as
+read-only.
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import type { TagChip as TTagChip } from "@/lib/iblai/crm-tags";
+
+export function TagChip({ tag, onDetach }: { tag: TTagChip; onDetach?: () => void }) {
+  return (
+    <Badge style={{ backgroundColor: tag.color, color: "#fff" }} className="gap-1">
+      {tag.name}
+      {onDetach ? (
+        <button onClick={onDetach} aria-label={`Detach ${tag.name}`} className="ml-1">
+          <X className="h-3 w-3" />
+        </button>
+      ) : null}
+    </Badge>
+  );
+}
+```
+
+The `tags` array is **always present** on every Person, Organization,
+and Deal list/detail response — empty array, never `null`. So your
+renderer can iterate unconditionally.
+
+## Step 5: Attach control on host detail pages
+
+On Person, Organization, and Deal detail pages, add an "Add tag"
+button that opens a shadcn `Popover` containing a `Command` combobox.
+Populate the combobox with `listTags(token)` (search-as-you-type by
+filtering client-side, or pass `name=` to the API for large libraries).
+
+On select:
+
+```typescript
+const { assignment_id, tag } = await attachTag(token, host, hostId, selectedTagId);
+// Optimistically add `tag` to the local host.tags array; assignment_id is for
+// future detach reconciliation, not required for the chip itself.
+```
+
+Edge cases:
+
+- **409 Conflict** — the tag is already attached. The response body
+  still carries the existing `assignment_id` + `tag`, so you can
+  reconcile local state without a re-fetch and **must not** show a red
+  error toast. Treat 409 as a no-op success.
+- **404 Not Found** — the tag id is not in this Platform. Show
+  "Tag not found." The API never leaks existence across Platforms.
+
+## Step 6: Detach control
+
+Render the host's `tags` array as `TagChip` components with `onDetach`
+wired to `detachTag(token, host, hostId, tag.id)`.
+
+Edge case:
+
+- **404 Not Found** on detach means the tag was not attached. Detach
+  is **not** idempotent server-side — a retried DELETE returns 404,
+  not 204. Client code should treat both as the same success state.
+  The wrapper above already does this.
+
+## Step 7: Tag filter on list views
+
+Wire a multi-select tag picker into the Person, Organization, and Deal
+list pages.
+
+The list endpoints accept repeated or comma-separated `tags`:
+
+```
+GET /api/crm/persons/?tags=7&tags=12
+GET /api/crm/persons/?tags=7,12
+```
+
+Both forms have **OR** semantics — a record matching any selected tag
+appears once (the backend de-duplicates). The filter composes with
+every other filter on the same endpoint, e.g.:
+
+```
+GET /api/crm/persons/?tags=7&lifecycle_stage=customer&owner=4
+```
+
+Implementation: bind the selected tag-ids to `URLSearchParams.append`
+so a `tags` array becomes repeated params, then refetch the list.
+
+## Destructive cascade callout
+
+> **Deleting a tag silently removes it from every Person, Organization,
+> and Deal it is attached to.** `DELETE /tags/{id}/` cascades — there
+> is no preview, no soft-delete, and no undo.
+
+Best practice [confirm before deleting a tag](../../../docs/developer/applications/crm.md#167-confirm-before-deleting-a-tag): gate the delete button behind a confirmation modal
+that **names the tag explicitly** ("Delete tag *Enterprise*?"), states
+the consequence ("This will remove the tag from N records across people,
+organizations, and deals."), and requires an affirmative second action
+(typing the tag name or clicking a destructive button), not a single
+"OK". Optionally pre-fetch impact counts:
+
+```
+GET /api/crm/persons/?tags={id}&page_size=1   → response.count
+GET /api/crm/organizations/?tags={id}&page_size=1
+GET /api/crm/deals/?tags={id}&page_size=1
+```
+
+See `references/tags-api.md` for the full endpoint contract, error
+shapes, and host attach/detach matrix.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and visit the surface in the browser:
+   - Open the tag manager. Try to create a tag with color `#FFF`
+     (three digits) — the client should reject it before the request
+     leaves; if you bypass the client check, the server returns
+     `400 {"color": ["Color must be a hex string like \`#3F6BFF\`."]}`.
+   - Create a valid tag (`name`: `Enterprise`, `color`: `#3F6BFF`).
+   - On a Person detail page, attach the tag. Confirm the chip
+     renders. Click attach a second time — UI must not flash an
+     error (409 path).
+   - On an Organization detail page, attach the same tag.
+   - On a Deal detail page, attach the same tag.
+   - Detach the tag from the Person — chip disappears.
+   - On the Person list view, filter by the tag (`?tags=<id>`) and
+     confirm only tagged people remain.
+   - Trigger the delete-tag confirmation modal — confirm copy names
+     the tag and warns about cascade.
+3. Screenshot:
+   ```bash
+   npx playwright screenshot http://localhost:3000/crm/tags /tmp/tags.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC
+- `/iblai-crm-lead-flow` — attach tags to persons and organizations
+- `/iblai-crm-deal-flow` — attach tags to deals; filter board by tag
+- `/iblai-rbac` — CRM User role required for tag writes
+- `/iblai-auth` — token wiring

--- a/adapters/cursor/iblai-crm-activity.mdc
+++ b/adapters/cursor/iblai-crm-activity.mdc
@@ -1,0 +1,287 @@
+---
+description: "Build the CRM activity timeline panel that mounts inside a Person or a Deal detail surface — list calls, meetings, emails, notes, tasks, lunches, and deadlines, schedule them, set reminders, mark them done idempotently, and render server-emitted stage-change audit rows distinctly. Use when the user mentions CRM activity, activities, timeline, log a call, schedule a meeting, sales notes, tasks, deadlines, reminders, or mark done. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-lead-flow for the person host, /iblai-crm-deal-flow for the deal host and stage-change audit rows, /iblai-notification for the bell that surfaces reminders, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-activity
+
+Build the activity timeline panel that lives inside a Person or Deal detail
+surface: list activities, create them (call, meeting, email, note, task,
+lunch, deadline), schedule + remind, mark done, and render server-emitted
+audit rows distinctly.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for activity CRUD and the
+  `done/` action. See `/iblai-rbac` for the full matrix.
+- A host surface must already exist. The timeline is a **panel**, not a
+  standalone page. Either:
+  - `/iblai-crm-lead-flow` — for the Person detail timeline, OR
+  - `/iblai-crm-deal-flow` — for the Deal detail timeline (which is
+    also the source of the server-emitted `Stage changed` audit rows
+    you will render).
+
+## What you'll build
+
+- A **timeline panel** that mounts inside the existing Person detail
+  page (filtered by `person=<uuid>`) and inside the existing Deal
+  detail page (filtered by `deal=<id>`), backed by
+  `GET /api/crm/activities/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **create-activity form** with a type selector covering all seven
+  types — `call`, `meeting`, `email`, `note`, `task`, `lunch`,
+  `deadline` — plus `title`, `comment`, optional `location`,
+  `schedule_from`, `schedule_to`, `reminder_at`, and free-form
+  `metadata`.
+- A **done checkbox** on each open user row that calls
+  `POST /api/crm/activities/{id}/done/` — idempotent, safe to retry.
+- A **system-row renderer** that visually de-emphasizes
+  server-emitted stage-change audit rows
+  (`type === "note" && title === "Stage changed"`) and suppresses
+  their edit / delete / done controls per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently).
+
+Reference tables for every endpoint and field live in:
+
+- `references/activities-api.md`
+- `references/timeline-rendering.md`
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date. Run
+`iblai --version` to check the current version, then upgrade directly:
+
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+This is safe to run even if already at the latest version.
+
+## Step 1: Install shadcn primitives
+
+There is no dedicated `iblai add` generator for the timeline panel — it is
+plain shadcn/ui glued to the CRM REST API. Install the primitives you need:
+
+```bash
+npx shadcn@latest add card select input textarea checkbox button dialog calendar popover badge
+```
+
+You will use `card` for each row, `select` for the type picker, `input`
+and `textarea` for title/comment, `calendar` + `popover` for date
+pickers, `checkbox` for the done toggle, `dialog` for the create form,
+and `badge` for the type chip.
+
+## Step 2: Wrap the activities REST API
+
+Create `lib/iblai/crm-activities.ts`. Read the token and base URL the way
+`/iblai-auth` already wired them — do not introduce a parallel auth layer.
+
+Endpoints (every activity row is scoped to your Platform; cross-Platform
+rows return 404):
+
+| Verb | Path | Use |
+|---|---|---|
+| `GET` | `/api/crm/activities/?person={uuid}` | List a person's timeline |
+| `GET` | `/api/crm/activities/?deal={id}` | List a deal's timeline |
+| `POST` | `/api/crm/activities/` | Create — body MUST set EXACTLY one of `person`/`deal` (or both, where the person equals the deal's person). Neither = 400. |
+| `PATCH` | `/api/crm/activities/{id}/` | Edit user-authored rows. Do NOT call on system rows. |
+| `DELETE` | `/api/crm/activities/{id}/` | Delete user-authored rows. Do NOT call on system rows. |
+| `POST` | `/api/crm/activities/{id}/done/` | Mark done — idempotent, no body |
+
+Every list call uses the standard pagination envelope
+`{count, next_page, previous_page, results[]}`. Default ordering is
+newest-first by `created_at`.
+
+Server-managed fields you MUST NOT write from the client:
+
+- `done_at` — stamped server-side the first time `is_done` flips true
+- `reminder_sent` — flipped server-side after reminder dispatch
+
+See `references/activities-api.md` for the full field list, every
+filter, the attachment-rule errors, and curl examples.
+
+## Step 3: Activity-type selector
+
+Render a shadcn `select` whose values map 1:1 to the `type` field on the
+POST body. All seven types are first-class — none are aliases.
+
+| Value | Suggested chip color | Suggested icon |
+|---|---|---|
+| `call` | sky | Phone |
+| `meeting` | indigo | CalendarClock |
+| `email` | violet | Mail |
+| `note` | slate | StickyNote |
+| `task` | amber | CheckSquare |
+| `lunch` | rose | Utensils |
+| `deadline` | red | AlarmClock |
+
+The chip color is cosmetic — drive it from a small lookup table next to
+your renderer. The `type` you POST must be one of the seven strings
+above verbatim.
+
+## Step 4: Scheduling and reminders
+
+Collect three ISO-8601 datetime fields in the create form. Match the
+shape to the intent — do not invent dates to fill empty slots:
+
+| `schedule_from` | `schedule_to` | Read as |
+|---|---|---|
+| null | null | A past log entry recorded after the fact (a logged call, a written note) |
+| set | null | A scheduled task or deadline with a start time but no fixed end |
+| set | set | A meeting or other time-bounded event |
+
+Add an optional `reminder_at` — typically a fixed offset before
+`schedule_from` (15 minutes before is a common meeting default). The
+server stamps `reminder_sent` after dispatch — DO NOT set it from the
+client. The server also stamps `done_at` on completion — DO NOT set it
+from the client.
+
+> Reminder delivery is not yet dispatched server-side (see [Reminders](../../../docs/developer/applications/crm.md#105-reminders)).
+> `reminder_at` round-trips and you can surface a local in-app prompt
+> from it today; `reminder_sent` will stay `false` until the dispatcher
+> ships.
+
+## Step 5: Mark-done checkbox
+
+Render a shadcn `checkbox` on every open user row. When checked, POST
+to `/api/crm/activities/{id}/done/` with no body. The response is the
+full updated activity object — splice it into your local list so the
+row re-renders with `is_done=true` and `done_at` populated without a
+follow-up GET.
+
+This action is **idempotent**: repeat calls on an already-done activity
+return the SAME `done_at` the server stamped on the first call. That
+makes the checkbox safe to retry from a flaky network without drifting
+completion timestamps that downstream reports depend on.
+
+Do not render the checkbox on system rows — see Step 7.
+
+## Step 6: Render the timeline
+
+Order rows newest-first. Default to `created_at` desc (which is what
+the API returns); when you want a calendar-style view (e.g. an
+upcoming-meetings panel), sort by `schedule_from` instead and filter
+`?is_done=false` to hide completed entries.
+
+Each row should show, at minimum: the type chip (with the color +
+icon from Step 3), `title`, `comment`, the relative time, the owner,
+and — for scheduled rows — `schedule_from` (and `schedule_to` when
+present). Combine list filters to drive panel variants — for example
+`?deal=314&type=call&is_done=false` powers an "upcoming calls" panel
+on a deal.
+
+## Step 7: Render system audit rows distinctly
+
+Per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently), the CRM writes a system Activity every time a deal moves
+stage, wins, or is lost. Detect them client-side with one predicate:
+
+```ts
+const isStageChangeAudit = (a: Activity): boolean =>
+  a.type === "note" && a.title === "Stage changed";
+```
+
+For rows where that returns true:
+
+- Use a distinct system icon (a small arrow / system glyph)
+- Render at smaller size with muted text
+- Suppress edit, delete, and done controls — the row is server-authored
+  and arrives already complete (`is_done: true`, `done_at` set to the
+  transition timestamp)
+- Use the `comment` body (e.g. `"Discovery → Proposal"`) as the line
+  of record
+
+See `references/timeline-rendering.md` for the full rationale and the
+schedule / reminder / attachment semantics.
+
+## Filters
+
+The list endpoint accepts a focused set of query parameters useful for
+the panel variants you will build. The most commonly used here:
+
+| Param | Type | Use |
+|---|---|---|
+| `person` | UUID | Person timeline (mount on person detail) |
+| `deal` | integer | Deal timeline (mount on deal detail) |
+| `type` | string | One of the seven types — narrow to a single kind |
+| `is_done` | boolean | Hide completed / show only open |
+| `owner` | integer | Filter by owning user id |
+| `schedule_from__gte` | datetime | Calendar window start |
+| `schedule_from__lte` | datetime | Calendar window end |
+| `metadata__has_key` | string | Activities whose `metadata` JSON contains this top-level key |
+| `page`, `page_size` | integer | Standard pagination |
+
+The full list — including `metadata__has_key` semantics and combining
+rules — lives in `references/activities-api.md`.
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and open the relevant detail pages:
+   - Open a Person detail page from `/iblai-crm-lead-flow`. Create an
+     activity with `type=call`, no schedule, a short comment. Confirm
+     it appears at the top of the timeline. Mark it done with the
+     checkbox; confirm `is_done` flips and `done_at` populates.
+   - Open a Deal detail page from `/iblai-crm-deal-flow`. Create a
+     `meeting` with `schedule_from` and `schedule_to` set 30 minutes
+     apart, and `reminder_at` 15 minutes before `schedule_from`.
+     Confirm the row renders with the type chip, scheduled time, and
+     reminder.
+   - From the deal kanban, move the deal to a new stage. Reload the
+     deal timeline and confirm a server-emitted row appears with
+     `type="note"`, `title="Stage changed"`, `is_done=true`, and is
+     rendered distinctly (smaller, muted, system icon, no edit /
+     delete / done controls).
+3. Screenshot the timeline so the user can see it:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals/<id> /tmp/deal-timeline.png
+   npx playwright screenshot http://localhost:3000/crm/contacts/<uuid> /tmp/person-timeline.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — person timeline host
+- `/iblai-crm-deal-flow` — deal timeline host + audit row source (stage moves emit notes)
+- `/iblai-notification` — bell UI for activity reminders + CRM events
+- `/iblai-rbac` — CRM User role
+- `/iblai-auth` — token wiring

--- a/adapters/cursor/iblai-crm-deal-flow.mdc
+++ b/adapters/cursor/iblai-crm-deal-flow.mdc
@@ -1,0 +1,385 @@
+---
+description: "Build the revenue funnel CRM surface — pipelines, stages, lead sources, and the kanban deal board with move-stage / won / lost transitions. Use when the user mentions deals, kanban, pipeline, stages, lead sources, move stage, mark won, mark lost, lost reason, deal status, or sales funnel. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for persons (deals require one), /iblai-crm-activity for the timeline + audit rows, and /iblai-crm-notification for CRM_DEAL_STAGE_CHANGED routing."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-deal-flow
+
+Build the revenue funnel: a pipeline selector, a kanban deal board (columns = stages, cards = deals), and the move-stage / won / lost state machine with `lost_reason` collection.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — reuse the same token wiring
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- A Person already exists in the CRM. Deals REQUIRE a `person` UUID — if
+  you have not built the lead capture surface yet, do `/iblai-crm-lead-flow`
+  first and come back.
+- RBAC role on the caller:
+  - `CRM User` — list, read, create, update, delete deals; call
+    `move-stage/`, `won/`, `lost/`. This is what 95% of sales reps need.
+  - `CRM Manager` — additionally lets you CRUD pipelines, stages, and
+    lead sources. Only needed if you're building the admin UI in Step 8.
+  - See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+1. **Pipeline selector** — defaults to the seeded `default` pipeline; lets
+   the user switch when more than one exists.
+2. **Kanban board** — one column per stage in `sort_order`, cards grouped
+   by `deal.stage`. Card shows title, `lead_value` + `currency`, person
+   name, and days-in-stage.
+3. **Drag-drop → `move-stage`** — using `@dnd-kit`, fires
+   `POST /deals/{id}/move-stage/` with `{stage_code}`.
+4. **Deal detail panel** — clicking a card opens a slide-over with full
+   deal fields and **Won** / **Lost** buttons.
+5. **Lost modal** — collects required `lost_reason` before hitting
+   `POST /deals/{id}/lost/`.
+6. **(Optional) Admin UI** — pipeline + stage + lead source CRUD for
+   `CRM Manager` users.
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date.
+Run `iblai --version`, then upgrade directly:
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+## Step 1: Install shadcn primitives + dnd-kit
+
+```bash
+npx shadcn@latest add card badge dialog select button input textarea form sheet skeleton
+pnpm add @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+`@dnd-kit` is the recommended dnd primitive — accessible, headless, plays
+well with shadcn `card`. Do not write a custom drag layer.
+
+## Step 2: Typed API client wrappers
+
+Reuse the auth token wiring from `/iblai-auth` — do NOT introduce a new
+token-management layer. Read the same `Token` value the rest of the app
+uses (the SDK persists it; client code can grab it from `localStorage` or
+from the auth context).
+
+Create `lib/iblai/crm.ts` with thin typed fetchers:
+
+```ts
+// lib/iblai/crm.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+type Stage = {
+  id: number; pipeline: number; code: string; name: string;
+  probability: number; sort_order: number;
+  is_won: boolean; is_lost: boolean; metadata: Record<string, unknown>;
+};
+
+type Pipeline = {
+  id: number; name: string; code: string; is_default: boolean;
+  rotten_days: number; stages: Stage[]; metadata: Record<string, unknown>;
+};
+
+type Deal = {
+  id: number; title: string; description: string;
+  lead_value: string; currency: string;
+  status: "open" | "won" | "lost"; lost_reason: string;
+  expected_close_date: string | null; closed_at: string | null;
+  person: string; organization: string | null;
+  pipeline: number; stage: number;
+  source: number | null; owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string; updated_at: string;
+};
+
+const h = (token: string) => ({
+  Authorization: `Token ${token}`,
+  "Content-Type": "application/json",
+});
+
+export const crm = {
+  listPipelines: (token: string, params = "") =>
+    fetch(`${BASE}/pipelines/${params}`, { headers: h(token) }).then(r => r.json()),
+  listLeadSources: (token: string) =>
+    fetch(`${BASE}/lead-sources/`, { headers: h(token) }).then(r => r.json()),
+  listDeals: (token: string, pipelineId: number) =>
+    fetch(`${BASE}/deals/?pipeline=${pipelineId}&status=open`, { headers: h(token) })
+      .then(r => r.json()),
+  createDeal: (token: string, body: Partial<Deal>) =>
+    fetch(`${BASE}/deals/`, { method: "POST", headers: h(token), body: JSON.stringify(body) })
+      .then(r => r.json()),
+  moveStage: (token: string, id: number, stage_code: string) =>
+    fetch(`${BASE}/deals/${id}/move-stage/`, {
+      method: "POST", headers: h(token), body: JSON.stringify({ stage_code }),
+    }).then(r => r.json()),
+  won: (token: string, id: number, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/won/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify(stage_code ? { stage_code } : {}),
+    }).then(r => r.json()),
+  lost: (token: string, id: number, lost_reason: string, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/lost/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify({ lost_reason, ...(stage_code ? { stage_code } : {}) }),
+    }).then(r => r.json()),
+};
+```
+
+Full endpoint catalogs and field tables live in
+[`references/pipelines-api.md`](./references/pipelines-api.md),
+[`references/lead-sources-api.md`](./references/lead-sources-api.md), and
+[`references/deals-api.md`](./references/deals-api.md).
+
+## Step 3: Fetch the default pipeline once on mount
+
+Every Platform is seeded with a default pipeline (`code=default`) carrying
+six stages — `new`, `qualified`, `proposal`, `negotiation`, `won`, `lost`.
+The list response embeds the ordered `stages` array inline, so you do not
+need a second roundtrip.
+
+```ts
+const { results } = await crm.listPipelines(token, "?is_default=true");
+const pipeline = results[0];
+// Index stages by CODE — not id. Codes are stable across environments;
+// ids differ between dev / staging / prod (see the CRM doc's [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)).
+const stagesByCode = Object.fromEntries(pipeline.stages.map((s) => [s.code, s]));
+const stagesById = Object.fromEntries(pipeline.stages.map((s) => [s.id, s]));
+```
+
+Cache `pipeline.id` and the stages object in your store (Zustand, Redux,
+or React state). The board only needs to re-fetch when the user switches
+pipelines.
+
+## Step 4: Render the kanban board
+
+```ts
+const { results: deals } = await crm.listDeals(token, pipeline.id);
+const columns = pipeline.stages
+  .filter((s) => !s.is_won && !s.is_lost)        // hide terminal columns on the open board
+  .sort((a, b) => a.sort_order - b.sort_order);
+const byStage = Object.groupBy(deals, (d) => d.stage); // group cards by Deal.stage (the stage id)
+```
+
+Card content:
+- `title` — bold, truncated to 1 line
+- `lead_value` formatted with `Intl.NumberFormat` + `currency`
+- Person name (look up via `/iblai-crm-lead-flow` person store)
+- Days-in-stage = `dayjs().diff(deal.updated_at, "day")`; flag in red when
+  it exceeds `pipeline.rotten_days` (default 30)
+
+Use shadcn `card` for cards, `badge` for the stage chip, `skeleton` for
+the initial loading state.
+
+## Step 5: Drag-drop → move-stage
+
+Wire `@dnd-kit`'s `DndContext` around the columns. On drop, derive the
+destination stage CODE (never raw id — see [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)) and call:
+
+```ts
+async function onDragEnd(deal: Deal, destStageCode: string) {
+  const dest = stagesByCode[destStageCode];
+  if (!dest) return;
+  if (dest.id === deal.stage) return;      // no-op guard — see [Idempotency](../../../docs/developer/applications/crm.md#96-idempotency)
+  const updated = await crm.moveStage(token, deal.id, destStageCode);
+  setDeals((prev) => prev.map((d) => (d.id === deal.id ? updated : d)));
+}
+```
+
+**Server side effects to call out in the UI:**
+
+- The server appends an audit Activity (`type=note`,
+  `title="Stage changed"`, `comment="<from> → <to>"`,
+  `is_done=true`). This row will appear in the deal timeline — render it
+  with a distinct icon and no edit controls per
+  `/iblai-crm-activity` ([best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- A `CRM_DEAL_STAGE_CHANGED` notification fires. See
+  `/iblai-crm-notification` for recipient routing and channel config.
+- `Deal.status` is recomputed from the destination stage's `is_won` /
+  `is_lost` flags. Do **not** echo the optimistic status — re-read from
+  the server response.
+- Dragging onto the same column is **suppressed server-side** (no write,
+  no notification, no audit row). Gate the call client-side too so the
+  UI does not flash. See `references/state-machine.md`.
+
+## Step 6: Won / Lost buttons
+
+On the deal detail panel, add two buttons:
+
+```ts
+// Won — picks the first is_won stage by sort_order automatically
+const updated = await crm.won(token, deal.id);
+
+// Won — disambiguate when the pipeline has multiple is_won stages
+const updated = await crm.won(token, deal.id, "closed-won-expansion");
+```
+
+**Lost** requires `lost_reason` — the API returns `400` if missing or
+blank (see [best practice: always provide a lost_reason](../../../docs/developer/applications/crm.md#164-always-provide-a-lost_reason)). Always collect it in a modal:
+
+```tsx
+<Dialog open={lostOpen} onOpenChange={setLostOpen}>
+  <DialogContent>
+    <DialogTitle>Mark as Lost</DialogTitle>
+    <Textarea
+      placeholder="Why did this deal slip?"
+      value={reason}
+      onChange={(e) => setReason(e.target.value)}
+      maxLength={255}
+      required
+    />
+    <Button
+      disabled={!reason.trim()}
+      onClick={async () => {
+        const updated = await crm.lost(token, deal.id, reason.trim());
+        setLostOpen(false);
+        // refresh board — deal is now status="lost"
+      }}
+    >
+      Confirm Lost
+    </Button>
+  </DialogContent>
+</Dialog>
+```
+
+**Re-opening a deal.** Won/lost are not one-way doors. To re-open, call
+`crm.moveStage(token, dealId, "<non-terminal-stage-code>")`. The server
+clears `closed_at`, flips `status` back to `open`, writes an audit
+Activity, and fires `CRM_DEAL_STAGE_CHANGED` again. There is no dedicated
+"reopen" endpoint — the stage move IS the reopen.
+
+## Step 7: Client-side footguns (must enforce in the UI)
+
+- **Never PATCH `status` or `closed_at`.** Both are server-managed; sending
+  either on PUT/PATCH returns 400 with the message
+  *"Service-managed — write via move-stage/, won/, or lost/."* Do not
+  surface these fields on a deal edit form.
+- **`Deal.stage` must belong to `Deal.pipeline`.** If you let the user
+  switch a deal's pipeline, also force them to pick a stage from the new
+  pipeline before submit. Mismatch returns 400.
+- **`Deal.organization` must match `Person.organization`** when the person
+  already has one. Pre-fill the organization field from the selected
+  person and disable it when set, or you will hit a 400.
+- **`owner` defaults to the calling user.** Only send it when you are
+  explicitly reassigning the deal.
+
+## Step 8 (optional): Pipeline, Stage, and Lead Source admin
+
+Only build this when the user has the `CRM Manager` role. Gate the menu
+entry behind that role — see `/iblai-rbac`.
+
+Destructive-delete behavior differs across these resources — surface a
+confirmation dialog that explains the consequence:
+
+| Resource | DELETE behavior |
+|---|---|
+| Pipeline | `409 Conflict` if any Deal references it. Migrate deals first. |
+| Stage | `409 Conflict` if any Deal references it. Move those deals to another stage first. |
+| Lead Source | **Not blocked.** SETs `Deal.source = NULL` on every referencing deal. Historical attribution is lost. Treat as destructive. |
+
+Other admin guardrails:
+
+- Pipeline `code` is unique per Platform (duplicate → 400).
+- At most one pipeline can have `is_default=true` per Platform — un-flag
+  the existing default first.
+- Stage `code` is unique within its pipeline.
+- A stage cannot be both `is_won` and `is_lost` (400 if you try).
+- `probability` is 0–100 (400 otherwise).
+
+Full tables, error payloads, and curl examples live in
+[`references/pipelines-api.md`](./references/pipelines-api.md) and
+[`references/lead-sources-api.md`](./references/lead-sources-api.md).
+
+## State machine
+
+A Deal's `status` is **derived** from the stage it currently sits in —
+never written directly. Three endpoints change the stage:
+
+- `POST /deals/{id}/move-stage/` — go anywhere in the pipeline.
+- `POST /deals/{id}/won/` — go to the first `is_won` stage (or a specific
+  one via `stage_code`).
+- `POST /deals/{id}/lost/` — go to the first `is_lost` stage; **requires**
+  `lost_reason`.
+
+Every successful, non-no-op transition:
+1. Recomputes `status` (`is_won` → `won`, `is_lost` → `lost`, else `open`).
+2. Stamps or clears `closed_at`.
+3. Writes a `type=note`, `title="Stage changed"` audit Activity.
+4. Fires `CRM_DEAL_STAGE_CHANGED`.
+
+Idempotency: moving to the current stage is a no-op (no write, no signal,
+no audit row, no notification). `lost/` is the one exception — it overwrites
+`lost_reason` unconditionally even when the stage move is a no-op, so
+pass the original reason on retries.
+
+Concurrency: transitions serialize on a row lock. Two simultaneous
+requests cannot both observe the same `from_stage`. Refresh the deal
+after a transition so the UI matches reality.
+
+Full diagrams + edge cases: [`references/state-machine.md`](./references/state-machine.md).
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and drive the board:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals /tmp/deals.png
+   ```
+3. Drag a card from `qualified` → `negotiation`. Confirm:
+   - The card lands and `updated_at` advances.
+   - The deal timeline (via `/iblai-crm-activity`) shows a new system
+     row: title `"Stage changed"`, comment `"Qualified → Negotiation"`.
+   - The notification bell (via `/iblai-crm-notification` →
+     `/iblai-notification`) shows a fresh `CRM_DEAL_STAGE_CHANGED` entry.
+4. Click **Lost** with an empty textarea → submit button is disabled (or
+   the server returns 400 with `{"lost_reason": ["This field is required."]}`).
+5. Click **Won** on an open deal → confirm `status` flips to `won`,
+   `closed_at` is stamped, and the card moves off the open board.
+
+## Related skills
+
+- `/iblai-crm-overview` — auth, Platform scoping, seeded defaults, RBAC matrix.
+- `/iblai-crm-lead-flow` — deals REQUIRE a person; build that flow first.
+- `/iblai-crm-activity` — deal timeline rendering; system audit rows look
+  different from user-logged activities (see [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- `/iblai-crm-tag` — attach tags to deals; filter the kanban board by tag.
+- `/iblai-crm-notification` — `CRM_DEAL_STAGE_CHANGED` fires from every
+  transition in this skill.
+- `/iblai-rbac` — `CRM User` (deals) vs `CRM Manager` (pipelines, stages,
+  lead sources) permission matrix.
+- `/iblai-auth` — token wiring; do not introduce a parallel token layer.

--- a/adapters/cursor/iblai-crm-lead-flow.mdc
+++ b/adapters/cursor/iblai-crm-lead-flow.mdc
@@ -1,0 +1,432 @@
+---
+description: "Build the CRM top-of-funnel surface — lead-capture form, contacts table with lifecycle filter, organization records, and the three person onboarding actions (link existing Platform user, invite by email, merge duplicates). Use when the user mentions CRM leads, contacts, people, persons, organizations, lead capture, contact intake, link to user, invite by email, merge duplicates, or lifecycle stage. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-deal-flow to open a deal once a person exists, /iblai-crm-activity for the timeline, /iblai-crm-tag for tag chips, /iblai-crm-notification for the events this flow fires, /iblai-rbac for CRM Inviter/User/Manager roles, and /iblai-auth for token wiring."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-lead-flow
+
+Build the people-and-organizations surface of the CRM: capture leads, list
+contacts, view person detail, manage organizations, and run the three
+onboarding actions (link, invite, merge).
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for person and organization
+  CRUD. Add the **CRM Inviter** role on top if you need
+  `POST /persons/{id}/invite/`. See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+- A **lead-capture form** that POSTs to `/api/crm/persons/` with
+  `name`, `primary_email`, `lifecycle_stage`, optional `organization`,
+  and free-form `metadata`.
+- A **contacts table** at `/crm/contacts` with a lifecycle-stage
+  filter, owner filter, and tag filter, backed by
+  `GET /api/crm/persons/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **person detail panel** that loads `GET /api/crm/persons/{id}/`
+  and exposes three onboarding action buttons: **Link to user**,
+  **Invite by email**, **Merge duplicates**.
+- An **organizations table + form** at `/crm/organizations` for
+  `GET`/`POST /api/crm/organizations/`.
+- An **action-result toast** layer so the silent-refusal footgun on
+  `link-user/` is surfaced loudly.
+
+Reference tables for every endpoint live in:
+
+- `references/persons-api.md`
+- `references/organizations-api.md`
+- `references/onboarding-flows.md`
+
+## Step 1: Install shadcn primitives
+
+The contacts table, lead form, detail panel, and the link/invite/merge
+dialogs use only shadcn primitives. Install once:
+
+```bash
+npx shadcn@latest add form table dialog select badge input textarea
+```
+
+Do not write custom replacements for these — they share the ibl.ai
+Tailwind theme automatically.
+
+## Step 2: Add a typed CRM API client
+
+Reuse the auth token that `/iblai-auth` wrote into `.env.local`
+(`NEXT_PUBLIC_API_BASE_URL`, and the user token read from localStorage
+under the same key `/iblai-auth` uses). Do NOT introduce a new
+token-management layer.
+
+Create `lib/iblai/crm-client.ts`:
+
+```ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+function token() {
+  // /iblai-auth stores the access token in localStorage. Reuse it.
+  return typeof window !== "undefined"
+    ? localStorage.getItem("ibl_access_token") ?? ""
+    : "";
+}
+
+async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Token ${token()}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw Object.assign(new Error(res.statusText), { status: res.status, body });
+  }
+  return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+}
+
+export type Page<T> = {
+  count: number;
+  next_page: number | null;
+  previous_page: number | null;
+  results: T[];
+};
+
+export type LifecycleStage =
+  | "lead"
+  | "qualified"
+  | "opportunity"
+  | "customer"
+  | "churned";
+
+export type Person = {
+  id: string;
+  platform: number | string;
+  name: string;
+  primary_email: string | null;
+  emails: { label: string; email: string }[];
+  contact_numbers: { label: string; number: string }[];
+  job_title: string;
+  organization: string | null;
+  owner: number | null;
+  platform_user: number | null;
+  lifecycle_stage: LifecycleStage;
+  unique_id: string;
+  active: boolean;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Organization = {
+  id: string;
+  platform: number | string;
+  name: string;
+  address: Record<string, unknown>;
+  owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export const crm = {
+  // Persons
+  listPersons: (q: URLSearchParams) =>
+    call<Page<Person>>(`/persons/?${q.toString()}`),
+  getPerson: (id: string) => call<Person>(`/persons/${id}/`),
+  createPerson: (body: Partial<Person>) =>
+    call<Person>(`/persons/`, { method: "POST", body: JSON.stringify(body) }),
+  patchPerson: (id: string, body: Partial<Person>) =>
+    call<Person>(`/persons/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+  deletePerson: (id: string) =>
+    call<void>(`/persons/${id}/`, { method: "DELETE" }),
+  linkUser: (id: string, user_id: number) =>
+    call<Person>(`/persons/${id}/link-user/`, {
+      method: "POST",
+      body: JSON.stringify({ user_id }),
+    }),
+  invite: (
+    id: string,
+    body: {
+      is_admin?: boolean;
+      is_staff?: boolean;
+      enrollment_config?: Record<string, unknown>;
+      redirect_to?: string;
+    },
+  ) =>
+    call<{
+      person_id: string;
+      invitation_id: number;
+      invitation_email: string;
+      platform_key: string;
+      auto_accept: boolean;
+      active: boolean;
+      redirect_to: string | null;
+      created: string | null;
+    }>(`/persons/${id}/invite/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  merge: (primary_id: string, duplicate_ids: string[]) =>
+    call<{
+      primary_id: string;
+      merged_ids: string[];
+      reparented: { deals: number; activities: number; tags: number };
+    }>(`/persons/merge/`, {
+      method: "POST",
+      body: JSON.stringify({ primary_id, duplicate_ids }),
+    }),
+
+  // Organizations
+  listOrgs: (q: URLSearchParams) =>
+    call<Page<Organization>>(`/organizations/?${q.toString()}`),
+  getOrg: (id: string) => call<Organization>(`/organizations/${id}/`),
+  createOrg: (body: Partial<Organization>) =>
+    call<Organization>(`/organizations/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+};
+```
+
+All examples in the references send `Authorization: Token …` — this
+client does the same.
+
+## Step 3: Lead-capture form
+
+Page route: `app/crm/leads/new/page.tsx`. Fields:
+
+- `name` — required, text input.
+- `primary_email` — recommended; auto-link binds on Platform signup.
+- `lifecycle_stage` — `Select` defaulting to `lead`
+  (`lead | qualified | opportunity | customer | churned`).
+- `organization` — `Select` populated from
+  `crm.listOrgs(new URLSearchParams())`.
+- `metadata` — `textarea`, parsed as JSON before submit.
+
+Submit calls `crm.createPerson({...})`. On `201` redirect to
+`/crm/contacts/{id}`. Handle:
+
+- `400` with a `unique_id` array → show the server message under the
+  `unique_id` field (duplicate import key).
+- `403` → "You need the CRM User role to create contacts" (cross-ref
+  `/iblai-rbac`).
+
+Full field table: [`POST /persons/` in the Persons API reference](references/persons-api.md#post-persons).
+
+## Step 4: Contacts table
+
+Page route: `app/crm/contacts/page.tsx`. Fetch via
+`crm.listPersons(query)` where `query` is built from URL search params:
+
+- `lifecycle_stage` — `Select` with the five stages plus "All".
+- `owner` — numeric input or owner picker.
+- `tags` — multi-select; emit `?tags=1&tags=2` (OR semantics, results
+  de-duplicated server-side).
+- `page` / `page_size` — pagination, max `page_size=100`.
+
+Render rows in a shadcn `Table`. Columns: name, primary_email,
+lifecycle stage (`Badge`), owner, tags (chip per item). Wire pagination
+off the `{count, next_page, previous_page, results}` envelope — do not
+assume cursor pagination.
+
+Each row links to `/crm/contacts/{id}`.
+
+## Step 5: Person detail panel + onboarding actions
+
+Page route: `app/crm/contacts/[id]/page.tsx`. Load via
+`crm.getPerson(id)`. Display name, email, lifecycle stage,
+organization, owner, `platform_user` (when set), tags, metadata, and
+the three action buttons described below.
+
+### 5a. Link to existing Platform user
+
+Dialog with a single `user_id` numeric input. On submit:
+
+```ts
+const linked = await crm.linkUser(person.id, Number(userId));
+
+// SILENT-REFUSAL FOOTGUN: a 200 response whose platform_user
+// does NOT equal the requested user_id means the person was already
+// bound to a different user and the existing binding was preserved.
+// You MUST assert equality client-side before claiming success.
+if (linked.platform_user !== Number(userId)) {
+  toast.error(
+    `This person is already linked to user ${linked.platform_user}. ` +
+      `The existing binding was preserved.`,
+  );
+} else {
+  toast.success("Linked to Platform user.");
+}
+```
+
+Status codes to handle: `400` (missing/wrong `user_id`), `403` (target
+user has no active `UserPlatformLink` — surface "issue an invitation
+instead"), `404` (person or user does not exist). Full table:
+[the Link flow in the onboarding reference](references/onboarding-flows.md#1-link-an-existing-platform-user).
+
+### 5b. Invite by email
+
+Dialog with `is_admin` and `is_staff` checkboxes, optional
+`enrollment_config` (textarea, JSON), and optional `redirect_to` URL.
+Requires the person to have a `primary_email`.
+
+Status codes:
+
+| Code | Meaning |
+|------|---------|
+| `201` | Invitation queued. Show success toast. |
+| `400` | Person has no `primary_email`. Disable the button when null. |
+| `403` | Caller missing `Ibl.CRM/Invite/action` (CRM Inviter role). |
+| `404` | Person not found. |
+| `409` | Active invitation already exists. Body contains `invitation_id` — treat as "already done", offer a "resend" affordance. |
+| `422` | Person already linked to a Platform user. Hide the button when `platform_user` is set. |
+
+Full body and field list: [the Invite flow in the onboarding reference](references/onboarding-flows.md#2-invite-by-email).
+
+### 5c. Merge duplicates
+
+Dialog with a multi-select of duplicate person rows to merge into the
+current (primary) person. Submit:
+
+```ts
+const result = await crm.merge(primaryId, duplicateIds);
+// result.reparented = { deals, activities, tags }
+toast.success(
+  `Merged ${result.merged_ids.length} duplicates. ` +
+    `Reparented ${result.reparented.deals} deals, ` +
+    `${result.reparented.activities} activities, ` +
+    `${result.reparented.tags} tag assignments.`,
+);
+```
+
+Status codes: `400` (primary in `duplicate_ids`, empty
+`duplicate_ids`, cross-Platform duplicate), `403`, `404`. Duplicates
+are **soft-deleted** (`active=false`); their rows are still
+retrievable by id, so list views must filter on `active=true`.
+
+## Step 6: Organizations table + form
+
+Page route: `app/crm/organizations/page.tsx`. Use
+`crm.listOrgs(query)` with `?name=<substring>&owner=<id>&tags=…`.
+Render in a shadcn `Table` with name, owner, tags, created_at.
+
+Create form at `app/crm/organizations/new/page.tsx`:
+
+- `name` — required, must be unique within the Platform
+  (case-sensitive, trimmed). Handle `400 {"name": ["… already exists …"]}`
+  by surfacing the message inline.
+- `address` — free-form JSON `textarea` (the recommended shape
+  `{street, city, state, zip, country}` is a hint, not enforced).
+- `owner` — optional numeric.
+- `metadata` — free-form JSON.
+
+Deleting an organization sets `Person.organization` and
+`Deal.organization` to `null` on every referencing row — there is no
+cascade-delete. Tag assignments on the organization are removed. Full
+shape: `references/organizations-api.md`.
+
+## Auto-link signal
+
+You do not need to call any endpoint for this — but you must build for
+it. When a Platform user is created (signup, invitation acceptance,
+admin) and their email matches a Person's `primary_email`
+(case-insensitive) on a Platform they belong to, the system
+asynchronously sets `platform_user`, flips `active` from `true` to
+`false`, and fires a `CRM_PERSON_LINKED_TO_USER` notification.
+
+Two UI consequences:
+
+- A `GET /persons/{id}/` issued seconds after signup may still show
+  `active: true` and `platform_user: null`. Build polling or a
+  notification-driven refresh into any view that surfaces this state.
+- A row can disappear from an "active people" list between page loads
+  with no operator action in between. Tolerate the transition; do not
+  crash on missing rows.
+
+The notification fires regardless of whether your CRM UI is open.
+Cross-ref `/iblai-crm-notification` for recipient routing and how to
+subscribe an inbox.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done.
+
+```bash
+pnpm build         # must pass with zero errors
+pnpm typecheck
+pnpm dev &
+npx playwright screenshot http://localhost:3000/crm/leads/new       /tmp/crm-lead.png
+npx playwright screenshot http://localhost:3000/crm/contacts        /tmp/crm-contacts.png
+npx playwright screenshot http://localhost:3000/crm/organizations   /tmp/crm-orgs.png
+```
+
+Smoke checklist:
+
+- [ ] Create a Person via the lead form → row appears in contacts table.
+- [ ] Filter the contacts table by `lifecycle_stage=qualified`.
+- [ ] Open the detail panel; click **Link to user** with a known
+      `user_id` and confirm `platform_user === user_id`.
+- [ ] Repeat **Link to user** with the same `user_id` on a person
+      already bound elsewhere — confirm the silent-refusal toast fires
+      (response is 200, but `platform_user` differs).
+- [ ] **Invite by email** a person with a `primary_email`; the second
+      attempt returns 409 with the same `invitation_id`.
+- [ ] **Merge** two duplicates into a primary; confirm
+      `reparented.{deals,activities,tags}` counts are returned.
+- [ ] Create an Organization; deleting it does not cascade-delete
+      Persons that referenced it.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults, links to every sibling skill.
+- `/iblai-crm-deal-flow` — once a person exists, open a deal on the kanban.
+- `/iblai-crm-activity` — log timeline events (calls, meetings, notes, tasks) on a person.
+- `/iblai-crm-tag` — tag CRUD and chip components for people and organizations.
+- `/iblai-crm-notification` — `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER` fire from this flow.
+- `/iblai-rbac` — CRM Inviter / CRM User / CRM Manager roles and the action-definitions endpoint.
+- `/iblai-auth` — token wiring this skill reuses.

--- a/adapters/cursor/iblai-crm-notification.mdc
+++ b/adapters/cursor/iblai-crm-notification.mdc
@@ -1,0 +1,187 @@
+---
+description: "Reference for the three CRM notification event types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) the ibl.ai CRM dispatches after a write commits — payload shapes, recipient routing modes (default / per-Platform configured), and how to surface them in your app. Use when the user mentions CRM notifications, lead/deal alerts, \"who gets notified when a deal moves stages\", recipient mode configuration, or wiring a CRM-only inbox; see /iblai-crm-overview for setup, /iblai-crm-lead-flow and /iblai-crm-deal-flow for the events' source skills, and /iblai-notification for the bell UI that actually renders these events. This is a REFERENCE skill — it documents the contract; it does NOT build the bell UI."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-notification
+
+Reference skill for the three CRM notification event types. Documents
+when each one fires, the context keys included in the payload, the
+recipient-routing modes available per Platform, and where the developer
+goes next to surface these events in the UI. This skill does NOT build
+the notification bell — that is `/iblai-notification`.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth set up (`/iblai-auth`)
+- MCP and skills set up (`iblai add mcp`)
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user holds a CRM role (`CRM Viewer` is enough to read
+  inbox entries that target them; see `/iblai-rbac`)
+
+## The three CRM notification types
+
+Every CRM write that produces a notification routes through exactly one
+of these three event types. Full payload tables (every `context` key)
+live in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+| `event_type` | Fires when | Source skill | Default recipients |
+|---|---|---|---|
+| `CRM_PERSON_CREATED` | A person row is created via any path — REST `POST /persons/`, the Django admin, or bulk import | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+| `CRM_DEAL_STAGE_CHANGED` | A deal moves between stages via `POST /deals/{id}/move-stage/`, `POST /deals/{id}/won/`, or `POST /deals/{id}/lost/`. No-op transitions (destination stage equals current stage) are SUPPRESSED — no notification | `/iblai-crm-deal-flow` | Platform admins + `deal.owner` |
+| `CRM_PERSON_LINKED_TO_USER` | A person is bound to a Platform user — either by explicit `POST /persons/{id}/link-user/` or implicitly by the auto-link signal when a new user registers with a matching email | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+
+"Object owner" is `person.owner` for the two person-scoped events and
+`deal.owner` for the stage-change event. If the owner field is unset on
+the triggering object, the configured recipient mode decides whether to
+fall back to admins or drop the notification — see `## Recipient routing`
+below.
+
+## After-commit dispatch
+
+All three event types dispatch **asynchronously after the writing
+transaction commits**. The CRM signal is observed inside the request, but
+the actual notification send fires from a post-commit hook on the
+database transaction. The practical consequences:
+
+- A write that rolls back — failed validation, database constraint, a
+  `move-stage` call that raises mid-transition — produces no
+  notification. The signal is observed, the dispatch is not.
+- By the time a recipient sees the email, push entry, or inbox row, the
+  underlying record is durably on disk. There are no ghost notifications
+  for state that never persisted.
+- Context keys are snapshotted at signal time from the live object. A
+  template that references `{{ deal_lead_value }}` reads the value as it
+  stood the moment the stage transition committed; later edits to the
+  deal do not re-render or re-send.
+
+Cross-reference: this is the same after-commit rule the [System Overview](../../../docs/developer/applications/crm.md#2-system-overview) "Side
+Effects" block describes, and it is shared with the audit `Activity` row
+that `move-stage`/`won`/`lost` writes alongside the notification (see
+`/iblai-crm-activity`).
+
+## Recipient routing
+
+Every CRM notification template — and any notification type that opts
+into the shared recipients pipeline — can be configured per Platform
+with one of five recipient modes:
+
+| Mode | Effect |
+|---|---|
+| `platform_admins_only` | Deliver to active Platform admins only. The object's owner is ignored. |
+| `object_owner_only` | Deliver to the object's owner. If the owner field is unset, fall back to Platform admins so nothing is silently dropped. |
+| `object_owner_only_strict` | Deliver to the object's owner only. If the owner is unset, no one is notified. Use when the notification is meaningless without an owner. |
+| `platform_admins_and_object_owner` | **Default.** Both audiences receive the notification, deduplicated so an admin who is also the owner does not get two copies. |
+| `custom` | Deliver to a hand-picked list of users, user groups, or RBAC role-policy holders. Admins and the owner are NOT implicitly included. |
+
+When the mode is `custom`, the template's `recipients_custom_recipients`
+field holds a list of dicts. Each entry takes one of three shapes:
+
+```json
+{ "type": "user",        "id": 123 }
+{ "type": "user_group",  "id": 7 }
+{ "type": "rbac_policy", "policy_name": "CRM Manager" }
+```
+
+Entries compose freely — a single list can mix individual users, groups,
+and policy holders. The resolver expands each entry, unions the results,
+deduplicates, and runs the active-Platform-membership filter as a final
+gate. Stale entries (departed users, reassigned policies, drained
+groups) simply contribute zero recipients on that dispatch.
+
+Recipient configuration lives on the **notification template, not the
+CRM models**. Changing it for `CRM_DEAL_STAGE_CHANGED` on a given
+Platform is a `PATCH` against that Platform's template for that type,
+setting `recipients_recipient_mode` and (if `custom`) populating
+`recipients_custom_recipients`. The CRM does not add a separate API
+surface for this — the same template-management endpoints documented in
+`/iblai-notification` handle these three types alongside every other
+notification type on the platform. This skill does NOT modify those
+endpoints; it just documents which event types route through them.
+
+Full mode table, custom-shape examples, the change-recipients workflow,
+and the active-membership filter rules are in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+## Channels
+
+Email delivery is wired by default for all three CRM event types.
+Per-user notification preferences are honored by the underlying delivery
+machinery — the CRM does not bypass them. Additional channels (in-app
+inbox feed, push notification) follow the template's channel
+configuration, inspected and changed via the same templates API.
+
+The **in-app bell + notification center** that surfaces inbox entries is
+NOT in scope for this skill. Send the developer to `/iblai-notification`
+for the drop-in `<NotificationDropdown>` and `<NotificationDisplay>`
+components.
+
+## Consuming the events in your UI
+
+This is a reference skill. To actually show a user the three CRM event
+types in the browser:
+
+1. Install the bell + center via `/iblai-notification`. That skill ships
+   `components/iblai/notification-bell.tsx` and the
+   `<NotificationDisplay>` page surface (Inbox + Alerts tabs).
+2. The bell's inbox list is a standard notification feed — every
+   delivered notification carries an `event_type` matching one of the
+   three values from the table above. Filter the inbox query to those
+   three values (or any subset) when you want a CRM-only inbox view.
+3. For deeper drill-down (clicking an inbox entry that says "Deal moved
+   to Negotiation" and jumping to the kanban card), wire the
+   `onViewNotifications` callback on `<NotificationDropdown>` to route
+   to the deal detail page built by `/iblai-crm-deal-flow`.
+
+## Verify
+
+End-to-end smoke once the bell is wired:
+
+1. From the kanban built in `/iblai-crm-deal-flow`, move a deal from one
+   stage to another via `POST /deals/{id}/move-stage/`. Make sure the
+   destination stage actually differs from the current one (same-stage
+   moves are suppressed and produce nothing).
+2. Within a few seconds, confirm a `CRM_DEAL_STAGE_CHANGED` row appears
+   in the inbox bell installed by `/iblai-notification` for the deal's
+   owner.
+3. Open the deal's activity timeline (`/iblai-crm-activity`) and confirm
+   the corresponding audit `Activity` row exists with `type=note`,
+   `done=true`, `title="Stage changed"`. The notification and the audit
+   row are written together — if one is missing while the other is
+   present, the transaction split unexpectedly and is worth filing.
+4. Re-run the same `move-stage` call with `stage_code` set to the
+   destination it just reached. The API should return the deal
+   unchanged, no new audit row, and no new notification.
+
+Run `/iblai-ops-test` before reporting done.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — source of `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER`
+- `/iblai-crm-deal-flow` — source of `CRM_DEAL_STAGE_CHANGED`
+- `/iblai-notification` — bell UI + notification center that consumes these events
+- `/iblai-rbac` — required CRM roles
+- `/iblai-auth` — token wiring

--- a/adapters/cursor/iblai-crm-overview.mdc
+++ b/adapters/cursor/iblai-crm-overview.mdc
@@ -1,0 +1,140 @@
+---
+description: "Reference and family index for the ibl.ai Platform-scoped CRM REST API at /api/crm/ — auth, seeded defaults (default Pipeline + 6 stages + 4 Lead Sources), the four CRM RBAC roles (Viewer/User/Manager/Inviter), and the workflow sub-skill map. Use when the user mentions CRM, leads, pipelines, deals, contacts, or asks where a CRM workflow lives. See /iblai-crm-lead-flow for people + onboarding, /iblai-crm-deal-flow for pipelines + kanban, /iblai-crm-activity for the timeline, /iblai-crm-tag for tags, /iblai-crm-notification for CRM event routing, /iblai-auth for token wiring, /iblai-rbac for role assignment."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-overview
+
+Reference skill for the ibl.ai CRM. Covers authentication, seeded
+defaults, the four CRM RBAC roles, and points to every sub-skill in
+the `iblai-crm-*` family. This skill builds no UI — open it first when
+you need orientation, then jump to the workflow skill that matches the
+surface you are building.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Authentication
+
+Every CRM endpoint lives under `/api/crm/` and requires a
+Platform-scoped token:
+
+```
+Authorization: Token <your-access-token>
+```
+
+Tokens bind to exactly one Platform at the moment of issue. The
+Platform is inferred from the token on every request — there is no
+`?platform_key=` query parameter on the consumer surface, and supplying
+one will not change the Platform a request resolves to.
+
+Records belonging to a different Platform return **`404 Not Found`,
+never `403 Forbidden`**. This is intentional: returning `403` would
+leak the existence of cross-Platform records. Treat a `404` on a
+record you just created as a sign you are pointing at the wrong
+Platform; a `403` always means "authenticated but the role does not
+grant this action."
+
+The full REST contract (base URL, pagination envelope, ID types per
+resource, side effects) is in
+[`references/api-overview.md`](./references/api-overview.md). For
+token wiring inside a Next.js app see `/iblai-auth`.
+
+## Seeded defaults
+
+The first time a Platform is provisioned, the CRM seeds a working
+configuration. You do not need to create any of these yourself — they
+exist on every Platform and back-fill into existing Platforms via a
+data migration.
+
+- **One default Pipeline** with `code="default"`, `is_default=true`,
+  `rotten_days=30`.
+- **Six default Stages** on that Pipeline, referenced by stable `code`:
+  `new` → `qualified` → `proposal` → `negotiation` → `won` (terminal,
+  `is_won=true`) and `lost` (terminal, `is_lost=true`).
+- **Four default Lead Sources**: `web`, `referral`, `cold_call`,
+  `advertisement`.
+
+The stage and lead-source `code` fields are stable across environments
+(dev / staging / prod) and across renames. Numeric `id` values are not
+— always reference seeds by `code` in client code, save the pipeline
+`id` only for the immediate deal payload.
+
+Full seeded tables (every stage's `probability` / `sort_order` /
+terminal flags, every lead source `name`) are in
+[`references/seeded-defaults.md`](./references/seeded-defaults.md).
+
+## RBAC
+
+The CRM ships four roles per Platform. Roles are seeded automatically
+on Platform provisioning and assigned through the standard
+role-management surface — the CRM does not expose its own
+role-assignment endpoints. A user may hold more than one role;
+effective permissions are the union.
+
+| Role | One-line mandate |
+|---|---|
+| **CRM Viewer** | Read everything across the CRM. Write nothing. |
+| **CRM User** | Day-to-day operator — full CRUD on people, organizations, deals, activities, tags. Pipelines are read-only. No invitations. |
+| **CRM Manager** | Wildcard CRM access — pipeline / stage / lead-source administration plus invitations. |
+| **CRM Inviter** | Narrow role — read people and send invitations only. Cannot edit or create people. |
+
+Two non-obvious rules worth a second look:
+- **Invitation is its own bucket.** `Ibl.CRM/Persons/write` does not
+  imply `Ibl.CRM/Invite/action`. Gate the "Invite" affordance
+  independently.
+- **Tag attach/detach requires `Ibl.CRM/Tags/write`.** A role with
+  `Ibl.CRM/Persons/write` cannot tag a person without it.
+
+Full HTTP-verb → action-code mapping and the action-by-action matrix
+are in [`references/rbac-matrix.md`](./references/rbac-matrix.md). For
+the management UI that lists and binds roles, see `/iblai-rbac`.
+
+## The CRM skill family
+
+Every CRM skill is prefixed `iblai-crm-*`. There is no bare umbrella
+skill — this skill is the index. Pick the one that matches the
+surface you are building.
+
+| Skill | Role | Covers |
+|---|---|---|
+| `/iblai-crm-overview` | Reference / index (this skill) | Auth, seeded defaults, RBAC roles, family map |
+| `/iblai-crm-lead-flow` | Build UI | People + Organizations + lifecycle stage + onboarding (link / invite / merge) |
+| `/iblai-crm-deal-flow` | Build UI | Pipelines + Stages + Lead Sources + Deals (kanban + move-stage / won / lost state machine) |
+| `/iblai-crm-activity` | Build UI | Activity timeline (calls, meetings, notes, tasks; schedule / remind / done) on persons and deals |
+| `/iblai-crm-tag` | Build UI | Tag CRUD + attach / detach for persons, organizations, deals |
+| `/iblai-crm-notification` | Reference | Three CRM notification types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) + recipient routing |
+
+When in doubt, start with `/iblai-crm-lead-flow` (a deal needs a
+person), then `/iblai-crm-deal-flow`, then layer `/iblai-crm-activity`
+and `/iblai-crm-tag` on the detail pages.
+
+## Related skills
+
+- `/iblai-crm-lead-flow` — People + Organizations + onboarding
+- `/iblai-crm-deal-flow` — Pipelines + Stages + Lead Sources + Deals
+- `/iblai-crm-activity` — Activity timeline for persons and deals
+- `/iblai-crm-tag` — Tag CRUD + attach / detach
+- `/iblai-crm-notification` — CRM notification types and recipient routing
+- `/iblai-auth` — Token wiring; every CRM call uses the same
+  `Authorization: Token <token>` header.
+- `/iblai-rbac` — Role-management UI (`<Admin>` → Roles + Policies
+  tabs) and the action-definitions endpoint. The four CRM roles are
+  assigned here.
+- **Brand guidelines**: [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md)

--- a/adapters/cursor/iblai-crm-tag.mdc
+++ b/adapters/cursor/iblai-crm-tag.mdc
@@ -1,0 +1,351 @@
+---
+description: "Build the CRM tag manager — CRUD on /api/crm/tags/ with hex color picker, a reusable tag chip, attach/detach controls on Person/Organization/Deal detail pages, and tag filters on list views with OR semantics. Use when the user mentions CRM tags, labels, tagging, color chips, tag manager, attach tag, detach tag, filter by tag, or wants to add segmentation labels to people/orgs/deals. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for the person/org host pages, /iblai-crm-deal-flow for the deal host pages, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-tag
+
+Build the CRM tag surface — tag CRUD dialog, color chip, attach/detach
+controls on Person, Organization, and Deal pages, plus a `?tags=` filter
+on every CRM list view.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — provides the platform
+  `Authorization: Token <token>` header used by every call below.
+- MCP and skills must be set up: `iblai add mcp`.
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user must hold the **CRM User** role (or higher) on the
+  Platform. CRM User unlocks `Ibl.CRM/Tags/list`, `read`, `action`,
+  `write`, and `delete`. CRM Viewer can only see tags, not write or
+  attach them. See `/iblai-rbac` for the role matrix and how to assign
+  CRM roles to a user.
+- At least one host surface should already exist so there is something
+  to tag. Run `/iblai-crm-lead-flow` (people + organizations) or
+  `/iblai-crm-deal-flow` (deals) first if you have not yet.
+
+## What you'll build
+
+1. A **tag manager dialog** — list, create, edit, and delete tags. Color
+   input is validated client-side against `^#[0-9A-Fa-f]{6}$` before
+   submit so the user sees errors immediately (the server applies the
+   same regex).
+2. A **tag chip** component — renders `{id, name, color}` with the hex
+   color as background. Optional `x` button for detach.
+3. **Attach / detach controls** on Person, Organization, and Deal detail
+   pages. The contract is uniform: `POST /{host}/{id}/tags/` with
+   `{tag_id}`, `DELETE /{host}/{id}/tags/{tag_id}/`.
+4. A **tag filter** on Person, Organization, and Deal list views —
+   `?tags=<id>&tags=<id2>` with **OR** semantics. Results are
+   de-duplicated by the backend.
+
+## Step 0: Check for CLI updates
+
+```bash
+iblai --version    # upgrade if outdated: pip install --upgrade iblai-app-cli OR npm i -g @iblai/cli@latest
+```
+
+## Step 1: Install shadcn primitives
+
+```bash
+npx shadcn@latest add dialog input form popover command badge button
+```
+
+`dialog` powers the tag manager and the delete-confirmation modal.
+`popover` + `command` together make a searchable tag combobox for the
+attach control. `badge` is the visual base for the tag chip. `input`
++ `form` cover the create/edit form. `button` covers actions.
+
+## Step 2: Typed API client wrapper
+
+Reuse the auth token wired in `/iblai-auth`. Create
+`lib/iblai/crm-tags.ts` with one wrapper per route. Base URL is
+`${NEXT_PUBLIC_API_BASE_URL}/api/crm`.
+
+```typescript
+// lib/iblai/crm-tags.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+const HEX = /^#[0-9A-Fa-f]{6}$/;
+
+export type Tag = {
+  id: number;
+  platform: number;
+  name: string;
+  color: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TagChip = Pick<Tag, "id" | "name" | "color">;
+
+export type Assignment = { assignment_id: number; tag: TagChip };
+
+function authHeaders(token: string) {
+  return {
+    Authorization: `Token ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+// Tag CRUD
+export async function listTags(token: string, params: { name?: string; page?: number } = {}) {
+  const qs = new URLSearchParams();
+  if (params.name) qs.set("name", params.name);
+  if (params.page) qs.set("page", String(params.page));
+  const r = await fetch(`${BASE}/tags/?${qs}`, { headers: authHeaders(token) });
+  if (!r.ok) throw new Error(`listTags ${r.status}`);
+  return r.json() as Promise<{ count: number; results: Tag[]; next_page: number | null; previous_page: number | null }>;
+}
+
+export async function createTag(token: string, body: { name: string; color?: string; metadata?: Record<string, unknown> }) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/`, { method: "POST", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function patchTag(token: string, id: number, body: Partial<Pick<Tag, "name" | "color" | "metadata">>) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "PATCH", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function deleteTag(token: string, id: number) {
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "DELETE", headers: authHeaders(token) });
+  if (!r.ok && r.status !== 204) throw new Error(`deleteTag ${r.status}`);
+}
+
+// Uniform host attach / detach. `host` is "persons" | "organizations" | "deals".
+export type Host = "persons" | "organizations" | "deals";
+
+export async function attachTag(token: string, host: Host, hostId: string | number, tagId: number): Promise<Assignment> {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ tag_id: tagId }),
+  });
+  // 201 = created; 409 = already attached, body still carries assignment_id + tag.
+  if (r.status === 201 || r.status === 409) return r.json();
+  throw await r.json();
+}
+
+export async function detachTag(token: string, host: Host, hostId: string | number, tagId: number) {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/${tagId}/`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+  // 204 = removed; 404 = not attached (treat as no-op success).
+  if (r.status !== 204 && r.status !== 404) throw new Error(`detachTag ${r.status}`);
+}
+```
+
+See `references/tags-api.md` for full endpoint table, error shapes, and
+filter semantics.
+
+## Step 3: Tag manager dialog
+
+Create `components/crm/tag-manager-dialog.tsx`. It is a single dialog
+that lists all tags from `GET /tags/`, lets the user create a new tag,
+edit an existing tag, or delete one.
+
+Requirements:
+
+- **Create form**: `name` (required, ≤ 64 chars, unique-per-Platform —
+  server-enforced) and `color` (`<input type="color">` is fine; on
+  submit, validate the value against `^#[0-9A-Fa-f]{6}$` before
+  calling `createTag`). Surface the server's 400 errors verbatim —
+  duplicate name, blank name, > 64 chars, bad hex.
+- **Edit**: inline rename + recolor calls `patchTag`. Renames take
+  effect immediately on every host chip — the chip renders from the
+  Tag row, not from the assignment.
+- **Delete**: opens a confirmation modal — see the destructive cascade
+  callout below. Disable the delete button until the user types the
+  tag name to confirm, or at minimum require a second click.
+
+The dialog reads the token from the auth store wired by `/iblai-auth`.
+
+## Step 4: Tag chip component
+
+Create `components/crm/tag-chip.tsx`. Renders `{id, name, color}` as a
+shadcn `Badge` with `style={{ backgroundColor: tag.color, color: '#fff' }}`.
+Accept an optional `onDetach: () => void` prop — when supplied, render
+a small `x` icon button inside the chip; otherwise render the chip as
+read-only.
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import type { TagChip as TTagChip } from "@/lib/iblai/crm-tags";
+
+export function TagChip({ tag, onDetach }: { tag: TTagChip; onDetach?: () => void }) {
+  return (
+    <Badge style={{ backgroundColor: tag.color, color: "#fff" }} className="gap-1">
+      {tag.name}
+      {onDetach ? (
+        <button onClick={onDetach} aria-label={`Detach ${tag.name}`} className="ml-1">
+          <X className="h-3 w-3" />
+        </button>
+      ) : null}
+    </Badge>
+  );
+}
+```
+
+The `tags` array is **always present** on every Person, Organization,
+and Deal list/detail response — empty array, never `null`. So your
+renderer can iterate unconditionally.
+
+## Step 5: Attach control on host detail pages
+
+On Person, Organization, and Deal detail pages, add an "Add tag"
+button that opens a shadcn `Popover` containing a `Command` combobox.
+Populate the combobox with `listTags(token)` (search-as-you-type by
+filtering client-side, or pass `name=` to the API for large libraries).
+
+On select:
+
+```typescript
+const { assignment_id, tag } = await attachTag(token, host, hostId, selectedTagId);
+// Optimistically add `tag` to the local host.tags array; assignment_id is for
+// future detach reconciliation, not required for the chip itself.
+```
+
+Edge cases:
+
+- **409 Conflict** — the tag is already attached. The response body
+  still carries the existing `assignment_id` + `tag`, so you can
+  reconcile local state without a re-fetch and **must not** show a red
+  error toast. Treat 409 as a no-op success.
+- **404 Not Found** — the tag id is not in this Platform. Show
+  "Tag not found." The API never leaks existence across Platforms.
+
+## Step 6: Detach control
+
+Render the host's `tags` array as `TagChip` components with `onDetach`
+wired to `detachTag(token, host, hostId, tag.id)`.
+
+Edge case:
+
+- **404 Not Found** on detach means the tag was not attached. Detach
+  is **not** idempotent server-side — a retried DELETE returns 404,
+  not 204. Client code should treat both as the same success state.
+  The wrapper above already does this.
+
+## Step 7: Tag filter on list views
+
+Wire a multi-select tag picker into the Person, Organization, and Deal
+list pages.
+
+The list endpoints accept repeated or comma-separated `tags`:
+
+```
+GET /api/crm/persons/?tags=7&tags=12
+GET /api/crm/persons/?tags=7,12
+```
+
+Both forms have **OR** semantics — a record matching any selected tag
+appears once (the backend de-duplicates). The filter composes with
+every other filter on the same endpoint, e.g.:
+
+```
+GET /api/crm/persons/?tags=7&lifecycle_stage=customer&owner=4
+```
+
+Implementation: bind the selected tag-ids to `URLSearchParams.append`
+so a `tags` array becomes repeated params, then refetch the list.
+
+## Destructive cascade callout
+
+> **Deleting a tag silently removes it from every Person, Organization,
+> and Deal it is attached to.** `DELETE /tags/{id}/` cascades — there
+> is no preview, no soft-delete, and no undo.
+
+Best practice [confirm before deleting a tag](../../../docs/developer/applications/crm.md#167-confirm-before-deleting-a-tag): gate the delete button behind a confirmation modal
+that **names the tag explicitly** ("Delete tag *Enterprise*?"), states
+the consequence ("This will remove the tag from N records across people,
+organizations, and deals."), and requires an affirmative second action
+(typing the tag name or clicking a destructive button), not a single
+"OK". Optionally pre-fetch impact counts:
+
+```
+GET /api/crm/persons/?tags={id}&page_size=1   → response.count
+GET /api/crm/organizations/?tags={id}&page_size=1
+GET /api/crm/deals/?tags={id}&page_size=1
+```
+
+See `references/tags-api.md` for the full endpoint contract, error
+shapes, and host attach/detach matrix.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and visit the surface in the browser:
+   - Open the tag manager. Try to create a tag with color `#FFF`
+     (three digits) — the client should reject it before the request
+     leaves; if you bypass the client check, the server returns
+     `400 {"color": ["Color must be a hex string like \`#3F6BFF\`."]}`.
+   - Create a valid tag (`name`: `Enterprise`, `color`: `#3F6BFF`).
+   - On a Person detail page, attach the tag. Confirm the chip
+     renders. Click attach a second time — UI must not flash an
+     error (409 path).
+   - On an Organization detail page, attach the same tag.
+   - On a Deal detail page, attach the same tag.
+   - Detach the tag from the Person — chip disappears.
+   - On the Person list view, filter by the tag (`?tags=<id>`) and
+     confirm only tagged people remain.
+   - Trigger the delete-tag confirmation modal — confirm copy names
+     the tag and warns about cascade.
+3. Screenshot:
+   ```bash
+   npx playwright screenshot http://localhost:3000/crm/tags /tmp/tags.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC
+- `/iblai-crm-lead-flow` — attach tags to persons and organizations
+- `/iblai-crm-deal-flow` — attach tags to deals; filter board by tag
+- `/iblai-rbac` — CRM User role required for tag writes
+- `/iblai-auth` — token wiring

--- a/skills/iblai-crm-activity/SKILL.md
+++ b/skills/iblai-crm-activity/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: iblai-crm-activity
+description: Build the CRM activity timeline panel that mounts inside a Person or a Deal detail surface — list calls, meetings, emails, notes, tasks, lunches, and deadlines, schedule them, set reminders, mark them done idempotently, and render server-emitted stage-change audit rows distinctly. Use when the user mentions CRM activity, activities, timeline, log a call, schedule a meeting, sales notes, tasks, deadlines, reminders, or mark done. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-lead-flow for the person host, /iblai-crm-deal-flow for the deal host and stage-change audit rows, /iblai-notification for the bell that surfaces reminders, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-activity
+
+Build the activity timeline panel that lives inside a Person or Deal detail
+surface: list activities, create them (call, meeting, email, note, task,
+lunch, deadline), schedule + remind, mark done, and render server-emitted
+audit rows distinctly.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for activity CRUD and the
+  `done/` action. See `/iblai-rbac` for the full matrix.
+- A host surface must already exist. The timeline is a **panel**, not a
+  standalone page. Either:
+  - `/iblai-crm-lead-flow` — for the Person detail timeline, OR
+  - `/iblai-crm-deal-flow` — for the Deal detail timeline (which is
+    also the source of the server-emitted `Stage changed` audit rows
+    you will render).
+
+## What you'll build
+
+- A **timeline panel** that mounts inside the existing Person detail
+  page (filtered by `person=<uuid>`) and inside the existing Deal
+  detail page (filtered by `deal=<id>`), backed by
+  `GET /api/crm/activities/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **create-activity form** with a type selector covering all seven
+  types — `call`, `meeting`, `email`, `note`, `task`, `lunch`,
+  `deadline` — plus `title`, `comment`, optional `location`,
+  `schedule_from`, `schedule_to`, `reminder_at`, and free-form
+  `metadata`.
+- A **done checkbox** on each open user row that calls
+  `POST /api/crm/activities/{id}/done/` — idempotent, safe to retry.
+- A **system-row renderer** that visually de-emphasizes
+  server-emitted stage-change audit rows
+  (`type === "note" && title === "Stage changed"`) and suppresses
+  their edit / delete / done controls per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently).
+
+Reference tables for every endpoint and field live in:
+
+- `references/activities-api.md`
+- `references/timeline-rendering.md`
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date. Run
+`iblai --version` to check the current version, then upgrade directly:
+
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+This is safe to run even if already at the latest version.
+
+## Step 1: Install shadcn primitives
+
+There is no dedicated `iblai add` generator for the timeline panel — it is
+plain shadcn/ui glued to the CRM REST API. Install the primitives you need:
+
+```bash
+npx shadcn@latest add card select input textarea checkbox button dialog calendar popover badge
+```
+
+You will use `card` for each row, `select` for the type picker, `input`
+and `textarea` for title/comment, `calendar` + `popover` for date
+pickers, `checkbox` for the done toggle, `dialog` for the create form,
+and `badge` for the type chip.
+
+## Step 2: Wrap the activities REST API
+
+Create `lib/iblai/crm-activities.ts`. Read the token and base URL the way
+`/iblai-auth` already wired them — do not introduce a parallel auth layer.
+
+Endpoints (every activity row is scoped to your Platform; cross-Platform
+rows return 404):
+
+| Verb | Path | Use |
+|---|---|---|
+| `GET` | `/api/crm/activities/?person={uuid}` | List a person's timeline |
+| `GET` | `/api/crm/activities/?deal={id}` | List a deal's timeline |
+| `POST` | `/api/crm/activities/` | Create — body MUST set EXACTLY one of `person`/`deal` (or both, where the person equals the deal's person). Neither = 400. |
+| `PATCH` | `/api/crm/activities/{id}/` | Edit user-authored rows. Do NOT call on system rows. |
+| `DELETE` | `/api/crm/activities/{id}/` | Delete user-authored rows. Do NOT call on system rows. |
+| `POST` | `/api/crm/activities/{id}/done/` | Mark done — idempotent, no body |
+
+Every list call uses the standard pagination envelope
+`{count, next_page, previous_page, results[]}`. Default ordering is
+newest-first by `created_at`.
+
+Server-managed fields you MUST NOT write from the client:
+
+- `done_at` — stamped server-side the first time `is_done` flips true
+- `reminder_sent` — flipped server-side after reminder dispatch
+
+See `references/activities-api.md` for the full field list, every
+filter, the attachment-rule errors, and curl examples.
+
+## Step 3: Activity-type selector
+
+Render a shadcn `select` whose values map 1:1 to the `type` field on the
+POST body. All seven types are first-class — none are aliases.
+
+| Value | Suggested chip color | Suggested icon |
+|---|---|---|
+| `call` | sky | Phone |
+| `meeting` | indigo | CalendarClock |
+| `email` | violet | Mail |
+| `note` | slate | StickyNote |
+| `task` | amber | CheckSquare |
+| `lunch` | rose | Utensils |
+| `deadline` | red | AlarmClock |
+
+The chip color is cosmetic — drive it from a small lookup table next to
+your renderer. The `type` you POST must be one of the seven strings
+above verbatim.
+
+## Step 4: Scheduling and reminders
+
+Collect three ISO-8601 datetime fields in the create form. Match the
+shape to the intent — do not invent dates to fill empty slots:
+
+| `schedule_from` | `schedule_to` | Read as |
+|---|---|---|
+| null | null | A past log entry recorded after the fact (a logged call, a written note) |
+| set | null | A scheduled task or deadline with a start time but no fixed end |
+| set | set | A meeting or other time-bounded event |
+
+Add an optional `reminder_at` — typically a fixed offset before
+`schedule_from` (15 minutes before is a common meeting default). The
+server stamps `reminder_sent` after dispatch — DO NOT set it from the
+client. The server also stamps `done_at` on completion — DO NOT set it
+from the client.
+
+> Reminder delivery is not yet dispatched server-side (see [Reminders](../../../docs/developer/applications/crm.md#105-reminders)).
+> `reminder_at` round-trips and you can surface a local in-app prompt
+> from it today; `reminder_sent` will stay `false` until the dispatcher
+> ships.
+
+## Step 5: Mark-done checkbox
+
+Render a shadcn `checkbox` on every open user row. When checked, POST
+to `/api/crm/activities/{id}/done/` with no body. The response is the
+full updated activity object — splice it into your local list so the
+row re-renders with `is_done=true` and `done_at` populated without a
+follow-up GET.
+
+This action is **idempotent**: repeat calls on an already-done activity
+return the SAME `done_at` the server stamped on the first call. That
+makes the checkbox safe to retry from a flaky network without drifting
+completion timestamps that downstream reports depend on.
+
+Do not render the checkbox on system rows — see Step 7.
+
+## Step 6: Render the timeline
+
+Order rows newest-first. Default to `created_at` desc (which is what
+the API returns); when you want a calendar-style view (e.g. an
+upcoming-meetings panel), sort by `schedule_from` instead and filter
+`?is_done=false` to hide completed entries.
+
+Each row should show, at minimum: the type chip (with the color +
+icon from Step 3), `title`, `comment`, the relative time, the owner,
+and — for scheduled rows — `schedule_from` (and `schedule_to` when
+present). Combine list filters to drive panel variants — for example
+`?deal=314&type=call&is_done=false` powers an "upcoming calls" panel
+on a deal.
+
+## Step 7: Render system audit rows distinctly
+
+Per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently), the CRM writes a system Activity every time a deal moves
+stage, wins, or is lost. Detect them client-side with one predicate:
+
+```ts
+const isStageChangeAudit = (a: Activity): boolean =>
+  a.type === "note" && a.title === "Stage changed";
+```
+
+For rows where that returns true:
+
+- Use a distinct system icon (a small arrow / system glyph)
+- Render at smaller size with muted text
+- Suppress edit, delete, and done controls — the row is server-authored
+  and arrives already complete (`is_done: true`, `done_at` set to the
+  transition timestamp)
+- Use the `comment` body (e.g. `"Discovery → Proposal"`) as the line
+  of record
+
+See `references/timeline-rendering.md` for the full rationale and the
+schedule / reminder / attachment semantics.
+
+## Filters
+
+The list endpoint accepts a focused set of query parameters useful for
+the panel variants you will build. The most commonly used here:
+
+| Param | Type | Use |
+|---|---|---|
+| `person` | UUID | Person timeline (mount on person detail) |
+| `deal` | integer | Deal timeline (mount on deal detail) |
+| `type` | string | One of the seven types — narrow to a single kind |
+| `is_done` | boolean | Hide completed / show only open |
+| `owner` | integer | Filter by owning user id |
+| `schedule_from__gte` | datetime | Calendar window start |
+| `schedule_from__lte` | datetime | Calendar window end |
+| `metadata__has_key` | string | Activities whose `metadata` JSON contains this top-level key |
+| `page`, `page_size` | integer | Standard pagination |
+
+The full list — including `metadata__has_key` semantics and combining
+rules — lives in `references/activities-api.md`.
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and open the relevant detail pages:
+   - Open a Person detail page from `/iblai-crm-lead-flow`. Create an
+     activity with `type=call`, no schedule, a short comment. Confirm
+     it appears at the top of the timeline. Mark it done with the
+     checkbox; confirm `is_done` flips and `done_at` populates.
+   - Open a Deal detail page from `/iblai-crm-deal-flow`. Create a
+     `meeting` with `schedule_from` and `schedule_to` set 30 minutes
+     apart, and `reminder_at` 15 minutes before `schedule_from`.
+     Confirm the row renders with the type chip, scheduled time, and
+     reminder.
+   - From the deal kanban, move the deal to a new stage. Reload the
+     deal timeline and confirm a server-emitted row appears with
+     `type="note"`, `title="Stage changed"`, `is_done=true`, and is
+     rendered distinctly (smaller, muted, system icon, no edit /
+     delete / done controls).
+3. Screenshot the timeline so the user can see it:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals/<id> /tmp/deal-timeline.png
+   npx playwright screenshot http://localhost:3000/crm/contacts/<uuid> /tmp/person-timeline.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — person timeline host
+- `/iblai-crm-deal-flow` — deal timeline host + audit row source (stage moves emit notes)
+- `/iblai-notification` — bell UI for activity reminders + CRM events
+- `/iblai-rbac` — CRM User role
+- `/iblai-auth` — token wiring

--- a/skills/iblai-crm-activity/references/activities-api.md
+++ b/skills/iblai-crm-activity/references/activities-api.md
@@ -1,0 +1,197 @@
+# Activities API — `/api/crm/activities/`
+
+Condensed from the [Activities API](../../../../docs/developer/applications/crm.md#76-activities) section of the CRM developer documentation. An Activity is a
+timeline entry attached to a Deal **or** a Person (or both, when they
+agree). It carries a type, optional schedule, optional reminder, an
+owner, and a free-form metadata bag. Activities are also the audit row
+the server writes when a Deal transitions stages — those rows arrive
+already complete and are surfaced through the same endpoint.
+
+> **Base URL:** `https://<your-platform-host>/api/crm/`
+> **Auth:** `Authorization: Token <token>`
+> **Pagination envelope:** `{count, next_page, previous_page, results[]}`
+> **Default ordering:** newest-first by `created_at`
+
+## Endpoint summary
+
+| Method | Path | Purpose | Required permission |
+|---|---|---|---|
+| `GET` | `/activities/` | List activities (paginated) | `Ibl.CRM/Activities/list` |
+| `POST` | `/activities/` | Create an activity | `Ibl.CRM/Activities/action` |
+| `GET` | `/activities/{id}/` | Retrieve one activity | `Ibl.CRM/Activities/read` |
+| `PUT` | `/activities/{id}/` | Replace all editable fields | `Ibl.CRM/Activities/write` |
+| `PATCH` | `/activities/{id}/` | Patch supplied fields | `Ibl.CRM/Activities/write` |
+| `DELETE` | `/activities/{id}/` | Delete the activity | `Ibl.CRM/Activities/delete` |
+| `POST` | `/activities/{id}/done/` | Mark done (idempotent) | `Ibl.CRM/Activities/write` |
+
+## Activity object
+
+| Field | Type | Writable | Notes |
+|---|---|---|---|
+| `id` | integer | no | Server-assigned |
+| `platform` | integer | no | Owning Platform id |
+| `title` | string | yes | Short summary. Required on create. |
+| `type` | string | yes | One of `call`, `meeting`, `email`, `note`, `task`, `lunch`, `deadline`. Required on create. |
+| `location` | string | yes | Meeting location, dial-in URL, venue. Defaults to `""`. |
+| `comment` | string | yes | Free-text body. Defaults to `""`. |
+| `schedule_from` | datetime \| null | yes | Scheduled start (ISO-8601). |
+| `schedule_to` | datetime \| null | yes | Scheduled end (ISO-8601). |
+| `is_done` | boolean | yes | Defaults to `false`. Prefer `POST /activities/{id}/done/` to flip this — it stamps `done_at` for you and is idempotent. |
+| `done_at` | datetime \| null | **no — read-only** | Stamped the first time `is_done` flips true. Preserved on repeat `done/` calls. |
+| `deal` | integer \| null | yes | Attached Deal id. EXACTLY one of `deal`/`person` must be set on create (both is allowed only if they agree — see attachment rule). |
+| `person` | UUID \| null | yes | Attached Person id. See attachment rule. |
+| `owner` | integer \| null | yes | Owning user id. Defaults to the calling user. Must be an active member of your Platform. |
+| `reminder_at` | datetime \| null | yes | When to remind the owner. Typically a fixed offset before `schedule_from` (15 min before is common). |
+| `reminder_sent` | boolean | **no — read-only** | Flipped server-side after the reminder dispatch runs. Do not write from the client. |
+| `metadata` | object | yes | Free-form JSON, defaults to `{}`. |
+| `created_at` | datetime | no | Creation timestamp. |
+| `updated_at` | datetime | no | Last-modified timestamp. |
+
+## Attachment rule
+
+Every activity must attach to a `deal` **or** a `person`:
+
+- **Neither set** → `400 Bad Request`: `{"detail": "Activity must attach to a `deal` or a `person`."}`. The serializer raises before any database write, so a failed create has no side effects.
+- **Only `deal` set** → attached to that deal only.
+- **Only `person` set** → attached to that person only.
+- **Both set** → the person must equal the deal's `person`. A mismatch returns `400` with a field-level error: `{"person": "Person does not match the Deal's Person."}`.
+
+The rule is re-checked on every write. A `PATCH` that clears the only
+remaining attachment field returns `400`.
+
+## `GET /activities/`
+
+Paginated list. Query parameters:
+
+| Param | Type | Description |
+|---|---|---|
+| `type` | string | One of `call`, `meeting`, `email`, `note`, `task`, `lunch`, `deadline` |
+| `is_done` | boolean | Filter completed vs open |
+| `owner` | integer | Owning user id |
+| `deal` | integer | Deal id |
+| `person` | UUID | Person id |
+| `schedule_from__gte` | ISO-8601 datetime | Scheduled start on or after |
+| `schedule_from__lte` | ISO-8601 datetime | Scheduled start on or before |
+| `metadata__has_key` | string | Only activities whose top-level `metadata` object contains this key |
+| `page` | integer | Page number, defaults to 1 |
+| `page_size` | integer | Items per page |
+
+Combine filters freely — `?deal=314&type=call&is_done=false` powers an
+"upcoming calls" panel for a deal; `?person=<uuid>&schedule_from__gte=<now>`
+powers a "what is on this person's calendar" panel.
+
+```bash
+curl -X GET "https://api.iblai.app/dm/api/crm/activities/?deal=184&is_done=false" \
+  -H "Authorization: Token YOUR_ACCESS_TOKEN"
+```
+
+Response is the standard envelope; each result is the full Activity
+object documented above.
+
+## `POST /activities/`
+
+Create an activity. Required: `title`, `type`, and EXACTLY one of
+`deal` / `person` (both allowed only if they agree).
+
+```json
+{
+  "title": "Discovery call",
+  "type": "call",
+  "location": "Zoom",
+  "comment": "Walk through requirements with VP Eng.",
+  "schedule_from": "2026-06-02T15:00:00Z",
+  "schedule_to": "2026-06-02T15:45:00Z",
+  "deal": 184,
+  "person": "c4d2b1a8-7c3e-4f9a-9d6b-9a2c4f1e7b80",
+  "reminder_at": "2026-06-02T14:45:00Z",
+  "metadata": {"meeting_link": "https://zoom.us/j/123"}
+}
+```
+
+Response `201 Created` — full activity object.
+
+### Error responses
+
+`400 Bad Request` — attachment / validation failures:
+
+```json
+{"detail": "Activity must attach to a `deal` or a `person`."}
+```
+
+```json
+{"person": "Person does not match the Deal's Person."}
+```
+
+```json
+{"deal": "Deal belongs to a different platform."}
+```
+
+```json
+{"owner": "User is not an active member of this Platform."}
+```
+
+`403 Forbidden` — caller missing `Ibl.CRM/Activities/action`.
+
+## `GET /activities/{id}/`
+
+Retrieve one activity by integer id. Returns the full Activity object.
+`404 Not Found` if the id does not exist, or exists on another Platform
+(the API does not leak cross-Platform existence — see [cross-platform isolation](../../../../docs/developer/applications/crm.md#153-cross-platform-isolation)).
+
+## `PUT` / `PATCH /activities/{id}/`
+
+Replace (PUT) or patch (PATCH) editable fields. `done_at` and
+`reminder_sent` are read-only — attempting to set them is silently
+ignored. The attachment rule is re-checked on every write — a PATCH that
+clears the only attachment field returns `400`.
+
+```json
+{
+  "title": "Discovery call — rescheduled",
+  "schedule_from": "2026-06-03T15:00:00Z",
+  "schedule_to": "2026-06-03T15:45:00Z"
+}
+```
+
+Response `200 OK` — full updated activity.
+`403 Forbidden` — missing `Ibl.CRM/Activities/write`.
+`400 Bad Request` — attachment failures (see above).
+
+## `DELETE /activities/{id}/`
+
+Delete an activity. Response `204 No Content`. `404` if not found.
+
+> **Be deliberate when deleting server-emitted stage-change rows**
+> (`type === "note" && title === "Stage changed"`). They are the audit
+> trail for the deal's `move-stage/`, `won/`, `lost/` transitions —
+> once deleted there is no way to reconstruct that history. The
+> recommended UI suppresses the delete control on these rows entirely.
+
+## `POST /activities/{id}/done/`
+
+Mark an activity as done. **Idempotent**: the first call flips
+`is_done` to `true` and stamps `done_at` with the current server time;
+subsequent calls return the same activity with the ORIGINAL `done_at`
+preserved. Safe to retry from a flaky network without drifting
+completion timestamps that downstream reports depend on.
+
+- Request body: none. Any payload is ignored.
+- Response `200 OK` — the full updated Activity object. Splice it into
+  your local list to re-render without a follow-up `GET`.
+- `403 Forbidden` — missing `Ibl.CRM/Activities/write`.
+- `404 Not Found`.
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/activities/4408/done/" \
+  -H "Authorization: Token YOUR_ACCESS_TOKEN"
+```
+
+## Cross-references
+
+- [Activities API](../../../../docs/developer/applications/crm.md#76-activities) — full Activities API reference (this file is its condensed form)
+- [Activity Timeline & Auto-Records](../../../../docs/developer/applications/crm.md#10-activity-timeline--auto-records) — see `references/timeline-rendering.md`
+- [Render system audit Activities differently](../../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently) — rendering system audit Activities
+- [Deal audit trail](../../../../docs/developer/applications/crm.md#93-deal-audit-trail) — the source of stage-change Activities
+- [Filtering and pagination](../../../../docs/developer/applications/crm.md#13-filtering-and-pagination)
+- [RBAC roles and permissions](../../../../docs/developer/applications/crm.md#14-rbac-roles-and-permissions)
+- [Error reference](../../../../docs/developer/applications/crm.md#15-error-reference)

--- a/skills/iblai-crm-activity/references/timeline-rendering.md
+++ b/skills/iblai-crm-activity/references/timeline-rendering.md
@@ -1,0 +1,153 @@
+# Timeline Rendering — [Activity Timeline & Auto-Records](../../../../docs/developer/applications/crm.md#10-activity-timeline--auto-records) + [Render system audit Activities differently](../../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)
+
+Condensed from [Activity Timeline & Auto-Records](../../../../docs/developer/applications/crm.md#10-activity-timeline--auto-records) and
+[Render system audit Activities differently](../../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently). Use this alongside
+`references/activities-api.md` when wiring the timeline panel.
+
+## 10.1 Reading a timeline
+
+The list endpoint is filterable by either parent. The panel is mounted
+inside an existing Person or Deal detail surface, and filters by
+exactly one host:
+
+- Deal-centric panel: `GET /api/crm/activities/?deal={id}`
+- Person-centric panel: `GET /api/crm/activities/?person={uuid}`
+
+Both calls return the standard paginated envelope. Default ordering is
+newest-first by `created_at`.
+
+Combine filters to drive panel variants — for example
+`?deal=314&type=call&is_done=false` renders an "upcoming calls" panel
+on a deal page.
+
+## 10.2 Distinguishing system rows from user rows
+
+The CRM writes its own Activities when a Deal transitions stages, wins,
+or is lost (see [Deal audit trail](../../../../docs/developer/applications/crm.md#93-deal-audit-trail)). These appear in the same `/activities/` feed as
+user-authored entries. There is no dedicated `source` field — use a
+client-side predicate:
+
+```ts
+const isStageChangeAudit = (a: Activity): boolean =>
+  a.type === "note" && a.title === "Stage changed";
+```
+
+System rows arrive already complete: `is_done: true` and `done_at` set
+to the transition timestamp. The `comment` body carries the transition
+line, e.g. `"Discovery → Proposal"`.
+
+**Do not** offer edit, delete, or mark-done controls for these rows —
+the user did not author them and there is nothing left to mark done.
+
+See also [Render system audit Activities differently](../../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently) below.
+
+## 10.3 Marking an activity done
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/activities/8821/done/" \
+  -H "Authorization: Token $TOKEN"
+```
+
+- No request body.
+- **Idempotent**: the first call flips `is_done=true` and stamps
+  `done_at` with the current server time. Subsequent calls return the
+  same activity with the ORIGINAL `done_at` preserved — the server does
+  not re-stamp on repeat invocations.
+- This matters for offline-capable clients that may retry the same
+  request after a network blip; you will not see the completion time
+  drift forward each time the queue flushes.
+- The response is the full updated Activity object, so the client can
+  replace the row in its local store without a follow-up `GET`.
+
+## 10.4 Schedule semantics
+
+`schedule_from` and `schedule_to` combine to express three intents.
+Pick the shape that matches what you are recording — do not invent
+dates to satisfy both fields:
+
+| `schedule_from` | `schedule_to` | Read as |
+|---|---|---|
+| null | null | A past log entry — what happened, recorded after the fact (e.g. "logged call") |
+| set | null | A scheduled task or deadline with a start time but no fixed end |
+| set | set | A meeting or other time-bounded event |
+
+A call note written ten minutes after the call ended is the first
+shape. A "follow up next Tuesday" task is the second. A 30-minute demo
+on the calendar is the third.
+
+The server does not enforce a relationship between the two fields
+beyond storage. A malformed combination (e.g. `schedule_to` earlier
+than `schedule_from`) is the client's responsibility to prevent — wire
+a simple ordering check into the create form.
+
+## 10.5 Reminders
+
+- `reminder_at` is set by the caller — typically a fixed offset before
+  `schedule_from` (15 minutes before is a common default for meetings).
+- `reminder_sent` is server-managed. **Do not write to it from the
+  client.**
+
+> **Reminder delivery is not currently dispatched server-side.** Set
+> `reminder_at` to track intent and surface a local in-app prompt; the
+> field round-trips correctly. `reminder_sent` will remain `false`
+> until a server-side dispatcher is wired.
+
+In the meantime, you can drive an in-app prompt from `reminder_at` for
+the current user's own owned activities, and feed CRM event
+notifications (see [Notifications](../../../../docs/developer/applications/crm.md#12-notifications) and `/iblai-notification`) into the bell UI.
+
+## 10.6 Attaching an activity
+
+Every activity must attach to a Deal **or** a Person — or both, where
+they agree:
+
+- Posting with neither set returns `400`:
+  ```json
+  { "detail": ["Activity must attach to a `deal` or a `person`."] }
+  ```
+  The serializer raises before any database write — a failed create
+  has no side effects.
+- If both `deal` and `person` are set, the person must equal the
+  person already attached to the deal. A mismatch returns `400` with a
+  field-level error rather than letting orphaned rows appear in the
+  timeline.
+
+A typical create call for a meeting attached to both:
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/activities/" \
+  -H "Authorization: Token $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "meeting",
+    "title": "Pricing review",
+    "deal": 314,
+    "person": "9c6f4a2e-1b88-4a0e-9b71-2c2f7a1d6e44",
+    "schedule_from": "2026-06-10T16:00:00Z",
+    "schedule_to": "2026-06-10T16:45:00Z",
+    "reminder_at": "2026-06-10T15:45:00Z"
+  }'
+```
+
+The response is the created Activity — ready to splice into the
+timeline view without a re-fetch.
+
+## 16.5 Render system audit Activities differently
+
+When a deal transitions stages (via `move-stage/`, `won/`, or
+`lost/`), the server writes a system Activity with `type === "note"`
+and `title === "Stage changed"`. These appear in the same
+`/api/crm/activities/` list as user-authored notes, calls, and tasks.
+
+In the timeline UI:
+
+- Render them with a distinct icon — a system / arrow glyph works well.
+- **Suppress edit, delete, and mark-done controls.** They are already
+  complete (`is_done: true`, `done_at` set) and immutable in intent.
+- Keep them visually quieter than user-authored entries — smaller text,
+  muted color — so the timeline still reads as a human history with
+  system audit beats woven in.
+- The `comment` body (e.g. `"Discovery → Proposal"`) is the line of
+  record. Use it as the row body.
+
+See [Activities API](../../../../docs/developer/applications/crm.md#76-activities) and [Activity Timeline & Auto-Records](../../../../docs/developer/applications/crm.md#10-activity-timeline--auto-records) for the canonical references this guidance is built on.

--- a/skills/iblai-crm-deal-flow/SKILL.md
+++ b/skills/iblai-crm-deal-flow/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: iblai-crm-deal-flow
+description: Build the revenue funnel CRM surface — pipelines, stages, lead sources, and the kanban deal board with move-stage / won / lost transitions. Use when the user mentions deals, kanban, pipeline, stages, lead sources, move stage, mark won, mark lost, lost reason, deal status, or sales funnel. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for persons (deals require one), /iblai-crm-activity for the timeline + audit rows, and /iblai-crm-notification for CRM_DEAL_STAGE_CHANGED routing.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-deal-flow
+
+Build the revenue funnel: a pipeline selector, a kanban deal board (columns = stages, cards = deals), and the move-stage / won / lost state machine with `lost_reason` collection.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — reuse the same token wiring
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- A Person already exists in the CRM. Deals REQUIRE a `person` UUID — if
+  you have not built the lead capture surface yet, do `/iblai-crm-lead-flow`
+  first and come back.
+- RBAC role on the caller:
+  - `CRM User` — list, read, create, update, delete deals; call
+    `move-stage/`, `won/`, `lost/`. This is what 95% of sales reps need.
+  - `CRM Manager` — additionally lets you CRUD pipelines, stages, and
+    lead sources. Only needed if you're building the admin UI in Step 8.
+  - See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+1. **Pipeline selector** — defaults to the seeded `default` pipeline; lets
+   the user switch when more than one exists.
+2. **Kanban board** — one column per stage in `sort_order`, cards grouped
+   by `deal.stage`. Card shows title, `lead_value` + `currency`, person
+   name, and days-in-stage.
+3. **Drag-drop → `move-stage`** — using `@dnd-kit`, fires
+   `POST /deals/{id}/move-stage/` with `{stage_code}`.
+4. **Deal detail panel** — clicking a card opens a slide-over with full
+   deal fields and **Won** / **Lost** buttons.
+5. **Lost modal** — collects required `lost_reason` before hitting
+   `POST /deals/{id}/lost/`.
+6. **(Optional) Admin UI** — pipeline + stage + lead source CRUD for
+   `CRM Manager` users.
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date.
+Run `iblai --version`, then upgrade directly:
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+## Step 1: Install shadcn primitives + dnd-kit
+
+```bash
+npx shadcn@latest add card badge dialog select button input textarea form sheet skeleton
+pnpm add @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+`@dnd-kit` is the recommended dnd primitive — accessible, headless, plays
+well with shadcn `card`. Do not write a custom drag layer.
+
+## Step 2: Typed API client wrappers
+
+Reuse the auth token wiring from `/iblai-auth` — do NOT introduce a new
+token-management layer. Read the same `Token` value the rest of the app
+uses (the SDK persists it; client code can grab it from `localStorage` or
+from the auth context).
+
+Create `lib/iblai/crm.ts` with thin typed fetchers:
+
+```ts
+// lib/iblai/crm.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+type Stage = {
+  id: number; pipeline: number; code: string; name: string;
+  probability: number; sort_order: number;
+  is_won: boolean; is_lost: boolean; metadata: Record<string, unknown>;
+};
+
+type Pipeline = {
+  id: number; name: string; code: string; is_default: boolean;
+  rotten_days: number; stages: Stage[]; metadata: Record<string, unknown>;
+};
+
+type Deal = {
+  id: number; title: string; description: string;
+  lead_value: string; currency: string;
+  status: "open" | "won" | "lost"; lost_reason: string;
+  expected_close_date: string | null; closed_at: string | null;
+  person: string; organization: string | null;
+  pipeline: number; stage: number;
+  source: number | null; owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string; updated_at: string;
+};
+
+const h = (token: string) => ({
+  Authorization: `Token ${token}`,
+  "Content-Type": "application/json",
+});
+
+export const crm = {
+  listPipelines: (token: string, params = "") =>
+    fetch(`${BASE}/pipelines/${params}`, { headers: h(token) }).then(r => r.json()),
+  listLeadSources: (token: string) =>
+    fetch(`${BASE}/lead-sources/`, { headers: h(token) }).then(r => r.json()),
+  listDeals: (token: string, pipelineId: number) =>
+    fetch(`${BASE}/deals/?pipeline=${pipelineId}&status=open`, { headers: h(token) })
+      .then(r => r.json()),
+  createDeal: (token: string, body: Partial<Deal>) =>
+    fetch(`${BASE}/deals/`, { method: "POST", headers: h(token), body: JSON.stringify(body) })
+      .then(r => r.json()),
+  moveStage: (token: string, id: number, stage_code: string) =>
+    fetch(`${BASE}/deals/${id}/move-stage/`, {
+      method: "POST", headers: h(token), body: JSON.stringify({ stage_code }),
+    }).then(r => r.json()),
+  won: (token: string, id: number, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/won/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify(stage_code ? { stage_code } : {}),
+    }).then(r => r.json()),
+  lost: (token: string, id: number, lost_reason: string, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/lost/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify({ lost_reason, ...(stage_code ? { stage_code } : {}) }),
+    }).then(r => r.json()),
+};
+```
+
+Full endpoint catalogs and field tables live in
+[`references/pipelines-api.md`](./references/pipelines-api.md),
+[`references/lead-sources-api.md`](./references/lead-sources-api.md), and
+[`references/deals-api.md`](./references/deals-api.md).
+
+## Step 3: Fetch the default pipeline once on mount
+
+Every Platform is seeded with a default pipeline (`code=default`) carrying
+six stages — `new`, `qualified`, `proposal`, `negotiation`, `won`, `lost`.
+The list response embeds the ordered `stages` array inline, so you do not
+need a second roundtrip.
+
+```ts
+const { results } = await crm.listPipelines(token, "?is_default=true");
+const pipeline = results[0];
+// Index stages by CODE — not id. Codes are stable across environments;
+// ids differ between dev / staging / prod (see the CRM doc's [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)).
+const stagesByCode = Object.fromEntries(pipeline.stages.map((s) => [s.code, s]));
+const stagesById = Object.fromEntries(pipeline.stages.map((s) => [s.id, s]));
+```
+
+Cache `pipeline.id` and the stages object in your store (Zustand, Redux,
+or React state). The board only needs to re-fetch when the user switches
+pipelines.
+
+## Step 4: Render the kanban board
+
+```ts
+const { results: deals } = await crm.listDeals(token, pipeline.id);
+const columns = pipeline.stages
+  .filter((s) => !s.is_won && !s.is_lost)        // hide terminal columns on the open board
+  .sort((a, b) => a.sort_order - b.sort_order);
+const byStage = Object.groupBy(deals, (d) => d.stage); // group cards by Deal.stage (the stage id)
+```
+
+Card content:
+- `title` — bold, truncated to 1 line
+- `lead_value` formatted with `Intl.NumberFormat` + `currency`
+- Person name (look up via `/iblai-crm-lead-flow` person store)
+- Days-in-stage = `dayjs().diff(deal.updated_at, "day")`; flag in red when
+  it exceeds `pipeline.rotten_days` (default 30)
+
+Use shadcn `card` for cards, `badge` for the stage chip, `skeleton` for
+the initial loading state.
+
+## Step 5: Drag-drop → move-stage
+
+Wire `@dnd-kit`'s `DndContext` around the columns. On drop, derive the
+destination stage CODE (never raw id — see [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)) and call:
+
+```ts
+async function onDragEnd(deal: Deal, destStageCode: string) {
+  const dest = stagesByCode[destStageCode];
+  if (!dest) return;
+  if (dest.id === deal.stage) return;      // no-op guard — see [Idempotency](../../../docs/developer/applications/crm.md#96-idempotency)
+  const updated = await crm.moveStage(token, deal.id, destStageCode);
+  setDeals((prev) => prev.map((d) => (d.id === deal.id ? updated : d)));
+}
+```
+
+**Server side effects to call out in the UI:**
+
+- The server appends an audit Activity (`type=note`,
+  `title="Stage changed"`, `comment="<from> → <to>"`,
+  `is_done=true`). This row will appear in the deal timeline — render it
+  with a distinct icon and no edit controls per
+  `/iblai-crm-activity` ([best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- A `CRM_DEAL_STAGE_CHANGED` notification fires. See
+  `/iblai-crm-notification` for recipient routing and channel config.
+- `Deal.status` is recomputed from the destination stage's `is_won` /
+  `is_lost` flags. Do **not** echo the optimistic status — re-read from
+  the server response.
+- Dragging onto the same column is **suppressed server-side** (no write,
+  no notification, no audit row). Gate the call client-side too so the
+  UI does not flash. See `references/state-machine.md`.
+
+## Step 6: Won / Lost buttons
+
+On the deal detail panel, add two buttons:
+
+```ts
+// Won — picks the first is_won stage by sort_order automatically
+const updated = await crm.won(token, deal.id);
+
+// Won — disambiguate when the pipeline has multiple is_won stages
+const updated = await crm.won(token, deal.id, "closed-won-expansion");
+```
+
+**Lost** requires `lost_reason` — the API returns `400` if missing or
+blank (see [best practice: always provide a lost_reason](../../../docs/developer/applications/crm.md#164-always-provide-a-lost_reason)). Always collect it in a modal:
+
+```tsx
+<Dialog open={lostOpen} onOpenChange={setLostOpen}>
+  <DialogContent>
+    <DialogTitle>Mark as Lost</DialogTitle>
+    <Textarea
+      placeholder="Why did this deal slip?"
+      value={reason}
+      onChange={(e) => setReason(e.target.value)}
+      maxLength={255}
+      required
+    />
+    <Button
+      disabled={!reason.trim()}
+      onClick={async () => {
+        const updated = await crm.lost(token, deal.id, reason.trim());
+        setLostOpen(false);
+        // refresh board — deal is now status="lost"
+      }}
+    >
+      Confirm Lost
+    </Button>
+  </DialogContent>
+</Dialog>
+```
+
+**Re-opening a deal.** Won/lost are not one-way doors. To re-open, call
+`crm.moveStage(token, dealId, "<non-terminal-stage-code>")`. The server
+clears `closed_at`, flips `status` back to `open`, writes an audit
+Activity, and fires `CRM_DEAL_STAGE_CHANGED` again. There is no dedicated
+"reopen" endpoint — the stage move IS the reopen.
+
+## Step 7: Client-side footguns (must enforce in the UI)
+
+- **Never PATCH `status` or `closed_at`.** Both are server-managed; sending
+  either on PUT/PATCH returns 400 with the message
+  *"Service-managed — write via move-stage/, won/, or lost/."* Do not
+  surface these fields on a deal edit form.
+- **`Deal.stage` must belong to `Deal.pipeline`.** If you let the user
+  switch a deal's pipeline, also force them to pick a stage from the new
+  pipeline before submit. Mismatch returns 400.
+- **`Deal.organization` must match `Person.organization`** when the person
+  already has one. Pre-fill the organization field from the selected
+  person and disable it when set, or you will hit a 400.
+- **`owner` defaults to the calling user.** Only send it when you are
+  explicitly reassigning the deal.
+
+## Step 8 (optional): Pipeline, Stage, and Lead Source admin
+
+Only build this when the user has the `CRM Manager` role. Gate the menu
+entry behind that role — see `/iblai-rbac`.
+
+Destructive-delete behavior differs across these resources — surface a
+confirmation dialog that explains the consequence:
+
+| Resource | DELETE behavior |
+|---|---|
+| Pipeline | `409 Conflict` if any Deal references it. Migrate deals first. |
+| Stage | `409 Conflict` if any Deal references it. Move those deals to another stage first. |
+| Lead Source | **Not blocked.** SETs `Deal.source = NULL` on every referencing deal. Historical attribution is lost. Treat as destructive. |
+
+Other admin guardrails:
+
+- Pipeline `code` is unique per Platform (duplicate → 400).
+- At most one pipeline can have `is_default=true` per Platform — un-flag
+  the existing default first.
+- Stage `code` is unique within its pipeline.
+- A stage cannot be both `is_won` and `is_lost` (400 if you try).
+- `probability` is 0–100 (400 otherwise).
+
+Full tables, error payloads, and curl examples live in
+[`references/pipelines-api.md`](./references/pipelines-api.md) and
+[`references/lead-sources-api.md`](./references/lead-sources-api.md).
+
+## State machine
+
+A Deal's `status` is **derived** from the stage it currently sits in —
+never written directly. Three endpoints change the stage:
+
+- `POST /deals/{id}/move-stage/` — go anywhere in the pipeline.
+- `POST /deals/{id}/won/` — go to the first `is_won` stage (or a specific
+  one via `stage_code`).
+- `POST /deals/{id}/lost/` — go to the first `is_lost` stage; **requires**
+  `lost_reason`.
+
+Every successful, non-no-op transition:
+1. Recomputes `status` (`is_won` → `won`, `is_lost` → `lost`, else `open`).
+2. Stamps or clears `closed_at`.
+3. Writes a `type=note`, `title="Stage changed"` audit Activity.
+4. Fires `CRM_DEAL_STAGE_CHANGED`.
+
+Idempotency: moving to the current stage is a no-op (no write, no signal,
+no audit row, no notification). `lost/` is the one exception — it overwrites
+`lost_reason` unconditionally even when the stage move is a no-op, so
+pass the original reason on retries.
+
+Concurrency: transitions serialize on a row lock. Two simultaneous
+requests cannot both observe the same `from_stage`. Refresh the deal
+after a transition so the UI matches reality.
+
+Full diagrams + edge cases: [`references/state-machine.md`](./references/state-machine.md).
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and drive the board:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals /tmp/deals.png
+   ```
+3. Drag a card from `qualified` → `negotiation`. Confirm:
+   - The card lands and `updated_at` advances.
+   - The deal timeline (via `/iblai-crm-activity`) shows a new system
+     row: title `"Stage changed"`, comment `"Qualified → Negotiation"`.
+   - The notification bell (via `/iblai-crm-notification` →
+     `/iblai-notification`) shows a fresh `CRM_DEAL_STAGE_CHANGED` entry.
+4. Click **Lost** with an empty textarea → submit button is disabled (or
+   the server returns 400 with `{"lost_reason": ["This field is required."]}`).
+5. Click **Won** on an open deal → confirm `status` flips to `won`,
+   `closed_at` is stamped, and the card moves off the open board.
+
+## Related skills
+
+- `/iblai-crm-overview` — auth, Platform scoping, seeded defaults, RBAC matrix.
+- `/iblai-crm-lead-flow` — deals REQUIRE a person; build that flow first.
+- `/iblai-crm-activity` — deal timeline rendering; system audit rows look
+  different from user-logged activities (see [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- `/iblai-crm-tag` — attach tags to deals; filter the kanban board by tag.
+- `/iblai-crm-notification` — `CRM_DEAL_STAGE_CHANGED` fires from every
+  transition in this skill.
+- `/iblai-rbac` — `CRM User` (deals) vs `CRM Manager` (pipelines, stages,
+  lead sources) permission matrix.
+- `/iblai-auth` — token wiring; do not introduce a parallel token layer.

--- a/skills/iblai-crm-deal-flow/references/deals-api.md
+++ b/skills/iblai-crm-deal-flow/references/deals-api.md
@@ -1,0 +1,223 @@
+# Deals API
+
+Condensed from the CRM doc [Deals API](../../../../docs/developer/applications/crm.md#75-deals).
+
+> **Base URL:** `${NEXT_PUBLIC_API_BASE_URL}/api/crm/`
+> **Auth:** `Authorization: Token <token>`
+> All responses are scoped to the Platform on the token. Cross-Platform
+> deals return `404 Not Found` — never `403` — so existence is never leaked.
+
+## Endpoint catalog
+
+| Method | Path | RBAC | Purpose |
+|---|---|---|---|
+| GET | `/deals/` | `Ibl.CRM/Deals/list` | Paginated list |
+| POST | `/deals/` | `Ibl.CRM/Deals/action` | Create |
+| GET | `/deals/{id}/` | `Ibl.CRM/Deals/read` | Retrieve one |
+| PUT | `/deals/{id}/` | `Ibl.CRM/Deals/write` | Replace editable fields |
+| PATCH | `/deals/{id}/` | `Ibl.CRM/Deals/write` | Patch editable fields |
+| DELETE | `/deals/{id}/` | `Ibl.CRM/Deals/delete` | Delete (cascades audit Activities + tag assignments) |
+| POST | `/deals/{id}/move-stage/` | `Ibl.CRM/Deals/write` | Move to any stage in the deal's pipeline |
+| POST | `/deals/{id}/won/` | `Ibl.CRM/Deals/write` | Move to first `is_won` stage (or `stage_code`-specified) |
+| POST | `/deals/{id}/lost/` | `Ibl.CRM/Deals/write` | Move to first `is_lost` stage; **requires `lost_reason`** |
+| POST | `/deals/{id}/tags/` | `Ibl.CRM/Tags/write` | Attach a tag (see /iblai-crm-tag) |
+| DELETE | `/deals/{id}/tags/{tag_id}/` | `Ibl.CRM/Tags/write` | Detach a tag |
+
+Holding `Ibl.CRM/Deals/write` is **not** sufficient for tag attach/detach
+— they require `Ibl.CRM/Tags/write`.
+
+## Query parameters — `GET /deals/`
+
+| Param | Type | Description |
+|---|---|---|
+| `status` | string | `open`, `won`, `lost` |
+| `pipeline` | integer | Pipeline id |
+| `stage` | integer | PipelineStage id |
+| `owner` | integer | Owning user id |
+| `source` | integer | LeadSource id |
+| `person` | UUID | Primary person on the deal |
+| `organization` | UUID | Organization on the deal |
+| `expected_close_date__gte` / `__lte` | ISO 8601 | Forecast close window |
+| `created_at__gte` / `__lte` | ISO 8601 | Creation window |
+| `metadata__has_key` | string | Top-level key in `metadata` |
+| `tags` | int (repeatable) or CSV | OR-match on tag ids. `?tags=1&tags=2` or `?tags=1,2`. Non-numeric pieces dropped silently |
+| `page` / `page_size` | integer | Pagination |
+
+## Deal fields
+
+| Field | Type | Write rules |
+|---|---|---|
+| `id` | int | Server-assigned |
+| `platform` | int | Server-set from auth token |
+| `title` | string | **Required on POST** |
+| `description` | string | Defaults to `""` |
+| `lead_value` | decimal string | Defaults to `"0"` |
+| `currency` | string | ISO 4217, defaults to `"USD"` |
+| `status` | string | **Server-managed. READ-ONLY.** Derived from current stage's `is_won`/`is_lost` flags. PUT/PATCH with `status` → 400 |
+| `lost_reason` | string | Persisted by the `lost/` action; empty otherwise. Max 255 chars |
+| `expected_close_date` | datetime\|null | Forecast close date |
+| `closed_at` | datetime\|null | **Server-managed. READ-ONLY.** Stamped on entry to terminal stage; cleared on re-open |
+| `person` | UUID | **Required on POST.** Must belong to your Platform |
+| `organization` | UUID\|null | Must belong to your Platform. If the Person has an organization, this MUST match it |
+| `pipeline` | int | **Required on POST.** Must belong to your Platform |
+| `stage` | int | **Required on POST.** Must belong to `pipeline`. Not directly writable on update — use `move-stage/`, `won/`, or `lost/` |
+| `source` | int\|null | LeadSource id; must belong to your Platform |
+| `owner` | int\|null | Defaults to the calling user. Must be an active member of your Platform |
+| `tags` | array | Flat `[{id, name, color}]` — read-only here, mutate via tag sub-routes |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+| `created_at` / `updated_at` | datetime | Timestamps |
+
+### Server-managed fields rule
+
+The serializer rejects writes to `status` and `closed_at` on POST, PUT,
+and PATCH. The only way to change either is via one of the three
+transition endpoints — they recompute both atomically from the destination
+stage's `is_won`/`is_lost` flags.
+
+## POST `/deals/` errors
+
+```json
+{"status": "Service-managed — write via `POST /deals/{id}/move-stage/`, `won/`, or `lost/`."}
+```
+
+```json
+{"stage": "Stage does not belong to the supplied pipeline."}
+```
+
+```json
+{"organization": "Organization does not match the Person's Organization."}
+```
+
+```json
+{"person": "Person belongs to a different platform."}
+```
+
+```json
+{"owner": "User is not an active member of this Platform."}
+```
+
+`403 Forbidden` — caller missing `Ibl.CRM/Deals/action`.
+
+## PUT/PATCH `/deals/{id}/` errors
+
+```json
+{
+  "status": "Service-managed — write via `POST /deals/{id}/move-stage/`, `won/`, or `lost/`.",
+  "closed_at": "Service-managed — write via `POST /deals/{id}/move-stage/`, `won/`, or `lost/`."
+}
+```
+
+## Transition endpoint bodies
+
+### `POST /deals/{id}/move-stage/`
+
+```json
+{"stage_code": "negotiation"}
+```
+
+or:
+
+```json
+{"stage_id": 12}
+```
+
+Provide **one** of `stage_id` or `stage_code`. `stage_code` is the
+integration-safe choice (ids differ across environments).
+
+Errors:
+
+```json
+{"detail": "Provide either `stage_id` or `stage_code`."}
+```
+
+```json
+{"detail": "Destination stage does not belong to this Deal's pipeline."}
+```
+
+```json
+{"detail": "Stage 'negotiation' not found in Deal's pipeline."}
+```
+
+### `POST /deals/{id}/won/`
+
+```json
+{}
+```
+
+or:
+
+```json
+{"stage_code": "closed-won-expansion"}
+```
+
+Errors:
+
+```json
+{"detail": "Pipeline 3 has no is_won=True stage configured."}
+```
+
+```json
+{"detail": "Stage 'closed-won-expansion' is not marked is_won=True."}
+```
+
+### `POST /deals/{id}/lost/`
+
+```json
+{
+  "lost_reason": "Chose competitor — Pied Piper undercut us on price.",
+  "stage_code": "closed-lost-price"
+}
+```
+
+`lost_reason` is **required** and must be non-blank. Max 255 chars.
+
+Errors:
+
+```json
+{"lost_reason": ["This field is required."]}
+```
+
+```json
+{"detail": "Pipeline 3 has no is_lost=True stage configured."}
+```
+
+```json
+{"detail": "Stage 'closed-lost-price' is not marked is_lost=True."}
+```
+
+## Sample list response (truncated)
+
+```json
+{
+  "count": 47,
+  "next_page": 2,
+  "previous_page": null,
+  "results": [
+    {
+      "id": 184,
+      "platform": 1,
+      "title": "Acme renewal — 2026",
+      "description": "Multi-year renewal, 220 seats.",
+      "lead_value": "48000.00",
+      "currency": "USD",
+      "status": "open",
+      "lost_reason": "",
+      "expected_close_date": "2026-09-30T00:00:00Z",
+      "closed_at": null,
+      "person": "c4d2b1a8-7c3e-4f9a-9d6b-9a2c4f1e7b80",
+      "organization": "b2a1e7d3-6f4c-4b2a-8e9d-1c3a5b7d9f10",
+      "pipeline": 3,
+      "stage": 12,
+      "source": 5,
+      "owner": 91,
+      "tags": [
+        {"id": 7, "name": "Enterprise", "color": "#3F6BFF"},
+        {"id": 11, "name": "Renewal", "color": "#22A06B"}
+      ],
+      "metadata": {"region": "NA", "campaign_id": "fy26-renewals"},
+      "created_at": "2026-04-12T08:14:22Z",
+      "updated_at": "2026-05-30T17:02:11Z"
+    }
+  ]
+}
+```

--- a/skills/iblai-crm-deal-flow/references/lead-sources-api.md
+++ b/skills/iblai-crm-deal-flow/references/lead-sources-api.md
@@ -1,0 +1,100 @@
+# Lead Sources API
+
+Condensed from the CRM doc [Lead Sources API](../../../../docs/developer/applications/crm.md#74-lead-sources).
+
+> **Base URL:** `${NEXT_PUBLIC_API_BASE_URL}/api/crm/`
+> **Auth:** `Authorization: Token <token>`
+
+Lead Sources record where a Deal originated (web traffic, referral,
+outbound campaign…). They live under the `Ibl.CRM/Pipelines/` RBAC
+bucket — anyone who can shape pipelines can shape lead sources.
+
+## Seeded defaults
+
+Every Platform ships with four lead sources, created automatically and
+backfilled into existing Platforms via data migration:
+
+| `code` | `name` |
+|---|---|
+| `web` | Web |
+| `referral` | Referral |
+| `cold_call` | Cold Call |
+| `advertisement` | Advertisement |
+
+`code` is the stable identifier. The display `name` can be renamed
+freely without breaking integrations.
+
+## Endpoints
+
+| Method | Path | RBAC | Purpose |
+|---|---|---|---|
+| GET | `/lead-sources/` | `Ibl.CRM/Pipelines/list` | Paginated list |
+| POST | `/lead-sources/` | `Ibl.CRM/Pipelines/action` | Create |
+| GET | `/lead-sources/{id}/` | `Ibl.CRM/Pipelines/read` | Retrieve one |
+| PUT | `/lead-sources/{id}/` | `Ibl.CRM/Pipelines/write` | Replace |
+| PATCH | `/lead-sources/{id}/` | `Ibl.CRM/Pipelines/write` | Patch |
+| DELETE | `/lead-sources/{id}/` | `Ibl.CRM/Pipelines/delete` | Delete — **SET NULL on referencing deals (destructive)** |
+
+## Query parameters — `GET /lead-sources/`
+
+| Name | Type | Description |
+|---|---|---|
+| `code` | string | Case-insensitive exact match |
+| `name` | string | Case-insensitive substring match |
+| `page` / `page_size` | integer | Pagination, `page_size` max 100 |
+
+## Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | int | Server-assigned, stable across renames |
+| `platform` | int | Server-set from auth token |
+| `name` | string | Display name |
+| `code` | string | Unique per Platform, lowercase letters/digits/hyphens |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+| `created_at` / `updated_at` | ISO 8601 | Timestamps |
+
+## Error catalog
+
+`400` on POST/PATCH with duplicate code:
+
+```json
+{"code": ["A LeadSource with code 'linkedin-outbound' already exists on this Platform."]}
+```
+
+`403 Forbidden` — caller missing `Ibl.CRM/Pipelines/action` (POST) /
+`/write` (PATCH/PUT) / `/delete` (DELETE).
+
+## Destructive-delete footgun
+
+Unlike Pipelines and Stages — which return `409 Conflict` when Deals
+reference them — deleting a Lead Source is **not blocked**. Instead, the
+server clears the foreign key on every referencing Deal:
+
+```
+Deal.source = NULL  -- on every Deal that referenced this source
+```
+
+Treat this as destructive. Once the source is gone, the historical
+"where did this Deal come from?" attribution is lost permanently. Surface
+a confirmation dialog that explicitly says so — do not lean on the
+generic shadcn confirm wording.
+
+If you only want to retire the source without losing attribution,
+PATCH the `name` instead (e.g. prefix with `[archived]`) and stop
+offering it in the create-deal UI.
+
+## Sample list response
+
+```json
+{
+  "count": 5,
+  "results": [
+    {"id": 1, "platform": 1, "name": "Web", "code": "web", "metadata": {}},
+    {"id": 2, "platform": 1, "name": "Referral", "code": "referral", "metadata": {}},
+    {"id": 3, "platform": 1, "name": "Cold Call", "code": "cold_call", "metadata": {}},
+    {"id": 4, "platform": 1, "name": "Advertisement", "code": "advertisement", "metadata": {}},
+    {"id": 5, "platform": 1, "name": "LinkedIn Outbound", "code": "linkedin-outbound", "metadata": {"campaign": "q3-saas"}}
+  ]
+}
+```

--- a/skills/iblai-crm-deal-flow/references/pipelines-api.md
+++ b/skills/iblai-crm-deal-flow/references/pipelines-api.md
@@ -1,0 +1,171 @@
+# Pipelines & Stages API
+
+Condensed from the CRM doc [Pipelines & Stages API](../../../../docs/developer/applications/crm.md#73-pipelines--stages).
+
+> **Base URL:** `${NEXT_PUBLIC_API_BASE_URL}/api/crm/`
+> **Auth:** `Authorization: Token <token>`
+> All responses are scoped to the Platform on the token.
+
+## Seeded defaults
+
+Every Platform is seeded with one pipeline and six stages on creation
+(existing Platforms were backfilled via data migration).
+
+| Pipeline `code` | `name` | `is_default` | `rotten_days` |
+|---|---|---|---|
+| `default` | Default Pipeline | `true` | `30` |
+
+Stages on the default pipeline, in `sort_order`:
+
+| `code` | `name` | `probability` | `sort_order` | `is_won` | `is_lost` |
+|---|---|---|---|---|---|
+| `new` | New | 10 | 0 | false | false |
+| `qualified` | Qualified | 25 | 1 | false | false |
+| `proposal` | Proposal | 50 | 2 | false | false |
+| `negotiation` | Negotiation | 75 | 3 | false | false |
+| `won` | Won | 100 | 4 | **true** | false |
+| `lost` | Lost | 0 | 5 | false | **true** |
+
+Treat `code` as the stable identifier in client payloads. `id` differs
+across environments.
+
+## Endpoint summary
+
+| Method | Path | RBAC | Purpose |
+|---|---|---|---|
+| GET | `/pipelines/` | `Ibl.CRM/Pipelines/list` | List pipelines (each carries `stages` inline) |
+| POST | `/pipelines/` | `Ibl.CRM/Pipelines/action` | Create a pipeline |
+| GET | `/pipelines/{id}/` | `Ibl.CRM/Pipelines/read` | Retrieve one |
+| PUT | `/pipelines/{id}/` | `Ibl.CRM/Pipelines/write` | Replace editable fields |
+| PATCH | `/pipelines/{id}/` | `Ibl.CRM/Pipelines/write` | Patch editable fields |
+| DELETE | `/pipelines/{id}/` | `Ibl.CRM/Pipelines/delete` | Delete pipeline (cascades stages) |
+| GET | `/pipelines/{pipeline_id}/stages/` | `Ibl.CRM/Pipelines/list` | List stages (ordered by `sort_order`) |
+| POST | `/pipelines/{pipeline_id}/stages/` | `Ibl.CRM/Pipelines/action` | Create stage in this pipeline |
+| GET | `/pipelines/{pipeline_id}/stages/{id}/` | `Ibl.CRM/Pipelines/read` | Retrieve one stage |
+| PUT | `/pipelines/{pipeline_id}/stages/{id}/` | `Ibl.CRM/Pipelines/write` | Replace stage fields |
+| PATCH | `/pipelines/{pipeline_id}/stages/{id}/` | `Ibl.CRM/Pipelines/write` | Patch stage fields |
+| DELETE | `/pipelines/{pipeline_id}/stages/{id}/` | `Ibl.CRM/Pipelines/delete` | Delete stage |
+
+Stages are nested — they cannot be moved between pipelines, and the
+nested route refuses access to stages of pipelines on other Platforms.
+
+## Query parameters
+
+### `GET /pipelines/`
+
+| Name | Type | Description |
+|---|---|---|
+| `code` | string | Case-insensitive exact match |
+| `name` | string | Case-insensitive substring match |
+| `is_default` | boolean | Filter to default (or non-default) |
+| `page` / `page_size` | integer | Pagination, max `page_size=100` |
+
+### `GET /pipelines/{pipeline_id}/stages/`
+
+| Name | Type | Description |
+|---|---|---|
+| `code` | string | Case-insensitive exact match |
+| `is_won` | boolean | Filter terminal won stages |
+| `is_lost` | boolean | Filter terminal lost stages |
+| `page` / `page_size` | integer | Pagination |
+
+## Pipeline fields
+
+| Field | Type | Write rules |
+|---|---|---|
+| `id` | int | Server-assigned |
+| `platform` | int | Server-set from auth token |
+| `name` | string | Required on create |
+| `code` | string | Required, unique per Platform, lowercase letters/digits/hyphens |
+| `is_default` | boolean | At most one default per Platform — un-flag the existing default first |
+| `rotten_days` | int | Defaults to `30` |
+| `stages` | array | **Read-only on pipeline.** Manage via nested endpoints |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+| `created_at` / `updated_at` | ISO 8601 | Timestamps |
+
+## Stage fields
+
+| Field | Type | Write rules |
+|---|---|---|
+| `id` | int | Server-assigned |
+| `pipeline` | int | **Immutable** — set automatically from URL on POST, read-only thereafter |
+| `code` | string | Required, unique within the pipeline |
+| `name` | string | Required, shown on kanban cards |
+| `probability` | int | 0–100, defaults to `0`, used for revenue forecasting |
+| `sort_order` | int | Left-to-right column order, defaults to `0` |
+| `is_won` | boolean | Terminal won. Moving a deal here sets `Deal.status="won"` |
+| `is_lost` | boolean | Terminal lost. Moving a deal here sets `Deal.status="lost"` |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+
+A stage cannot be both `is_won` and `is_lost`.
+
+## Error catalog
+
+### POST/PATCH pipeline
+
+```json
+{"code": ["A Pipeline with code 'b2b-sales' already exists on this Platform."]}
+```
+
+```json
+{"is_default": ["Another Pipeline on this Platform is already the default. Un-flag the existing default first."]}
+```
+
+### POST/PATCH stage
+
+```json
+{"code": ["A stage with code 'discovery' already exists in this Pipeline."]}
+```
+
+```json
+{"probability": ["probability must be between 0 and 100."]}
+```
+
+```json
+{"detail": ["A stage cannot be both is_won and is_lost."]}
+```
+
+`404 Not Found` — parent pipeline does not exist or belongs to another
+Platform.
+
+### DELETE pipeline
+
+`409 Conflict`:
+
+```json
+{"detail": "Pipeline still has Deals attached."}
+```
+
+Stages cascade-delete with the pipeline when no deals reference them.
+
+### DELETE stage
+
+`409 Conflict`:
+
+```json
+{"detail": "Stage still has Deals attached."}
+```
+
+Migrate deals off the stage first.
+
+## Sample list response (truncated)
+
+```json
+{
+  "count": 1,
+  "next_page": null,
+  "previous_page": null,
+  "results": [
+    {
+      "id": 1, "platform": 1, "name": "Default Pipeline", "code": "default",
+      "is_default": true, "rotten_days": 30,
+      "stages": [
+        {"id": 1, "pipeline": 1, "code": "new", "name": "New", "probability": 10, "sort_order": 0, "is_won": false, "is_lost": false, "metadata": {}},
+        {"id": 5, "pipeline": 1, "code": "won", "name": "Won", "probability": 100, "sort_order": 4, "is_won": true, "is_lost": false, "metadata": {}},
+        {"id": 6, "pipeline": 1, "code": "lost", "name": "Lost", "probability": 0, "sort_order": 5, "is_won": false, "is_lost": true, "metadata": {}}
+      ],
+      "metadata": {}
+    }
+  ]
+}
+```

--- a/skills/iblai-crm-deal-flow/references/state-machine.md
+++ b/skills/iblai-crm-deal-flow/references/state-machine.md
@@ -1,0 +1,205 @@
+# Deal Lifecycle — State Machine
+
+Full text of the CRM doc [Deal Lifecycle](../../../../docs/developer/applications/crm.md#9-deal-lifecycle).
+
+A Deal moves through the stages of its Pipeline and reports a high-level
+`status` of `open`, `won`, or `lost`. Both `status` and `closed_at` are
+**derived** from the stage the Deal currently sits in — they are never
+written directly. Anything that needs to change where a Deal lives in the
+pipeline goes through one of three action endpoints, and each one writes
+an audit row and fires a notification so the timeline and the inbox stay
+in sync with the kanban.
+
+This is the contract for that flow: which endpoints to call, which fields
+are off-limits to PATCH, what the audit row looks like, what happens under
+concurrency, and what counts as a no-op.
+
+## 1. The three transitions
+
+There are exactly three endpoints that change a Deal's stage. Everything
+else — list, retrieve, create, partial update of metadata — leaves the
+stage alone.
+
+### `POST /api/crm/deals/{id}/move-stage/`
+
+- Body: `{"stage_id": <int>}` OR `{"stage_code": "<slug>"}`
+- Moves the Deal to any stage in its Pipeline (initial, intermediate, or
+  terminal).
+- Use this for kanban drag-and-drop and for explicit stage pickers.
+
+### `POST /api/crm/deals/{id}/won/`
+
+- Body (optional): `{"stage_code": "<slug>"}`
+- Moves the Deal to a terminal won stage. If `stage_code` is omitted, the
+  API resolves the first stage in the Pipeline with `is_won: true`, ordered
+  by `sort_order`.
+- Use this for the "Mark as Won" button on a Deal detail page.
+
+### `POST /api/crm/deals/{id}/lost/`
+
+- Body: `{"lost_reason": "<string>", "stage_code": "<slug>?"}`
+- `lost_reason` is **REQUIRED** — the API returns 400 if it is missing or
+  blank. `stage_code` is optional and falls back to the first terminal
+  lost stage by `sort_order`.
+- Use this for the "Mark as Lost" modal, which should always collect a
+  reason before submitting.
+
+All three return the updated Deal on success and the standard error
+envelope on failure.
+
+## 2. Read-only fields
+
+`status` and `closed_at` are server-managed and cannot be set by the client.
+
+- A PATCH or PUT against `/api/crm/deals/{id}/` that includes `status` or
+  `closed_at` returns `400` with a field-level error message naming the
+  offending field.
+- The fix is to call one of the three action endpoints above. Do not
+  surface `status` or `closed_at` in a Deal edit form; they belong on the
+  transition controls.
+
+`stage` is also not directly writable on update — to change the stage,
+call `move-stage/`, `won/`, or `lost/`. Direct stage assignment is reserved
+for Deal creation.
+
+## 3. Audit trail
+
+Every successful stage move that actually changes the Deal's stage writes
+a system Activity. No-ops (see [Idempotency](#6-idempotency)) do not.
+
+The audit Activity is shaped like this:
+
+| Field | Value |
+|---|---|
+| `type` | `note` |
+| `is_done` | `true` |
+| `done_at` | transition time |
+| `title` | `"Stage changed"` |
+| `comment` | `"<From Display Name> → <To Display Name>"` — uses the human-readable stage names, not slugs (for example `"Negotiation → Closed Won"`, not `"negotiation → closed-won"`) |
+| `owner` | the user who triggered the transition (the authenticated caller; null for service-account callers without an underlying user) |
+| `deal` | the Deal that moved |
+| `person` | the Deal's `person`, so the audit row also surfaces in person-centric timelines |
+
+Listing activities filtered by `?deal={id}` returns these system rows
+interleaved with user-logged Activities (calls, meetings, tasks, notes).
+To make the timeline readable:
+
+- Render system stage-change rows with a distinct icon (an arrow or
+  pipeline glyph works well) and a muted background.
+- Do not show edit or "mark done" controls on them — they are already
+  `is_done: true` and they describe an event, not a task.
+- Keep them in chronological order with the rest of the timeline so reps
+  can read the full story of the Deal in one pass.
+
+See `/iblai-crm-activity` for the full timeline rendering contract.
+
+## 4. Notification
+
+Every successful, non-no-op stage move fires a `CRM_DEAL_STAGE_CHANGED`
+notification. The notification carries the Deal, the from-stage, the
+to-stage, and the user who triggered the move. Routing follows the
+standard CRM `RecipientsConfig` rules — owner, configured admins, or a
+custom list per Platform.
+
+See `/iblai-crm-notification` for the full context payload, the available
+channels, and how to wire recipient routing per Platform.
+
+## 5. Concurrency
+
+Stage moves on the same Deal are serialized.
+
+When the API processes any of the three transition endpoints, it acquires
+a row lock on the Deal before reading its current stage, writing the new
+one, recording the audit row, and firing the notification. If two requests
+land at the same time — a kanban drag racing with someone clicking the
+Won button, or two reps acting on the same Deal — one wins and runs to
+completion, then the other proceeds against the now-updated state.
+
+The practical consequences:
+
+- Exactly one stage transition is recorded per logical move. You never
+  get two audit rows for what was conceptually one drag.
+- Exactly one `CRM_DEAL_STAGE_CHANGED` notification is fired per logical
+  move. Recipients do not get duplicates.
+- The losing request still gets a successful response (or a no-op
+  response, if the winner happened to move the Deal to the same stage the
+  loser was targeting).
+
+The UI does not need to coordinate clients. The lock does the work. What
+the UI should do is **refresh the Deal after a successful transition** so
+the displayed stage matches reality, since another user's action may have
+run in between.
+
+## 6. Idempotency
+
+The three transitions are idempotent with respect to the Deal's current
+stage. Calling them when the Deal is already where you are asking it to
+go is a no-op:
+
+- `move-stage/` to the current stage: no write, no audit row, no signal,
+  no notification. Returns `200` with the unchanged Deal.
+- `won/` on a Deal already in its won stage: no-op. Returns `200`.
+- `lost/` on a Deal already in its lost stage: the stage transition is a
+  no-op (no audit row, no signal, no notification), **but `lost_reason`
+  is overwritten unconditionally with whatever value is in the request
+  body**. Pass the original reason on retries, or PATCH the Deal directly
+  if you want to change only the reason without re-firing the lost action.
+
+This means clients can safely retry transition requests on transient
+network failures without worrying about double-recording the move.
+
+## 7. Re-opening a Deal
+
+Won and lost are not one-way doors. Moving a Deal in a terminal stage
+back to a non-terminal stage re-opens it:
+
+- `status` flips back to `open`.
+- `closed_at` is cleared.
+- An audit Activity is still written (`"Closed Won → Negotiation"`, for
+  example).
+- A `CRM_DEAL_STAGE_CHANGED` notification still fires, so the owner and
+  configured admins know the Deal is live again.
+
+Use `move-stage/` to re-open. There is no dedicated "reopen" endpoint —
+the stage move IS the reopen, and the derived `status` follows the
+destination stage's `is_won` / `is_lost` flags.
+
+## 8. Diagram — winning a deal
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant API as CRM API
+    participant Recipients as Notification recipients
+    C->>API: POST /deals/{id}/won/
+    API->>API: Resolve target stage (first is_won)
+    API->>API: Lock deal row
+    API->>API: Update stage + status + closed_at
+    API->>API: Write audit Activity ("Stage changed: Negotiation → Closed Won")
+    API->>Recipients: CRM_DEAL_STAGE_CHANGED notification
+    API-->>C: 200 Deal (status: won, closed_at set)
+```
+
+## State diagram — derived status
+
+```
+                  move-stage(non-terminal)
+                 ┌───────────────────────────────┐
+                 │                               ▼
+            ┌────────┐   move-stage(is_won)   ┌────────┐
+            │  open  │ ─────── won/ ────────► │  won   │
+            └────────┘                        └────────┘
+                 │                               │
+                 │ move-stage(is_lost)           │ move-stage(non-terminal) → re-open
+                 │      lost/                    ▼
+                 │                          ┌────────┐
+                 └────────────────────────► │  lost  │
+                                            └────────┘
+                                                │
+                                                │ move-stage(non-terminal) → re-open
+                                                ▼
+                                            (back to open)
+```
+
+Every arrow above (except no-op self-loops) writes one audit Activity
+and fires one `CRM_DEAL_STAGE_CHANGED` notification.

--- a/skills/iblai-crm-lead-flow/SKILL.md
+++ b/skills/iblai-crm-lead-flow/SKILL.md
@@ -1,0 +1,433 @@
+---
+name: iblai-crm-lead-flow
+description: Build the CRM top-of-funnel surface — lead-capture form, contacts table with lifecycle filter, organization records, and the three person onboarding actions (link existing Platform user, invite by email, merge duplicates). Use when the user mentions CRM leads, contacts, people, persons, organizations, lead capture, contact intake, link to user, invite by email, merge duplicates, or lifecycle stage. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-deal-flow to open a deal once a person exists, /iblai-crm-activity for the timeline, /iblai-crm-tag for tag chips, /iblai-crm-notification for the events this flow fires, /iblai-rbac for CRM Inviter/User/Manager roles, and /iblai-auth for token wiring.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-lead-flow
+
+Build the people-and-organizations surface of the CRM: capture leads, list
+contacts, view person detail, manage organizations, and run the three
+onboarding actions (link, invite, merge).
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for person and organization
+  CRUD. Add the **CRM Inviter** role on top if you need
+  `POST /persons/{id}/invite/`. See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+- A **lead-capture form** that POSTs to `/api/crm/persons/` with
+  `name`, `primary_email`, `lifecycle_stage`, optional `organization`,
+  and free-form `metadata`.
+- A **contacts table** at `/crm/contacts` with a lifecycle-stage
+  filter, owner filter, and tag filter, backed by
+  `GET /api/crm/persons/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **person detail panel** that loads `GET /api/crm/persons/{id}/`
+  and exposes three onboarding action buttons: **Link to user**,
+  **Invite by email**, **Merge duplicates**.
+- An **organizations table + form** at `/crm/organizations` for
+  `GET`/`POST /api/crm/organizations/`.
+- An **action-result toast** layer so the silent-refusal footgun on
+  `link-user/` is surfaced loudly.
+
+Reference tables for every endpoint live in:
+
+- `references/persons-api.md`
+- `references/organizations-api.md`
+- `references/onboarding-flows.md`
+
+## Step 1: Install shadcn primitives
+
+The contacts table, lead form, detail panel, and the link/invite/merge
+dialogs use only shadcn primitives. Install once:
+
+```bash
+npx shadcn@latest add form table dialog select badge input textarea
+```
+
+Do not write custom replacements for these — they share the ibl.ai
+Tailwind theme automatically.
+
+## Step 2: Add a typed CRM API client
+
+Reuse the auth token that `/iblai-auth` wrote into `.env.local`
+(`NEXT_PUBLIC_API_BASE_URL`, and the user token read from localStorage
+under the same key `/iblai-auth` uses). Do NOT introduce a new
+token-management layer.
+
+Create `lib/iblai/crm-client.ts`:
+
+```ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+function token() {
+  // /iblai-auth stores the access token in localStorage. Reuse it.
+  return typeof window !== "undefined"
+    ? localStorage.getItem("ibl_access_token") ?? ""
+    : "";
+}
+
+async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Token ${token()}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw Object.assign(new Error(res.statusText), { status: res.status, body });
+  }
+  return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+}
+
+export type Page<T> = {
+  count: number;
+  next_page: number | null;
+  previous_page: number | null;
+  results: T[];
+};
+
+export type LifecycleStage =
+  | "lead"
+  | "qualified"
+  | "opportunity"
+  | "customer"
+  | "churned";
+
+export type Person = {
+  id: string;
+  platform: number | string;
+  name: string;
+  primary_email: string | null;
+  emails: { label: string; email: string }[];
+  contact_numbers: { label: string; number: string }[];
+  job_title: string;
+  organization: string | null;
+  owner: number | null;
+  platform_user: number | null;
+  lifecycle_stage: LifecycleStage;
+  unique_id: string;
+  active: boolean;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Organization = {
+  id: string;
+  platform: number | string;
+  name: string;
+  address: Record<string, unknown>;
+  owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export const crm = {
+  // Persons
+  listPersons: (q: URLSearchParams) =>
+    call<Page<Person>>(`/persons/?${q.toString()}`),
+  getPerson: (id: string) => call<Person>(`/persons/${id}/`),
+  createPerson: (body: Partial<Person>) =>
+    call<Person>(`/persons/`, { method: "POST", body: JSON.stringify(body) }),
+  patchPerson: (id: string, body: Partial<Person>) =>
+    call<Person>(`/persons/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+  deletePerson: (id: string) =>
+    call<void>(`/persons/${id}/`, { method: "DELETE" }),
+  linkUser: (id: string, user_id: number) =>
+    call<Person>(`/persons/${id}/link-user/`, {
+      method: "POST",
+      body: JSON.stringify({ user_id }),
+    }),
+  invite: (
+    id: string,
+    body: {
+      is_admin?: boolean;
+      is_staff?: boolean;
+      enrollment_config?: Record<string, unknown>;
+      redirect_to?: string;
+    },
+  ) =>
+    call<{
+      person_id: string;
+      invitation_id: number;
+      invitation_email: string;
+      platform_key: string;
+      auto_accept: boolean;
+      active: boolean;
+      redirect_to: string | null;
+      created: string | null;
+    }>(`/persons/${id}/invite/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  merge: (primary_id: string, duplicate_ids: string[]) =>
+    call<{
+      primary_id: string;
+      merged_ids: string[];
+      reparented: { deals: number; activities: number; tags: number };
+    }>(`/persons/merge/`, {
+      method: "POST",
+      body: JSON.stringify({ primary_id, duplicate_ids }),
+    }),
+
+  // Organizations
+  listOrgs: (q: URLSearchParams) =>
+    call<Page<Organization>>(`/organizations/?${q.toString()}`),
+  getOrg: (id: string) => call<Organization>(`/organizations/${id}/`),
+  createOrg: (body: Partial<Organization>) =>
+    call<Organization>(`/organizations/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+};
+```
+
+All examples in the references send `Authorization: Token …` — this
+client does the same.
+
+## Step 3: Lead-capture form
+
+Page route: `app/crm/leads/new/page.tsx`. Fields:
+
+- `name` — required, text input.
+- `primary_email` — recommended; auto-link binds on Platform signup.
+- `lifecycle_stage` — `Select` defaulting to `lead`
+  (`lead | qualified | opportunity | customer | churned`).
+- `organization` — `Select` populated from
+  `crm.listOrgs(new URLSearchParams())`.
+- `metadata` — `textarea`, parsed as JSON before submit.
+
+Submit calls `crm.createPerson({...})`. On `201` redirect to
+`/crm/contacts/{id}`. Handle:
+
+- `400` with a `unique_id` array → show the server message under the
+  `unique_id` field (duplicate import key).
+- `403` → "You need the CRM User role to create contacts" (cross-ref
+  `/iblai-rbac`).
+
+Full field table: [`POST /persons/` in the Persons API reference](references/persons-api.md#post-persons).
+
+## Step 4: Contacts table
+
+Page route: `app/crm/contacts/page.tsx`. Fetch via
+`crm.listPersons(query)` where `query` is built from URL search params:
+
+- `lifecycle_stage` — `Select` with the five stages plus "All".
+- `owner` — numeric input or owner picker.
+- `tags` — multi-select; emit `?tags=1&tags=2` (OR semantics, results
+  de-duplicated server-side).
+- `page` / `page_size` — pagination, max `page_size=100`.
+
+Render rows in a shadcn `Table`. Columns: name, primary_email,
+lifecycle stage (`Badge`), owner, tags (chip per item). Wire pagination
+off the `{count, next_page, previous_page, results}` envelope — do not
+assume cursor pagination.
+
+Each row links to `/crm/contacts/{id}`.
+
+## Step 5: Person detail panel + onboarding actions
+
+Page route: `app/crm/contacts/[id]/page.tsx`. Load via
+`crm.getPerson(id)`. Display name, email, lifecycle stage,
+organization, owner, `platform_user` (when set), tags, metadata, and
+the three action buttons described below.
+
+### 5a. Link to existing Platform user
+
+Dialog with a single `user_id` numeric input. On submit:
+
+```ts
+const linked = await crm.linkUser(person.id, Number(userId));
+
+// SILENT-REFUSAL FOOTGUN: a 200 response whose platform_user
+// does NOT equal the requested user_id means the person was already
+// bound to a different user and the existing binding was preserved.
+// You MUST assert equality client-side before claiming success.
+if (linked.platform_user !== Number(userId)) {
+  toast.error(
+    `This person is already linked to user ${linked.platform_user}. ` +
+      `The existing binding was preserved.`,
+  );
+} else {
+  toast.success("Linked to Platform user.");
+}
+```
+
+Status codes to handle: `400` (missing/wrong `user_id`), `403` (target
+user has no active `UserPlatformLink` — surface "issue an invitation
+instead"), `404` (person or user does not exist). Full table:
+[the Link flow in the onboarding reference](references/onboarding-flows.md#1-link-an-existing-platform-user).
+
+### 5b. Invite by email
+
+Dialog with `is_admin` and `is_staff` checkboxes, optional
+`enrollment_config` (textarea, JSON), and optional `redirect_to` URL.
+Requires the person to have a `primary_email`.
+
+Status codes:
+
+| Code | Meaning |
+|------|---------|
+| `201` | Invitation queued. Show success toast. |
+| `400` | Person has no `primary_email`. Disable the button when null. |
+| `403` | Caller missing `Ibl.CRM/Invite/action` (CRM Inviter role). |
+| `404` | Person not found. |
+| `409` | Active invitation already exists. Body contains `invitation_id` — treat as "already done", offer a "resend" affordance. |
+| `422` | Person already linked to a Platform user. Hide the button when `platform_user` is set. |
+
+Full body and field list: [the Invite flow in the onboarding reference](references/onboarding-flows.md#2-invite-by-email).
+
+### 5c. Merge duplicates
+
+Dialog with a multi-select of duplicate person rows to merge into the
+current (primary) person. Submit:
+
+```ts
+const result = await crm.merge(primaryId, duplicateIds);
+// result.reparented = { deals, activities, tags }
+toast.success(
+  `Merged ${result.merged_ids.length} duplicates. ` +
+    `Reparented ${result.reparented.deals} deals, ` +
+    `${result.reparented.activities} activities, ` +
+    `${result.reparented.tags} tag assignments.`,
+);
+```
+
+Status codes: `400` (primary in `duplicate_ids`, empty
+`duplicate_ids`, cross-Platform duplicate), `403`, `404`. Duplicates
+are **soft-deleted** (`active=false`); their rows are still
+retrievable by id, so list views must filter on `active=true`.
+
+## Step 6: Organizations table + form
+
+Page route: `app/crm/organizations/page.tsx`. Use
+`crm.listOrgs(query)` with `?name=<substring>&owner=<id>&tags=…`.
+Render in a shadcn `Table` with name, owner, tags, created_at.
+
+Create form at `app/crm/organizations/new/page.tsx`:
+
+- `name` — required, must be unique within the Platform
+  (case-sensitive, trimmed). Handle `400 {"name": ["… already exists …"]}`
+  by surfacing the message inline.
+- `address` — free-form JSON `textarea` (the recommended shape
+  `{street, city, state, zip, country}` is a hint, not enforced).
+- `owner` — optional numeric.
+- `metadata` — free-form JSON.
+
+Deleting an organization sets `Person.organization` and
+`Deal.organization` to `null` on every referencing row — there is no
+cascade-delete. Tag assignments on the organization are removed. Full
+shape: `references/organizations-api.md`.
+
+## Auto-link signal
+
+You do not need to call any endpoint for this — but you must build for
+it. When a Platform user is created (signup, invitation acceptance,
+admin) and their email matches a Person's `primary_email`
+(case-insensitive) on a Platform they belong to, the system
+asynchronously sets `platform_user`, flips `active` from `true` to
+`false`, and fires a `CRM_PERSON_LINKED_TO_USER` notification.
+
+Two UI consequences:
+
+- A `GET /persons/{id}/` issued seconds after signup may still show
+  `active: true` and `platform_user: null`. Build polling or a
+  notification-driven refresh into any view that surfaces this state.
+- A row can disappear from an "active people" list between page loads
+  with no operator action in between. Tolerate the transition; do not
+  crash on missing rows.
+
+The notification fires regardless of whether your CRM UI is open.
+Cross-ref `/iblai-crm-notification` for recipient routing and how to
+subscribe an inbox.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done.
+
+```bash
+pnpm build         # must pass with zero errors
+pnpm typecheck
+pnpm dev &
+npx playwright screenshot http://localhost:3000/crm/leads/new       /tmp/crm-lead.png
+npx playwright screenshot http://localhost:3000/crm/contacts        /tmp/crm-contacts.png
+npx playwright screenshot http://localhost:3000/crm/organizations   /tmp/crm-orgs.png
+```
+
+Smoke checklist:
+
+- [ ] Create a Person via the lead form → row appears in contacts table.
+- [ ] Filter the contacts table by `lifecycle_stage=qualified`.
+- [ ] Open the detail panel; click **Link to user** with a known
+      `user_id` and confirm `platform_user === user_id`.
+- [ ] Repeat **Link to user** with the same `user_id` on a person
+      already bound elsewhere — confirm the silent-refusal toast fires
+      (response is 200, but `platform_user` differs).
+- [ ] **Invite by email** a person with a `primary_email`; the second
+      attempt returns 409 with the same `invitation_id`.
+- [ ] **Merge** two duplicates into a primary; confirm
+      `reparented.{deals,activities,tags}` counts are returned.
+- [ ] Create an Organization; deleting it does not cascade-delete
+      Persons that referenced it.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults, links to every sibling skill.
+- `/iblai-crm-deal-flow` — once a person exists, open a deal on the kanban.
+- `/iblai-crm-activity` — log timeline events (calls, meetings, notes, tasks) on a person.
+- `/iblai-crm-tag` — tag CRUD and chip components for people and organizations.
+- `/iblai-crm-notification` — `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER` fire from this flow.
+- `/iblai-rbac` — CRM Inviter / CRM User / CRM Manager roles and the action-definitions endpoint.
+- `/iblai-auth` — token wiring this skill reuses.

--- a/skills/iblai-crm-lead-flow/references/onboarding-flows.md
+++ b/skills/iblai-crm-lead-flow/references/onboarding-flows.md
@@ -1,0 +1,268 @@
+# Person Onboarding — Link / Invite / Merge
+
+Condensed from the [Person Onboarding section of the CRM doc](../../../../docs/developer/applications/crm.md#8-person-onboarding-link-invite-merge). People in the CRM start as records — rows
+holding emails, lifecycle stage, ownership, tags — that are not yet
+real Platform accounts. They become first-class Platform users in one
+of three explicit ways (link, invite, merge), plus one implicit signal
+(auto-link). All examples send `Authorization: Token <token>`.
+
+## Decision tree
+
+Pick the right endpoint before you call anything.
+
+```
+Is there already a Platform user for this person?
+├── Yes, user_id is known         → POST /persons/{id}/link-user/
+├── No, but the person has email  → POST /persons/{id}/invite/
+└── Duplicate person rows         → POST /persons/merge/
+```
+
+The three branches are **not interchangeable**:
+
+| Branch | Precondition | What it produces |
+|--------|--------------|------------------|
+| Link   | Target Platform user already exists with an active membership | Person bound immediately (`platform_user` set, `active=false`) |
+| Invite | Person has a `primary_email` | Platform invitation row; user is created **only** when the invitee accepts |
+| Merge  | Two or more person rows for the same human | Deals / activities / tags re-parented onto a primary; duplicates soft-deleted |
+
+---
+
+## 1. Link an existing Platform user
+
+`POST /api/crm/persons/{id}/link-user/`
+
+**Request**
+
+```json
+{ "user_id": 1184 }
+```
+
+**Response** `200 OK` — full Person object. On success:
+`platform_user` is set to the requested `user_id` and `active` flips
+to `false`. Once bound, the Platform user is the source of truth and
+the person row becomes historical sales context.
+
+### Silent-refusal footgun
+
+The link service refuses to rebind a person that is already bound to a
+**different** Platform user. There is no error response — the call
+returns **200 OK** with the existing binding untouched. Clients
+**MUST** verify equality:
+
+```ts
+const linked = await crm.linkUser(personId, requestedUserId);
+if (linked.platform_user !== requestedUserId) {
+  // Refusal: this person is already linked to someone else.
+  // Surface "already linked to user X" — DO NOT claim success.
+}
+```
+
+Silent rebinds would erase a prior link without trace, so they are
+forbidden by design.
+
+### Status codes
+
+| Code | When |
+|------|------|
+| `200` | Linked **OR** silent refusal — compare `platform_user` to your request. |
+| `400` | `user_id` missing or wrong type. |
+| `403` | Target user has no active `UserPlatformLink` to this Platform — *"issue an invitation instead."* |
+| `404` | Person not found in this Platform, or `user_id` does not exist. |
+
+**RBAC:** `Ibl.CRM/Persons/write`. The target user must additionally
+have an active membership in the same Platform.
+
+---
+
+## 2. Invite by email
+
+`POST /api/crm/persons/{id}/invite/`
+
+Use this when the person is **not** yet a Platform user. The
+invitation reuses the standard Platform invitation pipeline. On
+acceptance a Platform user is created and the auto-link signal
+(section 4) binds the person automatically.
+
+**Request**
+
+```json
+{
+  "is_admin": false,
+  "is_staff": false,
+  "redirect_to": "https://app.example.com/dashboard"
+}
+```
+
+- `is_admin` / `is_staff` — privileges granted on acceptance. Both
+  default to `false`.
+- `redirect_to` — URL the invitee lands on after accepting. Omit for
+  the Platform default. Max 255 chars.
+- `enrollment_config` — optional object forwarded to the invitation
+  for auto-enrollment in courses, programs, or pathways.
+
+**Response** `201 Created`
+
+```json
+{
+  "person_id": "<uuid>",
+  "invitation_id": 9821,
+  "invitation_email": "alice@example.com",
+  "platform_key": "acme",
+  "auto_accept": true,
+  "active": true,
+  "redirect_to": "https://app.example.com/dashboard",
+  "created": "2026-06-04T09:24:01Z"
+}
+```
+
+The response confirms the invitation row was created — it does **not**
+guarantee the email landed; delivery happens out-of-band.
+
+### Status codes
+
+| Code | When |
+|------|------|
+| `201` | Invitation created and queued for delivery. |
+| `400` | Person has no `primary_email` — cannot invite. Disable the button when `primary_email` is null. |
+| `403` | Caller missing `Ibl.CRM/Invite/action`. |
+| `404` | Person not found in this Platform. |
+| `409` | Active invitation already exists for this email + Platform. **Informational, not a hard error** — the body carries the pre-existing `invitation_id`. Treat as "already done"; offer a "resend" affordance. |
+| `422` | Person already linked to a Platform user (`platform_user` is set). Hide the button. |
+
+**409 body shape**
+
+```json
+{
+  "detail": "Active PlatformInvitation already exists for this email + platform.",
+  "invitation_id": 9821,
+  "person_id": "<uuid>",
+  "platform_key": "acme"
+}
+```
+
+**RBAC:** `Ibl.CRM/Invite/action` — a **separate bucket** from
+person-write. A role that can fully edit and delete people but does
+not carry `Ibl.CRM/Invite/action` cannot send invitations. This is
+deliberate: invitations send email and grant Platform access, so the
+privilege is split out. See `/iblai-rbac` for the CRM Inviter role.
+
+---
+
+## 3. Merge duplicates
+
+`POST /api/crm/persons/merge/`
+
+Duplicates appear when the same human shows up through two channels —
+a CSV import plus a webform submission, two integrations pointing at
+the same address, a marketing list collision. Merge re-parents related
+records onto a chosen primary and marks the rest inactive.
+
+**Request**
+
+```json
+{
+  "primary_id": "<uuid>",
+  "duplicate_ids": ["<uuid>", "<uuid>"]
+}
+```
+
+**Response** `200 OK`
+
+```json
+{
+  "primary_id": "<uuid>",
+  "merged_ids": ["<uuid>", "<uuid>"],
+  "reparented": { "deals": 7, "activities": 23, "tags": 4 }
+}
+```
+
+### What re-parents
+
+In a single transaction:
+
+- **Deals** — every deal that pointed at a duplicate now points at the primary.
+- **Activities** — calls, meetings, tasks, notes are re-attached to the primary.
+- **Tag assignments** — moved across, with one wrinkle: if the primary already carries the same tag, the duplicate's assignment is **dropped silently** (the `(tag, person)` unique constraint forbids stacking). The `reparented.tags` count reflects every assignment **touched** — both moves and drops — not just successful moves. For exact post-merge counts, compare before/after listings.
+
+### What happens to duplicates
+
+Duplicates are **not deleted**. Each duplicate's `active` flag is set
+to `false` and the row remains retrievable by id. This preserves audit
+trail and lets you investigate later — but it also means a
+`GET /persons/{duplicate_id}/` after a merge returns the inactive row,
+not a 404. Filter on `active=true` if your UI should hide them.
+
+### Status codes
+
+| Code | When |
+|------|------|
+| `200` | Merge complete (or no-op rerun — counts are zero). |
+| `400` | `primary_id` appears in `duplicate_ids`, `duplicate_ids` empty, or cross-Platform duplicate. |
+| `403` | Caller missing `Ibl.CRM/Persons/write`. |
+| `404` | Primary not found in this Platform. |
+
+**RBAC:** `Ibl.CRM/Persons/write`. Cross-Platform merges are
+explicitly forbidden — every id must resolve to a person on the
+caller's Platform.
+
+---
+
+## 4. Auto-link signal (implicit)
+
+There is a fourth, implicit path. When a Platform user is created —
+through signup, invitation acceptance, or admin action — the system
+asynchronously walks the CRM and binds any matching person records
+automatically. This is what makes bulk-imported person rows
+"come to life" as their invitees register.
+
+### Matching rules
+
+After a Platform user is created with an active membership for a
+Platform, the system searches that Platform for person rows where:
+
+- `primary_email` equals the new user's email (case-insensitive), **or** `platform_user` is already set to that user,
+- `active` is `true`,
+- the person belongs to a Platform the user is an active member of.
+
+For every match: `platform_user` is set, `active` is flipped to
+`false`, and a **`CRM_PERSON_LINKED_TO_USER`** notification is
+dispatched. Cross-ref `/iblai-crm-notification`.
+
+The match is gated by Platform membership — a new user with email
+`alice@example.com` only auto-links to person rows on Platforms they
+actually belong to. Cross-Platform leakage is not possible through
+this path.
+
+### Sequence
+
+```
+1. App                POST /persons/  { primary_email: "alice@x.com" }
+2. CRM API            201 Person       (active: true, platform_user: null)
+   ... later ...
+3. alice@x.com signs up as a Platform user
+4. Background worker  matches persons by primary_email
+5. CRM API            sets platform_user, flips active → false
+6. Notification       CRM_PERSON_LINKED_TO_USER dispatched
+```
+
+### State-transition callout — build for it
+
+The auto-link runs in the background, so the response that created
+the Platform user returns **before** the link completes. Two
+consequences for clients:
+
+- A `GET /persons/{id}/` issued moments after a signup may still show
+  `active: true` and `platform_user: null`. A retry seconds later
+  shows the linked state. Build polling or a notification-driven
+  refresh into any UI that surfaces this.
+- A person can flip from `active: true` to `active: false` between
+  page loads with no operator action in between. UIs that render a
+  list of "active people" must tolerate rows disappearing on the next
+  fetch; never crash on the transition.
+
+### Edge cases
+
+- A user with no email is **skipped** — the system will not bulk-link every blank-`primary_email` person to a fresh emailless user.
+- A user with no active Platform memberships is **skipped** — no Platforms to scan.
+- A person already bound to a different Platform user is **left alone** (the silent-refusal rule from [Link an existing Platform user](../../../../docs/developer/applications/crm.md#81-link-an-existing-platform-user) applies here too).
+- Re-running auto-link for the same user is a no-op once everything is bound; it is safe to retry on background-task failures.

--- a/skills/iblai-crm-lead-flow/references/organizations-api.md
+++ b/skills/iblai-crm-lead-flow/references/organizations-api.md
@@ -1,0 +1,156 @@
+# Organizations API — Reference
+
+Condensed from the [Organizations API section of the CRM doc](../../../../docs/developer/applications/crm.md#72-organizations). Every endpoint is scoped to the caller's
+Platform. All examples send `Authorization: Token <token>`.
+
+**Base path:** `/api/crm/organizations/`
+
+**Pagination envelope** (shared across the CRM):
+
+```json
+{
+  "count": 0,
+  "next_page": null,
+  "previous_page": null,
+  "results": []
+}
+```
+
+## Endpoint summary
+
+| Method | Path | RBAC | Purpose |
+|--------|------|------|---------|
+| `GET`    | `/organizations/`                            | `Ibl.CRM/Organizations/list`   | List organizations in your Platform |
+| `POST`   | `/organizations/`                            | `Ibl.CRM/Organizations/action` | Create an organization |
+| `GET`    | `/organizations/{id}/`                       | `Ibl.CRM/Organizations/read`   | Retrieve one organization |
+| `PUT`    | `/organizations/{id}/`                       | `Ibl.CRM/Organizations/write`  | Replace all editable fields |
+| `PATCH`  | `/organizations/{id}/`                       | `Ibl.CRM/Organizations/write`  | Patch a subset of fields |
+| `DELETE` | `/organizations/{id}/`                       | `Ibl.CRM/Organizations/delete` | Hard-delete an organization |
+| `POST`   | `/organizations/{id}/tags/`                  | `Ibl.CRM/Tags/write`           | Attach a Tag (see `/iblai-crm-tag`) |
+| `DELETE` | `/organizations/{id}/tags/{tag_id}/`         | `Ibl.CRM/Tags/write`           | Detach a Tag |
+
+## Organization object
+
+| Field | Type | R/W | Notes |
+|-------|------|-----|-------|
+| `id` | UUID | R | Server-assigned. |
+| `platform` | string/int | R | Set server-side from the auth token. |
+| `name` | string | RW | Display name. **Unique per Platform**, case-sensitive, trimmed of surrounding whitespace before comparison. Max 255 chars. |
+| `address` | object | RW | **Free-form JSON.** Recommended (but not enforced) shape: `{street, city, state, zip, country}`. |
+| `owner` | int \| null | RW | Platform user id of the internal account manager. Must be an active member of your Platform. |
+| `tags` | `{id,name,color}[]` | R | Always present; empty array when none. |
+| `metadata` | object | RW | Free-form JSON. |
+| `created_at` / `updated_at` | ISO 8601 | R | Server-managed. |
+
+---
+
+## `GET /organizations/`
+
+Paginated list.
+
+**Query parameters**
+
+| Name | Type | Notes |
+|------|------|-------|
+| `owner` | int | Filter by owning Platform user id |
+| `name` | string | Case-insensitive substring match |
+| `tags` | int (repeatable) | OR semantics; results de-duplicated |
+| `page` / `page_size` | int | `page_size` max 100 |
+
+Response is the pagination envelope with `results: Organization[]`.
+
+```bash
+curl "https://api.iblai.app/dm/api/crm/organizations/?name=acme" \
+  -H "Authorization: Token <token>"
+```
+
+---
+
+## `POST /organizations/`
+
+Create an organization. `platform` is set server-side.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Unique per Platform (case-sensitive, trimmed). Max 255 chars. |
+| `address` | object | No | Free-form JSON. Defaults to `{}`. |
+| `owner` | int | No | Active member of your Platform. |
+| `metadata` | object | No | Free-form JSON. Defaults to `{}`. |
+
+**Response** `201 Created` — full Organization object.
+
+**Errors**
+
+| Code | Cause | Sample body |
+|------|-------|-------------|
+| `400` | Duplicate name | `{"name":["An Organization with name 'Acme Inc' already exists on this Platform."]}` |
+| `400` | Blank name | `{"name":["Name must not be blank."]}` |
+| `403` | Missing `Ibl.CRM/Organizations/action` | — |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/organizations/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Acme Inc","address":{"city":"New York"},"metadata":{"industry":"edtech"}}'
+```
+
+---
+
+## `GET /organizations/{id}/`
+
+Retrieve one. `200 OK` returns the full Organization; `404 Not Found`
+when the row is missing or belongs to another Platform (existence is
+not leaked).
+
+---
+
+## `PUT /organizations/{id}/`
+
+Replace every editable field. Same body shape as `POST /organizations/`.
+Server-managed fields (`id`, `platform`, `created_at`, `updated_at`)
+are ignored if sent.
+
+**Responses:** `200 OK`, `400`, `404`.
+
+---
+
+## `PATCH /organizations/{id}/`
+
+Partial update — only fields present in the body are touched.
+
+**Responses:** `200 OK`, `400`, `404`.
+
+---
+
+## `DELETE /organizations/{id}/`
+
+Hard-delete the organization.
+
+**No cascade.** Persons and Deals that referenced the deleted org are
+**kept**; their `organization` foreign key is set to `null` on every
+row. Tag assignments on the organization are removed.
+
+Practical UI implication: deleting an org from this skill's
+organizations table will not delete its Persons (rendered in the
+contacts table by `/iblai-crm-lead-flow`) or Deals (rendered by
+`/iblai-crm-deal-flow`) — those rows will simply lose their
+`organization` link. Surface this in the confirm dialog.
+
+**Responses:** `204 No Content`, `404`.
+
+---
+
+## `POST /organizations/{id}/tags/` and `DELETE /organizations/{id}/tags/{tag_id}/`
+
+Same shape as the person tag endpoints.
+
+| Code | Meaning |
+|------|---------|
+| `201` | Attached. Response: `{ "assignment_id": <int>, "tag": {id,name,color} }`. |
+| `409` | Already attached. Body includes existing `assignment_id`. |
+| `404` | Tag not found / wrong Platform (attach), or tag was not attached (detach). |
+| `204` | Detach success. |
+
+See `/iblai-crm-tag` for tag CRUD.

--- a/skills/iblai-crm-lead-flow/references/persons-api.md
+++ b/skills/iblai-crm-lead-flow/references/persons-api.md
@@ -1,0 +1,323 @@
+# Persons API — Reference
+
+Condensed from the [Persons API section of the CRM doc](../../../../docs/developer/applications/crm.md#71-persons). Every endpoint is scoped to the caller's
+Platform; cross-Platform reads return `404` and cross-Platform writes
+are rejected. All examples send `Authorization: Token <token>`.
+
+**Base path:** `/api/crm/persons/`
+
+**Pagination envelope** (used by every list endpoint in the CRM):
+
+```json
+{
+  "count": 0,
+  "next_page": null,
+  "previous_page": null,
+  "results": []
+}
+```
+
+## Endpoint summary
+
+| Method | Path | RBAC | Purpose |
+|--------|------|------|---------|
+| `GET`    | `/persons/`                            | `Ibl.CRM/Persons/list`   | List persons in your Platform |
+| `POST`   | `/persons/`                            | `Ibl.CRM/Persons/action` | Create a person |
+| `GET`    | `/persons/{id}/`                       | `Ibl.CRM/Persons/read`   | Retrieve one person |
+| `PUT`    | `/persons/{id}/`                       | `Ibl.CRM/Persons/write`  | Replace all editable fields |
+| `PATCH`  | `/persons/{id}/`                       | `Ibl.CRM/Persons/write`  | Patch a subset of fields |
+| `DELETE` | `/persons/{id}/`                       | `Ibl.CRM/Persons/delete` | Hard-delete a person |
+| `POST`   | `/persons/{id}/link-user/`             | `Ibl.CRM/Persons/write`  | Bind a person to an existing Platform user |
+| `POST`   | `/persons/{id}/invite/`                | `Ibl.CRM/Invite/action`  | Send a Platform invitation to `primary_email` |
+| `POST`   | `/persons/merge/`                      | `Ibl.CRM/Persons/write`  | Merge duplicates into a primary |
+| `POST`   | `/persons/{id}/tags/`                  | `Ibl.CRM/Tags/write`     | Attach a Tag (see `/iblai-crm-tag`) |
+| `DELETE` | `/persons/{id}/tags/{tag_id}/`         | `Ibl.CRM/Tags/write`     | Detach a Tag |
+
+## Person object
+
+| Field | Type | R/W | Notes |
+|-------|------|-----|-------|
+| `id` | UUID | R | Server-assigned. Stable across renames and merges. |
+| `platform` | string/int | R | Set server-side from the auth token. |
+| `name` | string | RW | Display name (required on create). |
+| `primary_email` | string \| null | RW | Canonical email. Drives the auto-link signal (case-insensitive match). |
+| `emails` | `{label, email}[]` | RW | Free-form additional emails. |
+| `contact_numbers` | `{label, number}[]` | RW | Free-form phone numbers. |
+| `job_title` | string | RW | Display only; not validated. |
+| `organization` | UUID \| null | RW | Org in your Platform. Cross-Platform refs rejected. |
+| `owner` | int \| null | RW | Platform user id of the internal account manager (must be an active member). |
+| `platform_user` | int \| null | R | Set once the person is bound to a Platform user. |
+| `lifecycle_stage` | enum | RW | `lead \| qualified \| opportunity \| customer \| churned`. Default `lead`. |
+| `unique_id` | string | RW | External import key; unique per Platform when non-blank; ≤128 chars. |
+| `active` | boolean | R | Flipped to `false` on link / merge-as-duplicate. |
+| `tags` | `{id,name,color}[]` | R | Always present; empty array when none. |
+| `metadata` | object | RW | Free-form JSON. |
+| `created_at` / `updated_at` | ISO 8601 | R | Server-managed timestamps. |
+
+---
+
+## `GET /persons/`
+
+Paginated list.
+
+**Query parameters**
+
+| Name | Type | Notes |
+|------|------|-------|
+| `lifecycle_stage` | enum | `lead \| qualified \| opportunity \| customer \| churned` |
+| `owner` | int | Platform user id of the account manager |
+| `organization` | UUID | Organization id |
+| `created_at__gte` / `created_at__lte` | ISO 8601 | Created-at window |
+| `metadata__has_key` | string | Persons whose `metadata` has the given top-level key |
+| `tags` | int (repeatable) | OR semantics: `?tags=1&tags=2` or `?tags=1,2`. Results de-duplicated. |
+| `page` / `page_size` | int | `page_size` max 100 |
+
+Response is the pagination envelope above with `results: Person[]`.
+
+```bash
+curl "https://api.iblai.app/dm/api/crm/persons/?lifecycle_stage=qualified&page=1&page_size=25" \
+  -H "Authorization: Token <token>"
+```
+
+---
+
+## `POST /persons/`
+
+Create a person. `platform` is set server-side.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Display name |
+| `primary_email` | string | No | Auto-link binding key |
+| `emails` | `{label,email}[]` | No | Defaults to `[]` |
+| `contact_numbers` | `{label,number}[]` | No | Defaults to `[]` |
+| `job_title` | string | No | Defaults to `""` |
+| `organization` | UUID | No | Must belong to your Platform |
+| `owner` | int | No | Active member of your Platform |
+| `lifecycle_stage` | enum | No | Defaults to `lead` |
+| `unique_id` | string | No | Unique per Platform when non-blank |
+| `metadata` | object | No | Defaults to `{}` |
+
+**Response** `201 Created` — full Person object.
+
+**Errors**
+
+| Code | Cause |
+|------|-------|
+| `400` | Validation: duplicate `unique_id`, cross-Platform `organization`, owner not in Platform, etc. Body has per-field arrays. |
+| `403` | Missing `Ibl.CRM/Persons/action`. |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/persons/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice Chen","primary_email":"alice@example.com","lifecycle_stage":"lead"}'
+```
+
+---
+
+## `GET /persons/{id}/`
+
+Retrieve one person.
+
+**Responses:** `200 OK` (full Person), `404 Not Found` (existence is
+not leaked across Platforms).
+
+---
+
+## `PUT /persons/{id}/`
+
+Replace every editable field. Omitted fields are reset to their
+serializer defaults. Server-managed fields (`id`, `platform`,
+`platform_user`, `active`, `created_at`, `updated_at`) are ignored if
+sent.
+
+**Responses:** `200 OK`, `400`, `404`.
+
+---
+
+## `PATCH /persons/{id}/`
+
+Partial update — only fields present in the body are touched.
+
+**Responses:** `200 OK`, `400`, `404`.
+
+---
+
+## `DELETE /persons/{id}/`
+
+Hard delete.
+
+**Responses:** `204 No Content`, `404`.
+
+---
+
+## `POST /persons/{id}/link-user/`
+
+Bind a person to an existing Platform user.
+
+**Request body**
+
+```json
+{ "user_id": 1184 }
+```
+
+**Response** `200 OK` — full Person object. On a successful bind,
+`platform_user` is set to the requested `user_id` and `active` flips
+to `false`.
+
+### Silent-refusal footgun
+
+A `200` response whose `platform_user` does **not** equal the
+requested `user_id` means the person was **already bound to a
+different Platform user** — the existing binding was preserved and
+the API will not silently re-parent. There is **no error response**
+for this case.
+
+Clients **MUST** assert:
+
+```ts
+if (response.platform_user !== requested_user_id) {
+  // Refusal — surface "already linked to user X" instead of "success".
+}
+```
+
+**Status codes**
+
+| Code | When |
+|------|------|
+| `200` | Success **or** silent refusal (compare `platform_user`). |
+| `400` | `user_id` missing or not an integer. |
+| `403` | Caller missing `Ibl.CRM/Persons/write`, **or** target user has no active `UserPlatformLink` to your Platform. |
+| `404` | Person or user does not exist. |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/persons/<id>/link-user/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": 1184}'
+```
+
+---
+
+## `POST /persons/{id}/invite/`
+
+Send a Platform invitation to the person's `primary_email`. On
+acceptance, the invitee joins the Platform with the privileges
+configured here and the auto-link signal binds the person to the new
+user account.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `is_admin` | boolean | No | Defaults to `false`. |
+| `is_staff` | boolean | No | Defaults to `false`. |
+| `enrollment_config` | object | No | Forwarded to the invitation (courses / programs / pathways auto-enrollment). |
+| `redirect_to` | string | No | Post-acceptance URL. Max 255 chars. |
+
+**Response** `201 Created`
+
+```json
+{
+  "person_id": "<uuid>",
+  "invitation_id": 8821,
+  "invitation_email": "alice@example.com",
+  "platform_key": "acme-learning",
+  "auto_accept": true,
+  "active": true,
+  "redirect_to": "https://acme.iblai.app/welcome",
+  "created": "2026-06-04T08:12:01Z"
+}
+```
+
+**Status codes**
+
+| Code | When |
+|------|------|
+| `201` | Invitation queued. |
+| `400` | Person has no `primary_email`. |
+| `403` | Caller missing `Ibl.CRM/Invite/action`. |
+| `404` | Person not found. |
+| `409` | Active invitation already exists. Body carries the pre-existing `invitation_id` — treat as "already done". |
+| `422` | Person already linked to a Platform user. |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/persons/<id>/invite/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"is_admin":false,"is_staff":false,"redirect_to":"https://acme.iblai.app/welcome"}'
+```
+
+---
+
+## `POST /persons/merge/`
+
+Re-parent Deals, Activities, and Tag assignments from duplicates onto
+a primary in a single transaction; soft-delete the duplicates.
+
+**Request body**
+
+```json
+{
+  "primary_id": "<uuid>",
+  "duplicate_ids": ["<uuid>", "<uuid>"]
+}
+```
+
+- `primary_id` must belong to your Platform.
+- `duplicate_ids` must be non-empty, belong to your Platform, and not
+  include `primary_id`.
+
+**Response** `200 OK`
+
+```json
+{
+  "primary_id": "<uuid>",
+  "merged_ids": ["<uuid>"],
+  "reparented": { "deals": 4, "activities": 11, "tags": 3 }
+}
+```
+
+Notes:
+
+- Duplicates are **soft-deleted** — `active=false`, row still
+  retrievable by id. `GET /persons/{duplicate_id}/` returns the
+  inactive row, not `404`. Filter on `active=true` to hide.
+- `reparented.tags` counts every assignment *touched* — both moved
+  and dropped (the `(tag, person)` unique constraint forbids
+  stacking, so a tag the primary already carries is dropped silently
+  but still counted).
+
+**Status codes**
+
+| Code | When |
+|------|------|
+| `200` | Merge complete (also returned on no-op rerun). |
+| `400` | `primary_id` appears in `duplicate_ids`, `duplicate_ids` empty, or cross-Platform duplicate. |
+| `403` | Caller missing `Ibl.CRM/Persons/write`. |
+| `404` | Primary person not found in your Platform. |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/persons/merge/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"primary_id":"<uuid>","duplicate_ids":["<uuid>"]}'
+```
+
+---
+
+## `POST /persons/{id}/tags/` and `DELETE /persons/{id}/tags/{tag_id}/`
+
+Tag attach/detach. Body for attach: `{ "tag_id": <int> }`.
+
+| Code | Meaning |
+|------|---------|
+| `201` | Attached. Response: `{ "assignment_id": <int>, "tag": {id,name,color} }`. |
+| `409` | Already attached. Body includes the existing `assignment_id`. |
+| `404` | Tag not found / wrong Platform (attach), or tag was not attached (detach). |
+| `204` | Detach success. |
+
+See `/iblai-crm-tag` for tag CRUD.

--- a/skills/iblai-crm-notification/SKILL.md
+++ b/skills/iblai-crm-notification/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: iblai-crm-notification
+description: Reference for the three CRM notification event types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) the ibl.ai CRM dispatches after a write commits — payload shapes, recipient routing modes (default / per-Platform configured), and how to surface them in your app. Use when the user mentions CRM notifications, lead/deal alerts, "who gets notified when a deal moves stages", recipient mode configuration, or wiring a CRM-only inbox; see /iblai-crm-overview for setup, /iblai-crm-lead-flow and /iblai-crm-deal-flow for the events' source skills, and /iblai-notification for the bell UI that actually renders these events. This is a REFERENCE skill — it documents the contract; it does NOT build the bell UI.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-notification
+
+Reference skill for the three CRM notification event types. Documents
+when each one fires, the context keys included in the payload, the
+recipient-routing modes available per Platform, and where the developer
+goes next to surface these events in the UI. This skill does NOT build
+the notification bell — that is `/iblai-notification`.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth set up (`/iblai-auth`)
+- MCP and skills set up (`iblai add mcp`)
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user holds a CRM role (`CRM Viewer` is enough to read
+  inbox entries that target them; see `/iblai-rbac`)
+
+## The three CRM notification types
+
+Every CRM write that produces a notification routes through exactly one
+of these three event types. Full payload tables (every `context` key)
+live in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+| `event_type` | Fires when | Source skill | Default recipients |
+|---|---|---|---|
+| `CRM_PERSON_CREATED` | A person row is created via any path — REST `POST /persons/`, the Django admin, or bulk import | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+| `CRM_DEAL_STAGE_CHANGED` | A deal moves between stages via `POST /deals/{id}/move-stage/`, `POST /deals/{id}/won/`, or `POST /deals/{id}/lost/`. No-op transitions (destination stage equals current stage) are SUPPRESSED — no notification | `/iblai-crm-deal-flow` | Platform admins + `deal.owner` |
+| `CRM_PERSON_LINKED_TO_USER` | A person is bound to a Platform user — either by explicit `POST /persons/{id}/link-user/` or implicitly by the auto-link signal when a new user registers with a matching email | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+
+"Object owner" is `person.owner` for the two person-scoped events and
+`deal.owner` for the stage-change event. If the owner field is unset on
+the triggering object, the configured recipient mode decides whether to
+fall back to admins or drop the notification — see `## Recipient routing`
+below.
+
+## After-commit dispatch
+
+All three event types dispatch **asynchronously after the writing
+transaction commits**. The CRM signal is observed inside the request, but
+the actual notification send fires from a post-commit hook on the
+database transaction. The practical consequences:
+
+- A write that rolls back — failed validation, database constraint, a
+  `move-stage` call that raises mid-transition — produces no
+  notification. The signal is observed, the dispatch is not.
+- By the time a recipient sees the email, push entry, or inbox row, the
+  underlying record is durably on disk. There are no ghost notifications
+  for state that never persisted.
+- Context keys are snapshotted at signal time from the live object. A
+  template that references `{{ deal_lead_value }}` reads the value as it
+  stood the moment the stage transition committed; later edits to the
+  deal do not re-render or re-send.
+
+Cross-reference: this is the same after-commit rule the [System Overview](../../../docs/developer/applications/crm.md#2-system-overview) "Side
+Effects" block describes, and it is shared with the audit `Activity` row
+that `move-stage`/`won`/`lost` writes alongside the notification (see
+`/iblai-crm-activity`).
+
+## Recipient routing
+
+Every CRM notification template — and any notification type that opts
+into the shared recipients pipeline — can be configured per Platform
+with one of five recipient modes:
+
+| Mode | Effect |
+|---|---|
+| `platform_admins_only` | Deliver to active Platform admins only. The object's owner is ignored. |
+| `object_owner_only` | Deliver to the object's owner. If the owner field is unset, fall back to Platform admins so nothing is silently dropped. |
+| `object_owner_only_strict` | Deliver to the object's owner only. If the owner is unset, no one is notified. Use when the notification is meaningless without an owner. |
+| `platform_admins_and_object_owner` | **Default.** Both audiences receive the notification, deduplicated so an admin who is also the owner does not get two copies. |
+| `custom` | Deliver to a hand-picked list of users, user groups, or RBAC role-policy holders. Admins and the owner are NOT implicitly included. |
+
+When the mode is `custom`, the template's `recipients_custom_recipients`
+field holds a list of dicts. Each entry takes one of three shapes:
+
+```json
+{ "type": "user",        "id": 123 }
+{ "type": "user_group",  "id": 7 }
+{ "type": "rbac_policy", "policy_name": "CRM Manager" }
+```
+
+Entries compose freely — a single list can mix individual users, groups,
+and policy holders. The resolver expands each entry, unions the results,
+deduplicates, and runs the active-Platform-membership filter as a final
+gate. Stale entries (departed users, reassigned policies, drained
+groups) simply contribute zero recipients on that dispatch.
+
+Recipient configuration lives on the **notification template, not the
+CRM models**. Changing it for `CRM_DEAL_STAGE_CHANGED` on a given
+Platform is a `PATCH` against that Platform's template for that type,
+setting `recipients_recipient_mode` and (if `custom`) populating
+`recipients_custom_recipients`. The CRM does not add a separate API
+surface for this — the same template-management endpoints documented in
+`/iblai-notification` handle these three types alongside every other
+notification type on the platform. This skill does NOT modify those
+endpoints; it just documents which event types route through them.
+
+Full mode table, custom-shape examples, the change-recipients workflow,
+and the active-membership filter rules are in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+## Channels
+
+Email delivery is wired by default for all three CRM event types.
+Per-user notification preferences are honored by the underlying delivery
+machinery — the CRM does not bypass them. Additional channels (in-app
+inbox feed, push notification) follow the template's channel
+configuration, inspected and changed via the same templates API.
+
+The **in-app bell + notification center** that surfaces inbox entries is
+NOT in scope for this skill. Send the developer to `/iblai-notification`
+for the drop-in `<NotificationDropdown>` and `<NotificationDisplay>`
+components.
+
+## Consuming the events in your UI
+
+This is a reference skill. To actually show a user the three CRM event
+types in the browser:
+
+1. Install the bell + center via `/iblai-notification`. That skill ships
+   `components/iblai/notification-bell.tsx` and the
+   `<NotificationDisplay>` page surface (Inbox + Alerts tabs).
+2. The bell's inbox list is a standard notification feed — every
+   delivered notification carries an `event_type` matching one of the
+   three values from the table above. Filter the inbox query to those
+   three values (or any subset) when you want a CRM-only inbox view.
+3. For deeper drill-down (clicking an inbox entry that says "Deal moved
+   to Negotiation" and jumping to the kanban card), wire the
+   `onViewNotifications` callback on `<NotificationDropdown>` to route
+   to the deal detail page built by `/iblai-crm-deal-flow`.
+
+## Verify
+
+End-to-end smoke once the bell is wired:
+
+1. From the kanban built in `/iblai-crm-deal-flow`, move a deal from one
+   stage to another via `POST /deals/{id}/move-stage/`. Make sure the
+   destination stage actually differs from the current one (same-stage
+   moves are suppressed and produce nothing).
+2. Within a few seconds, confirm a `CRM_DEAL_STAGE_CHANGED` row appears
+   in the inbox bell installed by `/iblai-notification` for the deal's
+   owner.
+3. Open the deal's activity timeline (`/iblai-crm-activity`) and confirm
+   the corresponding audit `Activity` row exists with `type=note`,
+   `done=true`, `title="Stage changed"`. The notification and the audit
+   row are written together — if one is missing while the other is
+   present, the transaction split unexpectedly and is worth filing.
+4. Re-run the same `move-stage` call with `stage_code` set to the
+   destination it just reached. The API should return the deal
+   unchanged, no new audit row, and no new notification.
+
+Run `/iblai-ops-test` before reporting done.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — source of `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER`
+- `/iblai-crm-deal-flow` — source of `CRM_DEAL_STAGE_CHANGED`
+- `/iblai-notification` — bell UI + notification center that consumes these events
+- `/iblai-rbac` — required CRM roles
+- `/iblai-auth` — token wiring

--- a/skills/iblai-crm-notification/references/notification-types.md
+++ b/skills/iblai-crm-notification/references/notification-types.md
@@ -1,0 +1,219 @@
+# CRM notification types — reference
+
+Condensed from the ibl.ai CRM developer documentation, [Notifications](../../../../docs/developer/applications/crm.md#12-notifications).
+Use this file as the lookup table when wiring inbox filters, configuring
+recipient routing on a Platform, or building a custom CRM-only inbox surface.
+
+The CRM fires three notification types. Each is configurable per Platform —
+you can change recipients, edit the email/push template content, or toggle
+the type off entirely through the notification templates API. The mechanics
+(template storage, channel routing, preference resolution) are the same
+machinery every other notification type in the system uses; cross-reference
+the notification system documentation (`/iblai-notification`) for the full
+template payload and lifecycle. This file covers only what is CRM-specific:
+when each type fires, the context keys the template can interpolate, and how
+recipient routing works.
+
+---
+
+## 1. The three types
+
+| Type | Fires when | Default recipients |
+|---|---|---|
+| `CRM_PERSON_CREATED` | A person is created (API, admin, or import) | Platform admins + person owner |
+| `CRM_DEAL_STAGE_CHANGED` | A deal moves between stages (`move-stage` / `won` / `lost`). No-op transitions (same stage to same stage) are suppressed. | Platform admins + deal owner |
+| `CRM_PERSON_LINKED_TO_USER` | A person is bound to a Platform user — either by the auto-link signal that matches on email when a new user registers, or by an explicit call to `/link-user/` | Platform admins + person owner |
+
+### Context keys per type
+
+Every notification carries a `context` object the template interpolates
+into the rendered title/body/email. The keys provided for each type:
+
+**`CRM_PERSON_CREATED`**
+
+| Key | Source |
+|---|---|
+| `person_id` | `person.id` |
+| `person_name` | `person.name` |
+| `person_email` | `person.email` |
+| `person_lifecycle_stage` | `person.lifecycle_stage` |
+| `person_job_title` | `person.job_title` |
+| `owner_username` | `person.owner.username` |
+
+**`CRM_DEAL_STAGE_CHANGED`**
+
+| Key | Source |
+|---|---|
+| `deal_id` | `deal.id` |
+| `deal_title` | `deal.title` |
+| `deal_status` | `deal.status` (`open` / `won` / `lost`) |
+| `deal_lead_value` | `deal.lead_value` |
+| `deal_currency` | `deal.currency` |
+| `from_stage_code` | Source stage's `code` |
+| `from_stage_name` | Source stage's display name |
+| `to_stage_code` | Destination stage's `code` |
+| `to_stage_name` | Destination stage's display name |
+| `person_name` | `deal.person.name` |
+| `actor_username` | Username of the user that called `move-stage`/`won`/`lost` |
+
+**`CRM_PERSON_LINKED_TO_USER`**
+
+| Key | Source |
+|---|---|
+| `person_id` | `person.id` |
+| `person_name` | `person.name` |
+| `person_email` | `person.email` |
+| `linked_user_id` | The Platform user's id |
+| `linked_user_username` | The Platform user's username |
+| `linked_user_email` | The Platform user's email |
+
+### After-commit dispatch rule
+
+All three are dispatched asynchronously **after the writing transaction
+commits**. If the write that triggered the signal is rolled back — a
+validation failure further down the request, a `move-stage` call that
+raises mid-transition — no notification is produced. The signal is
+observed, but the dispatch only fires on the post-commit hook, so
+consumers never see ghost notifications for state that never persisted.
+
+Context keys are populated at signal time from the live object. A
+template that references `{{ deal_lead_value }}` reads the value as it
+stood the moment the stage transition committed; later edits to the deal
+do not re-render or re-send the notification.
+
+---
+
+## 2. Recipient modes
+
+Every CRM notification template — and in fact any notification type that
+opts into the shared recipients pipeline — can be configured per Platform
+with one of five recipient modes:
+
+| Mode | Effect |
+|---|---|
+| `platform_admins_only` | Deliver only to active Platform admins. The object's owner is ignored. |
+| `object_owner_only` | Deliver to the object's owner. If the owner field is unset, fall back to Platform admins so the notification is not silently dropped. |
+| `object_owner_only_strict` | Deliver to the object's owner only. If the owner is unset, no one is notified. Use when the notification is meaningless without an owner. |
+| `platform_admins_and_object_owner` | Default. Both audiences receive the notification, deduplicated so an admin who is also the owner does not get two copies. |
+| `custom` | Deliver to a hand-picked list of users, user groups, or RBAC role-policy holders. Admins and the owner are not implicitly included. |
+
+"Object owner" refers to the `owner` field on the triggering object:
+
+- For `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER`, that is `person.owner`.
+- For `CRM_DEAL_STAGE_CHANGED`, that is `deal.owner`.
+
+If an object is created without an owner — for instance, an imported
+person row that has no assigned account manager yet — the fallback
+behavior described in the table applies. There is no separate concept of
+an organization-level owner being used for routing.
+
+---
+
+## 3. Custom recipient shape
+
+When the mode is `custom`, the template's `recipients_custom_recipients`
+field holds a list. Each entry takes one of three shapes:
+
+```json
+{"type": "user", "id": 123}
+```
+
+```json
+{"type": "user_group", "id": 7}
+```
+
+```json
+{"type": "rbac_policy", "policy_name": "CRM Manager"}
+```
+
+The three types compose freely — a single custom list can mix individual
+users, groups, and policy holders. The resolver expands each entry,
+unions the results, deduplicates, and then runs the active-Platform-
+membership filter described below.
+
+Custom recipients are re-filtered against active Platform membership at
+delivery time. A stale entry — a user who has left the Platform, a group
+whose roster has changed, a policy that has been reassigned — simply
+contributes no one to that send. You do not need to prune the list
+manually when membership changes; the resolver does it on every dispatch.
+This means a single custom recipient list can be maintained centrally
+even if individual users come and go.
+
+If every entry in a custom list resolves to zero active members, the
+notification produces no deliveries for that Platform on that event. It
+is not auto-promoted back to the default mode; "no recipients" is
+treated as a valid configured outcome.
+
+---
+
+## 4. Changing recipients
+
+Recipient configuration lives on the notification template, **not** on
+the CRM models. To change who hears about, say, deal stage transitions
+on a given Platform, `PATCH` the template for `CRM_DEAL_STAGE_CHANGED`
+on that Platform via the notification templates API and set:
+
+- `recipients_recipient_mode` — one of the five modes from section 2.
+- `recipients_custom_recipients` — required when the mode is `custom`; a
+  list of target dicts as shown in section 3. Ignored for the other modes.
+
+The exact endpoint path, full payload schema, and authentication
+requirements are documented under the notification system
+(`/iblai-notification`). The CRM does not add a separate API surface for
+this — the same template management endpoints that handle every other
+notification type handle these three.
+
+Toggling a type off entirely is also done at the template level via the
+standard enable/disable flag on the notification template. The CRM
+signal still fires; the callback short-circuits before resolving
+recipients or dispatching. There is no CRM-side setting to suppress
+notifications.
+
+---
+
+## 5. Channels
+
+Email delivery is wired by default for all three CRM notifications.
+Whether a given recipient actually receives mail depends on their
+individual notification preferences, which are honored by the underlying
+delivery machinery — the CRM does not bypass user preferences.
+
+Additional channels (in-app feed, push notification) follow the
+template's channel configuration if added there; the CRM callbacks
+themselves dispatch email. Consult the templates API
+(`/iblai-notification`) to inspect or change the active channel set per
+type, the same way you change recipients.
+
+---
+
+## 6. Diagram — notification routing
+
+```mermaid
+flowchart LR
+    E[CRM event - person created, deal stage change, person linked] --> S[Notification service - post-commit dispatch]
+    S --> R{Recipient mode}
+    R -->|platform_admins_only| A[Active Platform admins]
+    R -->|object_owner_only / strict| O[Object owner - person.owner or deal.owner]
+    R -->|platform_admins_and_object_owner default| AO[Admins + owner deduped]
+    R -->|custom| C[Custom users / user groups / RBAC policy holders]
+    A --> F[Active Platform membership filter]
+    O --> F
+    AO --> F
+    C --> F
+    F --> M[Email + push delivery, honoring per-user preferences]
+```
+
+The membership filter is the last gate before delivery. Every resolved
+recipient — regardless of mode — is checked against the Platform's
+active membership at dispatch time. A user who has been removed from the
+Platform between the event and the dispatch does not receive the
+notification, even if they appear in a custom list, were the recorded
+`owner`, or were an admin at the time the event fired.
+
+---
+
+## Related references
+
+- Source documentation: [IBL CRM Developer Documentation — Notifications](../../../../docs/developer/applications/crm.md#12-notifications)
+- Bell UI + template management API: `/iblai-notification`
+- Event sources: `/iblai-crm-lead-flow` (person events), `/iblai-crm-deal-flow` (stage events)

--- a/skills/iblai-crm-overview/SKILL.md
+++ b/skills/iblai-crm-overview/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: iblai-crm-overview
+description: Reference and family index for the ibl.ai Platform-scoped CRM REST API at /api/crm/ — auth, seeded defaults (default Pipeline + 6 stages + 4 Lead Sources), the four CRM RBAC roles (Viewer/User/Manager/Inviter), and the workflow sub-skill map. Use when the user mentions CRM, leads, pipelines, deals, contacts, or asks where a CRM workflow lives. See /iblai-crm-lead-flow for people + onboarding, /iblai-crm-deal-flow for pipelines + kanban, /iblai-crm-activity for the timeline, /iblai-crm-tag for tags, /iblai-crm-notification for CRM event routing, /iblai-auth for token wiring, /iblai-rbac for role assignment.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-overview
+
+Reference skill for the ibl.ai CRM. Covers authentication, seeded
+defaults, the four CRM RBAC roles, and points to every sub-skill in
+the `iblai-crm-*` family. This skill builds no UI — open it first when
+you need orientation, then jump to the workflow skill that matches the
+surface you are building.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Authentication
+
+Every CRM endpoint lives under `/api/crm/` and requires a
+Platform-scoped token:
+
+```
+Authorization: Token <your-access-token>
+```
+
+Tokens bind to exactly one Platform at the moment of issue. The
+Platform is inferred from the token on every request — there is no
+`?platform_key=` query parameter on the consumer surface, and supplying
+one will not change the Platform a request resolves to.
+
+Records belonging to a different Platform return **`404 Not Found`,
+never `403 Forbidden`**. This is intentional: returning `403` would
+leak the existence of cross-Platform records. Treat a `404` on a
+record you just created as a sign you are pointing at the wrong
+Platform; a `403` always means "authenticated but the role does not
+grant this action."
+
+The full REST contract (base URL, pagination envelope, ID types per
+resource, side effects) is in
+[`references/api-overview.md`](./references/api-overview.md). For
+token wiring inside a Next.js app see `/iblai-auth`.
+
+## Seeded defaults
+
+The first time a Platform is provisioned, the CRM seeds a working
+configuration. You do not need to create any of these yourself — they
+exist on every Platform and back-fill into existing Platforms via a
+data migration.
+
+- **One default Pipeline** with `code="default"`, `is_default=true`,
+  `rotten_days=30`.
+- **Six default Stages** on that Pipeline, referenced by stable `code`:
+  `new` → `qualified` → `proposal` → `negotiation` → `won` (terminal,
+  `is_won=true`) and `lost` (terminal, `is_lost=true`).
+- **Four default Lead Sources**: `web`, `referral`, `cold_call`,
+  `advertisement`.
+
+The stage and lead-source `code` fields are stable across environments
+(dev / staging / prod) and across renames. Numeric `id` values are not
+— always reference seeds by `code` in client code, save the pipeline
+`id` only for the immediate deal payload.
+
+Full seeded tables (every stage's `probability` / `sort_order` /
+terminal flags, every lead source `name`) are in
+[`references/seeded-defaults.md`](./references/seeded-defaults.md).
+
+## RBAC
+
+The CRM ships four roles per Platform. Roles are seeded automatically
+on Platform provisioning and assigned through the standard
+role-management surface — the CRM does not expose its own
+role-assignment endpoints. A user may hold more than one role;
+effective permissions are the union.
+
+| Role | One-line mandate |
+|---|---|
+| **CRM Viewer** | Read everything across the CRM. Write nothing. |
+| **CRM User** | Day-to-day operator — full CRUD on people, organizations, deals, activities, tags. Pipelines are read-only. No invitations. |
+| **CRM Manager** | Wildcard CRM access — pipeline / stage / lead-source administration plus invitations. |
+| **CRM Inviter** | Narrow role — read people and send invitations only. Cannot edit or create people. |
+
+Two non-obvious rules worth a second look:
+- **Invitation is its own bucket.** `Ibl.CRM/Persons/write` does not
+  imply `Ibl.CRM/Invite/action`. Gate the "Invite" affordance
+  independently.
+- **Tag attach/detach requires `Ibl.CRM/Tags/write`.** A role with
+  `Ibl.CRM/Persons/write` cannot tag a person without it.
+
+Full HTTP-verb → action-code mapping and the action-by-action matrix
+are in [`references/rbac-matrix.md`](./references/rbac-matrix.md). For
+the management UI that lists and binds roles, see `/iblai-rbac`.
+
+## The CRM skill family
+
+Every CRM skill is prefixed `iblai-crm-*`. There is no bare umbrella
+skill — this skill is the index. Pick the one that matches the
+surface you are building.
+
+| Skill | Role | Covers |
+|---|---|---|
+| `/iblai-crm-overview` | Reference / index (this skill) | Auth, seeded defaults, RBAC roles, family map |
+| `/iblai-crm-lead-flow` | Build UI | People + Organizations + lifecycle stage + onboarding (link / invite / merge) |
+| `/iblai-crm-deal-flow` | Build UI | Pipelines + Stages + Lead Sources + Deals (kanban + move-stage / won / lost state machine) |
+| `/iblai-crm-activity` | Build UI | Activity timeline (calls, meetings, notes, tasks; schedule / remind / done) on persons and deals |
+| `/iblai-crm-tag` | Build UI | Tag CRUD + attach / detach for persons, organizations, deals |
+| `/iblai-crm-notification` | Reference | Three CRM notification types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) + recipient routing |
+
+When in doubt, start with `/iblai-crm-lead-flow` (a deal needs a
+person), then `/iblai-crm-deal-flow`, then layer `/iblai-crm-activity`
+and `/iblai-crm-tag` on the detail pages.
+
+## Related skills
+
+- `/iblai-crm-lead-flow` — People + Organizations + onboarding
+- `/iblai-crm-deal-flow` — Pipelines + Stages + Lead Sources + Deals
+- `/iblai-crm-activity` — Activity timeline for persons and deals
+- `/iblai-crm-tag` — Tag CRUD + attach / detach
+- `/iblai-crm-notification` — CRM notification types and recipient routing
+- `/iblai-auth` — Token wiring; every CRM call uses the same
+  `Authorization: Token <token>` header.
+- `/iblai-rbac` — Role-management UI (`<Admin>` → Roles + Policies
+  tabs) and the action-definitions endpoint. The four CRM roles are
+  assigned here.
+- **Brand guidelines**: [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md)

--- a/skills/iblai-crm-overview/references/api-overview.md
+++ b/skills/iblai-crm-overview/references/api-overview.md
@@ -1,0 +1,132 @@
+# CRM REST API — Overview
+
+The at-a-glance contract that every CRM sub-skill builds on. Pair with
+the per-resource references in the `iblai-crm-lead-flow`,
+`iblai-crm-deal-flow`, `iblai-crm-activity`, and `iblai-crm-tag`
+skills.
+
+## Base URL
+
+```
+/api/crm/
+```
+
+Mounted on the same Platform host as the rest of the ibl.ai API. In a
+Next.js app the host comes from `NEXT_PUBLIC_API_BASE_URL`
+(e.g. `https://api.iblai.app/dm/api/crm/...`). The Platform is inferred
+from the token — there is no `?platform_key=` parameter on the
+consumer surface.
+
+## Authentication
+
+```
+Authorization: Token YOUR_ACCESS_TOKEN
+```
+
+Required on every method (`GET`, `POST`, `PATCH`, `PUT`, `DELETE`)
+and every resource. Tokens bind to exactly one Platform; cross-Platform
+records return `404 Not Found`, never `403 Forbidden`.
+
+Failure modes:
+
+| Status | Meaning |
+|---|---|
+| `401` | Header missing / malformed / expired token |
+| `403` | Authenticated but role does not grant this action (or a service-account key is bound to a different Platform) |
+| `404` | Record does not exist *on your Platform* (existence is not leaked across Platforms) |
+| `409` | Conflict — tag already attached, pending invitation exists, or pipeline/stage delete attempted with deals still attached |
+| `422` | Unprocessable — e.g. invite attempted on a person already linked to a Platform user |
+
+## Pagination envelope
+
+Every list endpoint returns:
+
+```json
+{
+  "count": 142,
+  "next_page": 2,
+  "previous_page": null,
+  "results": [ ... ]
+}
+```
+
+- `next_page` and `previous_page` are **integer page numbers** (or
+  `null` at the edges). They are NOT URLs.
+- Walk pages with `?page=N`.
+- `page_size` is configurable per Platform; **max `page_size=100`**.
+  Treat the returned page size as authoritative — do not assume a
+  fixed number of rows.
+
+## The eight resources
+
+| Resource | URL prefix | ID type | Scoped to |
+|---|---|---|---|
+| Person | `/api/crm/persons/` | UUID string | Platform |
+| Organization | `/api/crm/organizations/` | UUID string | Platform |
+| Pipeline | `/api/crm/pipelines/` | integer | Platform |
+| Stage | `/api/crm/pipelines/{pipeline_id}/stages/` | integer | Pipeline |
+| Lead Source | `/api/crm/lead-sources/` | integer | Platform |
+| Deal | `/api/crm/deals/` | integer | Platform |
+| Activity | `/api/crm/activities/` | integer | Platform |
+| Tag | `/api/crm/tags/` | integer | Platform |
+
+Persons and Organizations use UUIDs so they can be minted client-side
+and survive cross-system imports. Everything else uses integer IDs.
+
+## Common envelope fields
+
+Every resource returns three standard fields on read:
+
+- `created_at` — ISO-8601 timestamp, set on insert
+- `updated_at` — ISO-8601 timestamp, refreshed on every save
+- `metadata` — free-form JSON object the integrator owns
+
+`Person`, `Organization`, `Deal`, and `Activity` additionally carry an
+`owner` foreign key (Platform user id). `Person`, `Organization`, and
+`Deal` expose a read-only `tags` array — mutate via the attach/detach
+endpoints, never by `PATCH`ing the host.
+
+Server-managed fields that clients must never send on write:
+
+| Resource | Fields | Why |
+|---|---|---|
+| Person | `platform_user`, `active` | Set by `/link-user/` or auto-link signal |
+| Deal | `status`, `closed_at` | Derived from current stage + won/lost actions |
+| Activity | `done_at`, `reminder_sent` | Stamped on completion / reminder dispatch |
+
+## Side effects on write
+
+Three classes of write trigger automatic follow-up work. All
+notifications dispatch asynchronously **after the transaction
+commits** — a write that rolls back produces no notification.
+
+| Trigger | Side effect |
+|---|---|
+| Create a Person (any code path: API, admin, bulk import) | `CRM_PERSON_CREATED` notification |
+| `POST /deals/{id}/move-stage/`, `/won/`, `/lost/` to a different stage | (1) audit `Activity` row — `type="note"`, `title="Stage changed"`, marked done, with from→to display names in the `comment`; (2) `CRM_DEAL_STAGE_CHANGED` notification to the deal's owner |
+| `POST /persons/{id}/link-user/` (explicit) or signup auto-link by email | `CRM_PERSON_LINKED_TO_USER` notification |
+
+Transitions that resolve to the deal's current stage are suppressed:
+no write, no audit row, no notification.
+
+## Pagination + filtering dialect
+
+Three patterns recur across resources:
+
+- **Date ranges.** Any field suffixed `__gte` / `__lte` accepts an
+  ISO-8601 date or datetime. Both bounds are inclusive.
+- **Foreign-key filters.** Pass the related record's primary
+  identifier — numeric IDs for users / pipelines, UUIDs for persons /
+  organizations / deals.
+- **Tag filters.** `?tags=7&tags=12` or `?tags=7,12`. Both forms use
+  OR semantics; the response never duplicates rows when a record
+  matches multiple tag IDs.
+
+Person and Deal list endpoints additionally support
+`?metadata__has_key=fieldName` — strict key presence (`null` values
+count, missing keys do not). There is no operator for filtering by
+metadata value.
+
+There is **no cross-resource search endpoint** and no substring
+filter on `Person.name`. Combine the filters above and do final
+substring matching client-side if needed.

--- a/skills/iblai-crm-overview/references/rbac-matrix.md
+++ b/skills/iblai-crm-overview/references/rbac-matrix.md
@@ -1,0 +1,107 @@
+# CRM RBAC Matrix
+
+The CRM ships four roles per Platform. Roles are seeded automatically
+on Platform provisioning — there is nothing to create. Assign them
+through the standard Platform role-management surface (`<Admin>` →
+Roles + Policies — see `/iblai-rbac`); the CRM does not expose its own
+role-assignment endpoints. A single user may hold more than one role
+and effective permissions are the union.
+
+## The four roles
+
+**CRM Viewer.** Read-only across the entire CRM. Sees every Person,
+Organization, Pipeline, Stage, Lead Source, Deal, Activity, and Tag,
+but cannot create, update, delete, or send invitations. Right role
+for sales-ops dashboards, finance reviewers, and any audience that
+needs visibility without write access.
+
+**CRM User.** The day-to-day operator. Full create / update / delete
+on people, organizations, deals, activities, and tags — the records
+that move during normal sales work. Pipelines, stages, and lead
+sources are **read-only** for this role — pipeline topology is an
+admin job. Cannot send invitations (that lives in a separate bucket).
+Right role for individual sales reps and account managers.
+
+**CRM Manager.** Wildcard access to every CRM action. Adds
+pipeline / stage / lead-source administration and invitation sending
+on top of everything the CRM User can do. Right role for sales
+leadership and CRM admins.
+
+**CRM Inviter.** A narrow role: read people and send invitations
+only. Cannot edit or create people, cannot see organizations or
+deals. Right role for partner-portal flows, gated onboarding teams,
+or any surface that needs to turn known leads into Platform users
+without exposing the broader pipeline.
+
+## Action-by-action matrix
+
+Action codes follow the bucket convention `Ibl.CRM/<Resource>/<verb>`
+with five canonical verbs: `list`, `read`, `action`, `write`,
+`delete`. `action` covers create (`POST`) and custom verb endpoints
+(`move-stage`, `won`, `lost`, `done`, `link-user`, `merge`).
+
+| Resource bucket | Action codes | Viewer | User | Manager | Inviter |
+|---|---|---|---|---|---|
+| `Ibl.CRM/Persons` | `list`, `read` | ✓ | ✓ | ✓ | ✓ |
+| `Ibl.CRM/Persons` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Organizations` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Organizations` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Pipelines` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Pipelines` | `action`, `write`, `delete` | — | — | ✓ | — |
+| `Ibl.CRM/Deals` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Deals` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Activities` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Activities` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Tags` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Tags` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Invite` | `action` | — | — | ✓ | ✓ |
+
+Notes:
+- **Lead Source endpoints fall under `Ibl.CRM/Pipelines`.** They are
+  administrative — only CRM Manager can create / update / delete a
+  lead source even though CRM Users will reference them on Deals.
+- **Stage CRUD also lives under `Ibl.CRM/Pipelines`.** Moving a
+  *stage* is admin work (Manager only); moving a *deal* between
+  stages is a Deal `action` (User or Manager).
+
+## HTTP verb → action code mapping
+
+| HTTP | Action code |
+|---|---|
+| `GET` (list endpoint) | `list` |
+| `GET` (detail endpoint) | `read` |
+| `POST` (create) | `action` |
+| `POST` (custom: `move-stage`, `won`, `lost`, `done`, `link-user`, `merge`) | `action` |
+| `POST` attach-tag, `DELETE` detach-tag | `write` (on `Ibl.CRM/Tags`) |
+| `PATCH` / `PUT` | `write` |
+| `DELETE` (resource delete) | `delete` |
+
+## Two permissions worth a second look
+
+- **Invitation is its own bucket.** A role with
+  `Ibl.CRM/Persons/write` does **not** have `Ibl.CRM/Invite/action`.
+  Gate the "Invite" affordance independently of the Person edit
+  affordance — they are distinct rights.
+- **Tag attach/detach requires `Ibl.CRM/Tags/write`.** A role with
+  `Ibl.CRM/Persons/write` cannot tag a person without it. This is
+  intentional — it lets you delegate tag-graph mutation separately
+  from person mutation.
+
+## Assigning the roles
+
+The CRM does not ship a role-assignment UI of its own. Use the
+SDK-provided management surface:
+
+- `<Admin>` (mounted via `<Account>` — see `/iblai-account`) →
+  **Roles** tab to inspect / edit the seeded CRM roles, and
+  **Policies** tab to bind a role to a user or group on the
+  Platform resource scope.
+- Or call `POST rbac/policies/` directly (see the REST contract
+  under `/iblai-agent-access` → "Roles CRUD").
+- For per-action gating in your CRM surfaces, hydrate
+  `rbacPermissions` via `POST rbac/permissions/check/` and gate the
+  affordance with `checkRbacPermission(rbacPermissions, path,
+  enableRbac)` from `@iblai/iblai-js/web-utils`.
+
+See `/iblai-rbac` for the full management-UI walkthrough and the
+action-definitions endpoint.

--- a/skills/iblai-crm-overview/references/seeded-defaults.md
+++ b/skills/iblai-crm-overview/references/seeded-defaults.md
@@ -1,0 +1,78 @@
+# CRM Seeded Defaults
+
+Every Platform ships with a working CRM configuration the first time
+it is provisioned. Existing Platforms have the same seeds back-filled
+by a data migration. You do not need to create any of the records
+below — they are present on every Platform and can be edited,
+renamed, or extended.
+
+> **Reference seeds by `code`, not `id`.** The `code` value on
+> stages and lead sources is stable across environments (dev /
+> staging / prod) and survives display-name renames. The numeric `id`
+> values differ between environments and should only be cached for
+> the lifetime of a single request (e.g. saving the pipeline `id`
+> long enough to build a deal payload).
+
+## Default Pipeline
+
+A single Pipeline is seeded and marked as the default:
+
+| Field | Value |
+|---|---|
+| `code` | `default` |
+| `is_default` | `true` |
+| `rotten_days` | `30` |
+
+Filter for it with `GET /api/crm/pipelines/?is_default=true`. The
+response embeds the six default stages inline (no second request
+needed).
+
+## Default Stages (on the default Pipeline)
+
+Six stages, ordered by `sort_order`. The first four are non-terminal
+(in-flight). `won` and `lost` are terminal — moving a deal into one
+of them stamps `closed_at` and updates `Deal.status` automatically.
+
+| `code` | `name` | `probability` | `sort_order` | `is_won` | `is_lost` |
+|---|---|---|---|---|---|
+| `new` | New | 10 | 0 | false | false |
+| `qualified` | Qualified | 25 | 1 | false | false |
+| `proposal` | Proposal | 50 | 2 | false | false |
+| `negotiation` | Negotiation | 75 | 3 | false | false |
+| `won` | Won | 100 | 4 | **true** | false |
+| `lost` | Lost | 0 | 5 | false | **true** |
+
+Notes:
+- `probability` is a 0–100 integer used for weighted-pipeline reports.
+- `sort_order` drives kanban column placement left-to-right.
+- The `/deals/{id}/won/` and `/deals/{id}/lost/` action endpoints
+  resolve to the first stage of the matching kind by `sort_order`
+  (`won` here, `lost` here). Pass `stage_code` only when a Platform
+  has multiple terminal stages of one kind.
+
+## Default Lead Sources
+
+Four lead sources are seeded — the channels that produced a Deal.
+They live under the `Ibl.CRM/Pipelines/` RBAC bucket because shaping
+attribution categories is an administrative job.
+
+| `code` | `name` |
+|---|---|
+| `web` | Web |
+| `referral` | Referral |
+| `cold_call` | Cold Call |
+| `advertisement` | Advertisement |
+
+The `source` field on Deal is a nullable foreign key — leave it
+`null` for an unattributed deal.
+
+## What is not seeded
+
+- **No default Persons / Organizations / Deals / Activities / Tags.**
+  The CRM is empty on Platform creation. The seeds above are the
+  topology you can build on top of, not data.
+- **No default Tag palette.** Tags must be created before they can be
+  attached (see `/iblai-crm-tag`).
+- **No default custom-metadata schema.** `metadata` is an open
+  free-form JSON object on every resource — the integrator owns the
+  shape end-to-end.

--- a/skills/iblai-crm-tag/SKILL.md
+++ b/skills/iblai-crm-tag/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: iblai-crm-tag
+description: Build the CRM tag manager — CRUD on /api/crm/tags/ with hex color picker, a reusable tag chip, attach/detach controls on Person/Organization/Deal detail pages, and tag filters on list views with OR semantics. Use when the user mentions CRM tags, labels, tagging, color chips, tag manager, attach tag, detach tag, filter by tag, or wants to add segmentation labels to people/orgs/deals. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for the person/org host pages, /iblai-crm-deal-flow for the deal host pages, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-tag
+
+Build the CRM tag surface — tag CRUD dialog, color chip, attach/detach
+controls on Person, Organization, and Deal pages, plus a `?tags=` filter
+on every CRM list view.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — provides the platform
+  `Authorization: Token <token>` header used by every call below.
+- MCP and skills must be set up: `iblai add mcp`.
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user must hold the **CRM User** role (or higher) on the
+  Platform. CRM User unlocks `Ibl.CRM/Tags/list`, `read`, `action`,
+  `write`, and `delete`. CRM Viewer can only see tags, not write or
+  attach them. See `/iblai-rbac` for the role matrix and how to assign
+  CRM roles to a user.
+- At least one host surface should already exist so there is something
+  to tag. Run `/iblai-crm-lead-flow` (people + organizations) or
+  `/iblai-crm-deal-flow` (deals) first if you have not yet.
+
+## What you'll build
+
+1. A **tag manager dialog** — list, create, edit, and delete tags. Color
+   input is validated client-side against `^#[0-9A-Fa-f]{6}$` before
+   submit so the user sees errors immediately (the server applies the
+   same regex).
+2. A **tag chip** component — renders `{id, name, color}` with the hex
+   color as background. Optional `x` button for detach.
+3. **Attach / detach controls** on Person, Organization, and Deal detail
+   pages. The contract is uniform: `POST /{host}/{id}/tags/` with
+   `{tag_id}`, `DELETE /{host}/{id}/tags/{tag_id}/`.
+4. A **tag filter** on Person, Organization, and Deal list views —
+   `?tags=<id>&tags=<id2>` with **OR** semantics. Results are
+   de-duplicated by the backend.
+
+## Step 0: Check for CLI updates
+
+```bash
+iblai --version    # upgrade if outdated: pip install --upgrade iblai-app-cli OR npm i -g @iblai/cli@latest
+```
+
+## Step 1: Install shadcn primitives
+
+```bash
+npx shadcn@latest add dialog input form popover command badge button
+```
+
+`dialog` powers the tag manager and the delete-confirmation modal.
+`popover` + `command` together make a searchable tag combobox for the
+attach control. `badge` is the visual base for the tag chip. `input`
++ `form` cover the create/edit form. `button` covers actions.
+
+## Step 2: Typed API client wrapper
+
+Reuse the auth token wired in `/iblai-auth`. Create
+`lib/iblai/crm-tags.ts` with one wrapper per route. Base URL is
+`${NEXT_PUBLIC_API_BASE_URL}/api/crm`.
+
+```typescript
+// lib/iblai/crm-tags.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+const HEX = /^#[0-9A-Fa-f]{6}$/;
+
+export type Tag = {
+  id: number;
+  platform: number;
+  name: string;
+  color: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TagChip = Pick<Tag, "id" | "name" | "color">;
+
+export type Assignment = { assignment_id: number; tag: TagChip };
+
+function authHeaders(token: string) {
+  return {
+    Authorization: `Token ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+// Tag CRUD
+export async function listTags(token: string, params: { name?: string; page?: number } = {}) {
+  const qs = new URLSearchParams();
+  if (params.name) qs.set("name", params.name);
+  if (params.page) qs.set("page", String(params.page));
+  const r = await fetch(`${BASE}/tags/?${qs}`, { headers: authHeaders(token) });
+  if (!r.ok) throw new Error(`listTags ${r.status}`);
+  return r.json() as Promise<{ count: number; results: Tag[]; next_page: number | null; previous_page: number | null }>;
+}
+
+export async function createTag(token: string, body: { name: string; color?: string; metadata?: Record<string, unknown> }) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/`, { method: "POST", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function patchTag(token: string, id: number, body: Partial<Pick<Tag, "name" | "color" | "metadata">>) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "PATCH", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function deleteTag(token: string, id: number) {
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "DELETE", headers: authHeaders(token) });
+  if (!r.ok && r.status !== 204) throw new Error(`deleteTag ${r.status}`);
+}
+
+// Uniform host attach / detach. `host` is "persons" | "organizations" | "deals".
+export type Host = "persons" | "organizations" | "deals";
+
+export async function attachTag(token: string, host: Host, hostId: string | number, tagId: number): Promise<Assignment> {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ tag_id: tagId }),
+  });
+  // 201 = created; 409 = already attached, body still carries assignment_id + tag.
+  if (r.status === 201 || r.status === 409) return r.json();
+  throw await r.json();
+}
+
+export async function detachTag(token: string, host: Host, hostId: string | number, tagId: number) {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/${tagId}/`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+  // 204 = removed; 404 = not attached (treat as no-op success).
+  if (r.status !== 204 && r.status !== 404) throw new Error(`detachTag ${r.status}`);
+}
+```
+
+See `references/tags-api.md` for full endpoint table, error shapes, and
+filter semantics.
+
+## Step 3: Tag manager dialog
+
+Create `components/crm/tag-manager-dialog.tsx`. It is a single dialog
+that lists all tags from `GET /tags/`, lets the user create a new tag,
+edit an existing tag, or delete one.
+
+Requirements:
+
+- **Create form**: `name` (required, ≤ 64 chars, unique-per-Platform —
+  server-enforced) and `color` (`<input type="color">` is fine; on
+  submit, validate the value against `^#[0-9A-Fa-f]{6}$` before
+  calling `createTag`). Surface the server's 400 errors verbatim —
+  duplicate name, blank name, > 64 chars, bad hex.
+- **Edit**: inline rename + recolor calls `patchTag`. Renames take
+  effect immediately on every host chip — the chip renders from the
+  Tag row, not from the assignment.
+- **Delete**: opens a confirmation modal — see the destructive cascade
+  callout below. Disable the delete button until the user types the
+  tag name to confirm, or at minimum require a second click.
+
+The dialog reads the token from the auth store wired by `/iblai-auth`.
+
+## Step 4: Tag chip component
+
+Create `components/crm/tag-chip.tsx`. Renders `{id, name, color}` as a
+shadcn `Badge` with `style={{ backgroundColor: tag.color, color: '#fff' }}`.
+Accept an optional `onDetach: () => void` prop — when supplied, render
+a small `x` icon button inside the chip; otherwise render the chip as
+read-only.
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import type { TagChip as TTagChip } from "@/lib/iblai/crm-tags";
+
+export function TagChip({ tag, onDetach }: { tag: TTagChip; onDetach?: () => void }) {
+  return (
+    <Badge style={{ backgroundColor: tag.color, color: "#fff" }} className="gap-1">
+      {tag.name}
+      {onDetach ? (
+        <button onClick={onDetach} aria-label={`Detach ${tag.name}`} className="ml-1">
+          <X className="h-3 w-3" />
+        </button>
+      ) : null}
+    </Badge>
+  );
+}
+```
+
+The `tags` array is **always present** on every Person, Organization,
+and Deal list/detail response — empty array, never `null`. So your
+renderer can iterate unconditionally.
+
+## Step 5: Attach control on host detail pages
+
+On Person, Organization, and Deal detail pages, add an "Add tag"
+button that opens a shadcn `Popover` containing a `Command` combobox.
+Populate the combobox with `listTags(token)` (search-as-you-type by
+filtering client-side, or pass `name=` to the API for large libraries).
+
+On select:
+
+```typescript
+const { assignment_id, tag } = await attachTag(token, host, hostId, selectedTagId);
+// Optimistically add `tag` to the local host.tags array; assignment_id is for
+// future detach reconciliation, not required for the chip itself.
+```
+
+Edge cases:
+
+- **409 Conflict** — the tag is already attached. The response body
+  still carries the existing `assignment_id` + `tag`, so you can
+  reconcile local state without a re-fetch and **must not** show a red
+  error toast. Treat 409 as a no-op success.
+- **404 Not Found** — the tag id is not in this Platform. Show
+  "Tag not found." The API never leaks existence across Platforms.
+
+## Step 6: Detach control
+
+Render the host's `tags` array as `TagChip` components with `onDetach`
+wired to `detachTag(token, host, hostId, tag.id)`.
+
+Edge case:
+
+- **404 Not Found** on detach means the tag was not attached. Detach
+  is **not** idempotent server-side — a retried DELETE returns 404,
+  not 204. Client code should treat both as the same success state.
+  The wrapper above already does this.
+
+## Step 7: Tag filter on list views
+
+Wire a multi-select tag picker into the Person, Organization, and Deal
+list pages.
+
+The list endpoints accept repeated or comma-separated `tags`:
+
+```
+GET /api/crm/persons/?tags=7&tags=12
+GET /api/crm/persons/?tags=7,12
+```
+
+Both forms have **OR** semantics — a record matching any selected tag
+appears once (the backend de-duplicates). The filter composes with
+every other filter on the same endpoint, e.g.:
+
+```
+GET /api/crm/persons/?tags=7&lifecycle_stage=customer&owner=4
+```
+
+Implementation: bind the selected tag-ids to `URLSearchParams.append`
+so a `tags` array becomes repeated params, then refetch the list.
+
+## Destructive cascade callout
+
+> **Deleting a tag silently removes it from every Person, Organization,
+> and Deal it is attached to.** `DELETE /tags/{id}/` cascades — there
+> is no preview, no soft-delete, and no undo.
+
+Best practice [confirm before deleting a tag](../../../docs/developer/applications/crm.md#167-confirm-before-deleting-a-tag): gate the delete button behind a confirmation modal
+that **names the tag explicitly** ("Delete tag *Enterprise*?"), states
+the consequence ("This will remove the tag from N records across people,
+organizations, and deals."), and requires an affirmative second action
+(typing the tag name or clicking a destructive button), not a single
+"OK". Optionally pre-fetch impact counts:
+
+```
+GET /api/crm/persons/?tags={id}&page_size=1   → response.count
+GET /api/crm/organizations/?tags={id}&page_size=1
+GET /api/crm/deals/?tags={id}&page_size=1
+```
+
+See `references/tags-api.md` for the full endpoint contract, error
+shapes, and host attach/detach matrix.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and visit the surface in the browser:
+   - Open the tag manager. Try to create a tag with color `#FFF`
+     (three digits) — the client should reject it before the request
+     leaves; if you bypass the client check, the server returns
+     `400 {"color": ["Color must be a hex string like \`#3F6BFF\`."]}`.
+   - Create a valid tag (`name`: `Enterprise`, `color`: `#3F6BFF`).
+   - On a Person detail page, attach the tag. Confirm the chip
+     renders. Click attach a second time — UI must not flash an
+     error (409 path).
+   - On an Organization detail page, attach the same tag.
+   - On a Deal detail page, attach the same tag.
+   - Detach the tag from the Person — chip disappears.
+   - On the Person list view, filter by the tag (`?tags=<id>`) and
+     confirm only tagged people remain.
+   - Trigger the delete-tag confirmation modal — confirm copy names
+     the tag and warns about cascade.
+3. Screenshot:
+   ```bash
+   npx playwright screenshot http://localhost:3000/crm/tags /tmp/tags.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC
+- `/iblai-crm-lead-flow` — attach tags to persons and organizations
+- `/iblai-crm-deal-flow` — attach tags to deals; filter board by tag
+- `/iblai-rbac` — CRM User role required for tag writes
+- `/iblai-auth` — token wiring

--- a/skills/iblai-crm-tag/references/tags-api.md
+++ b/skills/iblai-crm-tag/references/tags-api.md
@@ -1,0 +1,240 @@
+# CRM Tags — API reference
+
+Condensed from the [Tags API](../../../../docs/developer/applications/crm.md#77-tags) (Tags resource) and [Tagging](../../../../docs/developer/applications/crm.md#11-tagging) (Tagging workflow).
+
+> **Base URL:** `${NEXT_PUBLIC_API_BASE_URL}/api/crm`
+> **Auth:** `Authorization: Token <token>` (same token wired by `/iblai-auth`)
+> **Scope:** Tags are scoped to your Platform. Existence across Platforms is
+> never leaked — a 404 means "not in your Platform" or "does not exist," and
+> the API does not distinguish.
+
+## Mental model
+
+- **Tag rows are the taxonomy; assignments are the chips you see on a record.**
+- A single Tag (`{name, color}`) lives once and may be attached to many host
+  records of different types.
+- Host serializers (Person, Organization, Deal) expose a read-only `tags`
+  array on every list and detail response. The array is always present —
+  empty array, never `null`. No second call is needed to render chips.
+
+## Tag CRUD
+
+| Method | Path | Purpose | Permission |
+|---|---|---|---|
+| GET | `/tags/` | List tags. Query: `name`, `created_at__gte`, `created_at__lte`, `page`, `page_size` | `Ibl.CRM/Tags/list` |
+| POST | `/tags/` | Create a tag | `Ibl.CRM/Tags/action` |
+| GET | `/tags/{id}/` | Retrieve one tag | `Ibl.CRM/Tags/read` |
+| PUT | `/tags/{id}/` | Replace editable fields | `Ibl.CRM/Tags/write` |
+| PATCH | `/tags/{id}/` | Patch supplied fields | `Ibl.CRM/Tags/write` |
+| DELETE | `/tags/{id}/` | Delete the tag — cascades to every host | `Ibl.CRM/Tags/delete` |
+
+### Tag shape
+
+```json
+{
+  "id": 7,
+  "platform": 1,
+  "name": "Enterprise",
+  "color": "#3F6BFF",
+  "metadata": {"order": 1},
+  "created_at": "2026-02-08T09:12:01Z",
+  "updated_at": "2026-02-08T09:12:01Z"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | integer | Server-assigned |
+| `platform` | integer | Owning Platform id |
+| `name` | string | Up to 64 chars, unique-per-Platform, **case-sensitive** after `.strip()` |
+| `color` | string | Hex `#RRGGBB`. Defaults to `#888888`. Six hex digits required — `#FFF` shorthand is rejected |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+| `created_at` / `updated_at` | datetime | Server-managed |
+
+### Hex color regex
+
+The server validates `color` against:
+
+```
+^#[0-9A-Fa-f]{6}$
+```
+
+Validate the same regex client-side **before** submit so the user sees the
+error immediately rather than on round-trip. Three-digit shorthand and
+named CSS colors are rejected.
+
+### POST `/tags/` body
+
+```json
+{"name": "Enterprise", "color": "#3F6BFF", "metadata": {"order": 1}}
+```
+
+### 400 errors
+
+```json
+{"name": ["A Tag with this name already exists in this Platform."]}
+{"name": ["Name must not be blank."]}
+{"name": ["Name must be at most 64 characters."]}
+{"color": ["Color must be a hex string like `#3F6BFF`."]}
+```
+
+### Rename behavior
+
+PATCH on `name` or `color` takes effect **immediately on every host** that
+carries the tag chip. Chips render `{id, name, color}` live from the Tag
+row, so a rename updates everywhere the tag appears without touching the
+assignment tables.
+
+### DELETE — destructive cascade
+
+> **DESTRUCTIVE.** Deleting a Tag silently cascades: every assignment to
+> every Person, Organization, and Deal is removed atomically. No preview,
+> no confirmation step from the API, no undo. A tag deleted by mistake
+> must be recreated by hand and re-attached to every record.
+
+Response: `204 No Content`. UI **must** carry the warning — see best
+practice [confirm before deleting a tag](../../../../docs/developer/applications/crm.md#167-confirm-before-deleting-a-tag). Pre-fetch impact counts with `?tags={id}&page_size=1`
+against each host list endpoint and surface them in the confirmation
+modal.
+
+## Host attach / detach (uniform contract)
+
+The contract is identical across host types — only the path prefix changes.
+`{host}` is one of `persons`, `organizations`, `deals`. Person and
+Organization ids are UUIDs; Deal ids are integers.
+
+| Method | Path | Purpose | Permission |
+|---|---|---|---|
+| POST | `/persons/{person_id}/tags/` | Attach tag to a person | `Ibl.CRM/Tags/write` |
+| DELETE | `/persons/{person_id}/tags/{tag_id}/` | Detach tag from a person | `Ibl.CRM/Tags/write` |
+| POST | `/organizations/{organization_id}/tags/` | Attach tag to an organization | `Ibl.CRM/Tags/write` |
+| DELETE | `/organizations/{organization_id}/tags/{tag_id}/` | Detach tag from an organization | `Ibl.CRM/Tags/write` |
+| POST | `/deals/{deal_id}/tags/` | Attach tag to a deal | `Ibl.CRM/Tags/write` |
+| DELETE | `/deals/{deal_id}/tags/{tag_id}/` | Detach tag from a deal | `Ibl.CRM/Tags/write` |
+
+**Critical permission rule.** All six attach/detach routes are gated by
+`Ibl.CRM/Tags/write`. Holding `Ibl.CRM/Persons/write`,
+`Ibl.CRM/Organizations/write`, or `Ibl.CRM/Deals/write` does **not**
+allow the caller to tag the record. A sales rep with full deal-edit rights
+but no tag-write rights still gets `403 Forbidden` from
+`POST /deals/{id}/tags/`. Check tag-write **separately** from host-write
+when deciding whether to render the "Add tag" affordance — see [permission-aware affordances](../../../../docs/developer/applications/crm.md#1611-permission-aware-affordances).
+
+### Attach request
+
+```json
+{"tag_id": 7}
+```
+
+`tag_id` is required, integer, must be ≥ 1, must belong to your Platform.
+
+### Attach `201 Created`
+
+```json
+{
+  "assignment_id": 532,
+  "tag": {"id": 7, "name": "Enterprise", "color": "#3F6BFF"}
+}
+```
+
+The embedded `tag` lets the client render the chip with no second
+round-trip.
+
+### Attach `409 Conflict` — already attached
+
+Same shape as 201, but `assignment_id` is the **existing** row:
+
+```json
+{
+  "detail": "Tag already attached.",
+  "assignment_id": 488,
+  "tag": {"id": 7, "name": "Enterprise", "color": "#3F6BFF"}
+}
+```
+
+Treat 409 as a **no-op success**. The user clicked twice or two tabs raced;
+the desired state is already in place. Use the returned `assignment_id`
+to reconcile local state without a re-fetch. Do **not** show a red
+error toast.
+
+### Attach errors
+
+| Status | Meaning |
+|---|---|
+| 400 | `{"tag_id": ["This field is required."]}` or `["Ensure this value is greater than or equal to 1."]` |
+| 403 | Missing `Ibl.CRM/Tags/write` |
+| 404 | Host id unknown, host on another Platform, or `{"detail": "Tag not found in this platform."}` |
+
+### Detach `204 No Content`
+
+Removes the assignment row only. The Tag itself is untouched.
+
+### Detach `404 Not Found` — treat as no-op
+
+```json
+{"detail": "Tag not attached to this record."}
+```
+
+Detach is **not idempotent** server-side — a second DELETE for the same
+pair returns 404, not 204. From the user's point of view both responses
+mean the tag is gone, so client code should treat 204 and 404 identically
+when reconciling local state.
+
+## Filtering by tag
+
+All three host list endpoints (`/persons/`, `/organizations/`, `/deals/`)
+accept a `tags` filter with **OR** semantics. Two equivalent forms:
+
+```
+GET /api/crm/persons/?tags=7&tags=12
+GET /api/crm/persons/?tags=7,12
+```
+
+Both queries return every person tagged with `7` *or* `12`. A record
+carrying both tags appears **once** — the backend de-duplicates, no
+client-side `DISTINCT` step needed.
+
+`tags` composes with every other filter on the list endpoint:
+
+```
+GET /api/crm/persons/?tags=7&lifecycle_stage=customer&owner=4
+```
+
+Response uses the standard pagination envelope:
+
+```json
+{"count": 14, "next_page": null, "previous_page": null, "results": [...]}
+```
+
+`next_page` and `previous_page` are integer page numbers or `null` at the
+boundaries — not URLs. Walk pages with `?page=N`. `page_size` is
+Platform-configurable; default may be smaller than your data set. See
+[pagination best practices](../../../../docs/developer/applications/crm.md#169-pagination).
+
+## Reading tags off a host
+
+Person, Organization, and Deal serializers expose a read-only `tags`
+array on every list and detail response:
+
+```json
+"tags": [
+  {"id": 7, "name": "VIP", "color": "#3F6BFF"},
+  {"id": 12, "name": "trial", "color": "#22AA66"}
+]
+```
+
+The array is **always present** — empty array, never `null` or missing.
+Renderers can iterate unconditionally.
+
+## RBAC summary
+
+| Verb | Permission | Default CRM role with it |
+|---|---|---|
+| List tags | `Ibl.CRM/Tags/list` | CRM Viewer + above |
+| Read tag | `Ibl.CRM/Tags/read` | CRM Viewer + above |
+| Create tag | `Ibl.CRM/Tags/action` | CRM User + above |
+| Update tag | `Ibl.CRM/Tags/write` | CRM User + above |
+| Delete tag | `Ibl.CRM/Tags/delete` | CRM User + above |
+| Attach / detach on any host | `Ibl.CRM/Tags/write` | CRM User + above |
+
+See `/iblai-rbac` for the full CRM role matrix.


### PR DESCRIPTION
## What

Six new skills covering the Platform-scoped CRM REST API at `/api/crm/`, following the same family pattern as `iblai-agent-*` and `iblai-security-*`:

| Skill | Purpose |
|---|---|
| `/iblai-crm-overview` | Reference + family index (auth, seeded defaults, RBAC, sub-skill map) |
| `/iblai-crm-lead-flow` | Lead capture, contacts table, organizations, link/invite/merge |
| `/iblai-crm-deal-flow` | Pipelines, stages, lead sources, kanban + move-stage/won/lost |
| `/iblai-crm-activity` | Timeline panel for persons and deals (call/meeting/note/task/etc.) |
| `/iblai-crm-tag` | Tag CRUD + attach/detach across persons/orgs/deals |
| `/iblai-crm-notification` | Reference for the three CRM event types and recipient routing |

Each skill ships its `SKILL.md` plus condensed `references/*.md` files (API field tables, state machine, onboarding decision tree, etc.).

## Why

Developers wanting to ship a CRM surface previously had to read the 4337-line CRM doc end-to-end. The suite breaks the API down along the workflow seams the doc already uses, so a developer can invoke `/iblai-crm-deal-flow` and walk straight to a working kanban.

## Also in this PR

- `CLAUDE.md` skill table — 6 new rows registering the suite
- `adapters/cursor/iblai-crm-*.mdc` + `adapters/codex/iblai-crm-*.md` — generated variants
