### PR TITLE
feat: add iblai-crm-overview skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 .env.local
+
+# Personal daily work log — never commit
+.daily-work-log/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,7 @@ Invoke with `/` in Claude Code:
 | `/iblai-agent-prompt` | Add the agent Prompts tab (system prompts and suggested prompts) |
 | `/iblai-agent-safety` | Add the agent Safety tab (moderation prompts and flagged content) |
 | `/iblai-agent-tool` | Add the agent Tools tab (enable/disable agent tools) |
+| `/iblai-crm-overview` | Reference + family index for the CRM API (auth, seeded defaults, RBAC roles, sub-skill map) |
 
 ### Marketing Skills
 

--- a/adapters/codex/iblai-crm-overview.md
+++ b/adapters/codex/iblai-crm-overview.md
@@ -1,0 +1,138 @@
+# iblai-crm-overview
+
+> Reference and family index for the ibl.ai Platform-scoped CRM REST API at /api/crm/ — auth, seeded defaults (default Pipeline + 6 stages + 4 Lead Sources), the four CRM RBAC roles (Viewer/User/Manager/Inviter), and the workflow sub-skill map. Use when the user mentions CRM, leads, pipelines, deals, contacts, or asks where a CRM workflow lives. See /iblai-crm-lead-flow for people + onboarding, /iblai-crm-deal-flow for pipelines + kanban, /iblai-crm-activity for the timeline, /iblai-crm-tag for tags, /iblai-crm-notification for CRM event routing, /iblai-auth for token wiring, /iblai-rbac for role assignment.
+
+# /iblai-crm-overview
+
+Reference skill for the ibl.ai CRM. Covers authentication, seeded
+defaults, the four CRM RBAC roles, and points to every sub-skill in
+the `iblai-crm-*` family. This skill builds no UI — open it first when
+you need orientation, then jump to the workflow skill that matches the
+surface you are building.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Authentication
+
+Every CRM endpoint lives under `/api/crm/` and requires a
+Platform-scoped token:
+
+```
+Authorization: Token <your-access-token>
+```
+
+Tokens bind to exactly one Platform at the moment of issue. The
+Platform is inferred from the token on every request — there is no
+`?platform_key=` query parameter on the consumer surface, and supplying
+one will not change the Platform a request resolves to.
+
+Records belonging to a different Platform return **`404 Not Found`,
+never `403 Forbidden`**. This is intentional: returning `403` would
+leak the existence of cross-Platform records. Treat a `404` on a
+record you just created as a sign you are pointing at the wrong
+Platform; a `403` always means "authenticated but the role does not
+grant this action."
+
+The full REST contract (base URL, pagination envelope, ID types per
+resource, side effects) is in
+[`references/api-overview.md`](./references/api-overview.md). For
+token wiring inside a Next.js app see `/iblai-auth`.
+
+## Seeded defaults
+
+The first time a Platform is provisioned, the CRM seeds a working
+configuration. You do not need to create any of these yourself — they
+exist on every Platform and back-fill into existing Platforms via a
+data migration.
+
+- **One default Pipeline** with `code="default"`, `is_default=true`,
+  `rotten_days=30`.
+- **Six default Stages** on that Pipeline, referenced by stable `code`:
+  `new` → `qualified` → `proposal` → `negotiation` → `won` (terminal,
+  `is_won=true`) and `lost` (terminal, `is_lost=true`).
+- **Four default Lead Sources**: `web`, `referral`, `cold_call`,
+  `advertisement`.
+
+The stage and lead-source `code` fields are stable across environments
+(dev / staging / prod) and across renames. Numeric `id` values are not
+— always reference seeds by `code` in client code, save the pipeline
+`id` only for the immediate deal payload.
+
+Full seeded tables (every stage's `probability` / `sort_order` /
+terminal flags, every lead source `name`) are in
+[`references/seeded-defaults.md`](./references/seeded-defaults.md).
+
+## RBAC
+
+The CRM ships four roles per Platform. Roles are seeded automatically
+on Platform provisioning and assigned through the standard
+role-management surface — the CRM does not expose its own
+role-assignment endpoints. A user may hold more than one role;
+effective permissions are the union.
+
+| Role | One-line mandate |
+|---|---|
+| **CRM Viewer** | Read everything across the CRM. Write nothing. |
+| **CRM User** | Day-to-day operator — full CRUD on people, organizations, deals, activities, tags. Pipelines are read-only. No invitations. |
+| **CRM Manager** | Wildcard CRM access — pipeline / stage / lead-source administration plus invitations. |
+| **CRM Inviter** | Narrow role — read people and send invitations only. Cannot edit or create people. |
+
+Two non-obvious rules worth a second look:
+- **Invitation is its own bucket.** `Ibl.CRM/Persons/write` does not
+  imply `Ibl.CRM/Invite/action`. Gate the "Invite" affordance
+  independently.
+- **Tag attach/detach requires `Ibl.CRM/Tags/write`.** A role with
+  `Ibl.CRM/Persons/write` cannot tag a person without it.
+
+Full HTTP-verb → action-code mapping and the action-by-action matrix
+are in [`references/rbac-matrix.md`](./references/rbac-matrix.md). For
+the management UI that lists and binds roles, see `/iblai-rbac`.
+
+## The CRM skill family
+
+Every CRM skill is prefixed `iblai-crm-*`. There is no bare umbrella
+skill — this skill is the index. Pick the one that matches the
+surface you are building.
+
+| Skill | Role | Covers |
+|---|---|---|
+| `/iblai-crm-overview` | Reference / index (this skill) | Auth, seeded defaults, RBAC roles, family map |
+| `/iblai-crm-lead-flow` | Build UI | People + Organizations + lifecycle stage + onboarding (link / invite / merge) |
+| `/iblai-crm-deal-flow` | Build UI | Pipelines + Stages + Lead Sources + Deals (kanban + move-stage / won / lost state machine) |
+| `/iblai-crm-activity` | Build UI | Activity timeline (calls, meetings, notes, tasks; schedule / remind / done) on persons and deals |
+| `/iblai-crm-tag` | Build UI | Tag CRUD + attach / detach for persons, organizations, deals |
+| `/iblai-crm-notification` | Reference | Three CRM notification types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) + recipient routing |
+
+When in doubt, start with `/iblai-crm-lead-flow` (a deal needs a
+person), then `/iblai-crm-deal-flow`, then layer `/iblai-crm-activity`
+and `/iblai-crm-tag` on the detail pages.
+
+## Related skills
+
+- `/iblai-crm-lead-flow` — People + Organizations + onboarding
+- `/iblai-crm-deal-flow` — Pipelines + Stages + Lead Sources + Deals
+- `/iblai-crm-activity` — Activity timeline for persons and deals
+- `/iblai-crm-tag` — Tag CRUD + attach / detach
+- `/iblai-crm-notification` — CRM notification types and recipient routing
+- `/iblai-auth` — Token wiring; every CRM call uses the same
+  `Authorization: Token <token>` header.
+- `/iblai-rbac` — Role-management UI (`<Admin>` → Roles + Policies
+  tabs) and the action-definitions endpoint. The four CRM roles are
+  assigned here.
+- **Brand guidelines**: [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md)

--- a/adapters/cursor/iblai-crm-overview.mdc
+++ b/adapters/cursor/iblai-crm-overview.mdc
@@ -1,0 +1,140 @@
+---
+description: "Reference and family index for the ibl.ai Platform-scoped CRM REST API at /api/crm/ — auth, seeded defaults (default Pipeline + 6 stages + 4 Lead Sources), the four CRM RBAC roles (Viewer/User/Manager/Inviter), and the workflow sub-skill map. Use when the user mentions CRM, leads, pipelines, deals, contacts, or asks where a CRM workflow lives. See /iblai-crm-lead-flow for people + onboarding, /iblai-crm-deal-flow for pipelines + kanban, /iblai-crm-activity for the timeline, /iblai-crm-tag for tags, /iblai-crm-notification for CRM event routing, /iblai-auth for token wiring, /iblai-rbac for role assignment."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-overview
+
+Reference skill for the ibl.ai CRM. Covers authentication, seeded
+defaults, the four CRM RBAC roles, and points to every sub-skill in
+the `iblai-crm-*` family. This skill builds no UI — open it first when
+you need orientation, then jump to the workflow skill that matches the
+surface you are building.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Authentication
+
+Every CRM endpoint lives under `/api/crm/` and requires a
+Platform-scoped token:
+
+```
+Authorization: Token <your-access-token>
+```
+
+Tokens bind to exactly one Platform at the moment of issue. The
+Platform is inferred from the token on every request — there is no
+`?platform_key=` query parameter on the consumer surface, and supplying
+one will not change the Platform a request resolves to.
+
+Records belonging to a different Platform return **`404 Not Found`,
+never `403 Forbidden`**. This is intentional: returning `403` would
+leak the existence of cross-Platform records. Treat a `404` on a
+record you just created as a sign you are pointing at the wrong
+Platform; a `403` always means "authenticated but the role does not
+grant this action."
+
+The full REST contract (base URL, pagination envelope, ID types per
+resource, side effects) is in
+[`references/api-overview.md`](./references/api-overview.md). For
+token wiring inside a Next.js app see `/iblai-auth`.
+
+## Seeded defaults
+
+The first time a Platform is provisioned, the CRM seeds a working
+configuration. You do not need to create any of these yourself — they
+exist on every Platform and back-fill into existing Platforms via a
+data migration.
+
+- **One default Pipeline** with `code="default"`, `is_default=true`,
+  `rotten_days=30`.
+- **Six default Stages** on that Pipeline, referenced by stable `code`:
+  `new` → `qualified` → `proposal` → `negotiation` → `won` (terminal,
+  `is_won=true`) and `lost` (terminal, `is_lost=true`).
+- **Four default Lead Sources**: `web`, `referral`, `cold_call`,
+  `advertisement`.
+
+The stage and lead-source `code` fields are stable across environments
+(dev / staging / prod) and across renames. Numeric `id` values are not
+— always reference seeds by `code` in client code, save the pipeline
+`id` only for the immediate deal payload.
+
+Full seeded tables (every stage's `probability` / `sort_order` /
+terminal flags, every lead source `name`) are in
+[`references/seeded-defaults.md`](./references/seeded-defaults.md).
+
+## RBAC
+
+The CRM ships four roles per Platform. Roles are seeded automatically
+on Platform provisioning and assigned through the standard
+role-management surface — the CRM does not expose its own
+role-assignment endpoints. A user may hold more than one role;
+effective permissions are the union.
+
+| Role | One-line mandate |
+|---|---|
+| **CRM Viewer** | Read everything across the CRM. Write nothing. |
+| **CRM User** | Day-to-day operator — full CRUD on people, organizations, deals, activities, tags. Pipelines are read-only. No invitations. |
+| **CRM Manager** | Wildcard CRM access — pipeline / stage / lead-source administration plus invitations. |
+| **CRM Inviter** | Narrow role — read people and send invitations only. Cannot edit or create people. |
+
+Two non-obvious rules worth a second look:
+- **Invitation is its own bucket.** `Ibl.CRM/Persons/write` does not
+  imply `Ibl.CRM/Invite/action`. Gate the "Invite" affordance
+  independently.
+- **Tag attach/detach requires `Ibl.CRM/Tags/write`.** A role with
+  `Ibl.CRM/Persons/write` cannot tag a person without it.
+
+Full HTTP-verb → action-code mapping and the action-by-action matrix
+are in [`references/rbac-matrix.md`](./references/rbac-matrix.md). For
+the management UI that lists and binds roles, see `/iblai-rbac`.
+
+## The CRM skill family
+
+Every CRM skill is prefixed `iblai-crm-*`. There is no bare umbrella
+skill — this skill is the index. Pick the one that matches the
+surface you are building.
+
+| Skill | Role | Covers |
+|---|---|---|
+| `/iblai-crm-overview` | Reference / index (this skill) | Auth, seeded defaults, RBAC roles, family map |
+| `/iblai-crm-lead-flow` | Build UI | People + Organizations + lifecycle stage + onboarding (link / invite / merge) |
+| `/iblai-crm-deal-flow` | Build UI | Pipelines + Stages + Lead Sources + Deals (kanban + move-stage / won / lost state machine) |
+| `/iblai-crm-activity` | Build UI | Activity timeline (calls, meetings, notes, tasks; schedule / remind / done) on persons and deals |
+| `/iblai-crm-tag` | Build UI | Tag CRUD + attach / detach for persons, organizations, deals |
+| `/iblai-crm-notification` | Reference | Three CRM notification types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) + recipient routing |
+
+When in doubt, start with `/iblai-crm-lead-flow` (a deal needs a
+person), then `/iblai-crm-deal-flow`, then layer `/iblai-crm-activity`
+and `/iblai-crm-tag` on the detail pages.
+
+## Related skills
+
+- `/iblai-crm-lead-flow` — People + Organizations + onboarding
+- `/iblai-crm-deal-flow` — Pipelines + Stages + Lead Sources + Deals
+- `/iblai-crm-activity` — Activity timeline for persons and deals
+- `/iblai-crm-tag` — Tag CRUD + attach / detach
+- `/iblai-crm-notification` — CRM notification types and recipient routing
+- `/iblai-auth` — Token wiring; every CRM call uses the same
+  `Authorization: Token <token>` header.
+- `/iblai-rbac` — Role-management UI (`<Admin>` → Roles + Policies
+  tabs) and the action-definitions endpoint. The four CRM roles are
+  assigned here.
+- **Brand guidelines**: [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md)

--- a/skills/iblai-crm-overview/SKILL.md
+++ b/skills/iblai-crm-overview/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: iblai-crm-overview
+description: Reference and family index for the ibl.ai Platform-scoped CRM REST API at /api/crm/ — auth, seeded defaults (default Pipeline + 6 stages + 4 Lead Sources), the four CRM RBAC roles (Viewer/User/Manager/Inviter), and the workflow sub-skill map. Use when the user mentions CRM, leads, pipelines, deals, contacts, or asks where a CRM workflow lives. See /iblai-crm-lead-flow for people + onboarding, /iblai-crm-deal-flow for pipelines + kanban, /iblai-crm-activity for the timeline, /iblai-crm-tag for tags, /iblai-crm-notification for CRM event routing, /iblai-auth for token wiring, /iblai-rbac for role assignment.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-overview
+
+Reference skill for the ibl.ai CRM. Covers authentication, seeded
+defaults, the four CRM RBAC roles, and points to every sub-skill in
+the `iblai-crm-*` family. This skill builds no UI — open it first when
+you need orientation, then jump to the workflow skill that matches the
+surface you are building.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Authentication
+
+Every CRM endpoint lives under `/api/crm/` and requires a
+Platform-scoped token:
+
+```
+Authorization: Token <your-access-token>
+```
+
+Tokens bind to exactly one Platform at the moment of issue. The
+Platform is inferred from the token on every request — there is no
+`?platform_key=` query parameter on the consumer surface, and supplying
+one will not change the Platform a request resolves to.
+
+Records belonging to a different Platform return **`404 Not Found`,
+never `403 Forbidden`**. This is intentional: returning `403` would
+leak the existence of cross-Platform records. Treat a `404` on a
+record you just created as a sign you are pointing at the wrong
+Platform; a `403` always means "authenticated but the role does not
+grant this action."
+
+The full REST contract (base URL, pagination envelope, ID types per
+resource, side effects) is in
+[`references/api-overview.md`](./references/api-overview.md). For
+token wiring inside a Next.js app see `/iblai-auth`.
+
+## Seeded defaults
+
+The first time a Platform is provisioned, the CRM seeds a working
+configuration. You do not need to create any of these yourself — they
+exist on every Platform and back-fill into existing Platforms via a
+data migration.
+
+- **One default Pipeline** with `code="default"`, `is_default=true`,
+  `rotten_days=30`.
+- **Six default Stages** on that Pipeline, referenced by stable `code`:
+  `new` → `qualified` → `proposal` → `negotiation` → `won` (terminal,
+  `is_won=true`) and `lost` (terminal, `is_lost=true`).
+- **Four default Lead Sources**: `web`, `referral`, `cold_call`,
+  `advertisement`.
+
+The stage and lead-source `code` fields are stable across environments
+(dev / staging / prod) and across renames. Numeric `id` values are not
+— always reference seeds by `code` in client code, save the pipeline
+`id` only for the immediate deal payload.
+
+Full seeded tables (every stage's `probability` / `sort_order` /
+terminal flags, every lead source `name`) are in
+[`references/seeded-defaults.md`](./references/seeded-defaults.md).
+
+## RBAC
+
+The CRM ships four roles per Platform. Roles are seeded automatically
+on Platform provisioning and assigned through the standard
+role-management surface — the CRM does not expose its own
+role-assignment endpoints. A user may hold more than one role;
+effective permissions are the union.
+
+| Role | One-line mandate |
+|---|---|
+| **CRM Viewer** | Read everything across the CRM. Write nothing. |
+| **CRM User** | Day-to-day operator — full CRUD on people, organizations, deals, activities, tags. Pipelines are read-only. No invitations. |
+| **CRM Manager** | Wildcard CRM access — pipeline / stage / lead-source administration plus invitations. |
+| **CRM Inviter** | Narrow role — read people and send invitations only. Cannot edit or create people. |
+
+Two non-obvious rules worth a second look:
+- **Invitation is its own bucket.** `Ibl.CRM/Persons/write` does not
+  imply `Ibl.CRM/Invite/action`. Gate the "Invite" affordance
+  independently.
+- **Tag attach/detach requires `Ibl.CRM/Tags/write`.** A role with
+  `Ibl.CRM/Persons/write` cannot tag a person without it.
+
+Full HTTP-verb → action-code mapping and the action-by-action matrix
+are in [`references/rbac-matrix.md`](./references/rbac-matrix.md). For
+the management UI that lists and binds roles, see `/iblai-rbac`.
+
+## The CRM skill family
+
+Every CRM skill is prefixed `iblai-crm-*`. There is no bare umbrella
+skill — this skill is the index. Pick the one that matches the
+surface you are building.
+
+| Skill | Role | Covers |
+|---|---|---|
+| `/iblai-crm-overview` | Reference / index (this skill) | Auth, seeded defaults, RBAC roles, family map |
+| `/iblai-crm-lead-flow` | Build UI | People + Organizations + lifecycle stage + onboarding (link / invite / merge) |
+| `/iblai-crm-deal-flow` | Build UI | Pipelines + Stages + Lead Sources + Deals (kanban + move-stage / won / lost state machine) |
+| `/iblai-crm-activity` | Build UI | Activity timeline (calls, meetings, notes, tasks; schedule / remind / done) on persons and deals |
+| `/iblai-crm-tag` | Build UI | Tag CRUD + attach / detach for persons, organizations, deals |
+| `/iblai-crm-notification` | Reference | Three CRM notification types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) + recipient routing |
+
+When in doubt, start with `/iblai-crm-lead-flow` (a deal needs a
+person), then `/iblai-crm-deal-flow`, then layer `/iblai-crm-activity`
+and `/iblai-crm-tag` on the detail pages.
+
+## Related skills
+
+- `/iblai-crm-lead-flow` — People + Organizations + onboarding
+- `/iblai-crm-deal-flow` — Pipelines + Stages + Lead Sources + Deals
+- `/iblai-crm-activity` — Activity timeline for persons and deals
+- `/iblai-crm-tag` — Tag CRUD + attach / detach
+- `/iblai-crm-notification` — CRM notification types and recipient routing
+- `/iblai-auth` — Token wiring; every CRM call uses the same
+  `Authorization: Token <token>` header.
+- `/iblai-rbac` — Role-management UI (`<Admin>` → Roles + Policies
+  tabs) and the action-definitions endpoint. The four CRM roles are
+  assigned here.
+- **Brand guidelines**: [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md)

--- a/skills/iblai-crm-overview/references/api-overview.md
+++ b/skills/iblai-crm-overview/references/api-overview.md
@@ -1,0 +1,132 @@
+# CRM REST API — Overview
+
+The at-a-glance contract that every CRM sub-skill builds on. Pair with
+the per-resource references in the `iblai-crm-lead-flow`,
+`iblai-crm-deal-flow`, `iblai-crm-activity`, and `iblai-crm-tag`
+skills.
+
+## Base URL
+
+```
+/api/crm/
+```
+
+Mounted on the same Platform host as the rest of the ibl.ai API. In a
+Next.js app the host comes from `NEXT_PUBLIC_API_BASE_URL`
+(e.g. `https://api.iblai.app/dm/api/crm/...`). The Platform is inferred
+from the token — there is no `?platform_key=` parameter on the
+consumer surface.
+
+## Authentication
+
+```
+Authorization: Token YOUR_ACCESS_TOKEN
+```
+
+Required on every method (`GET`, `POST`, `PATCH`, `PUT`, `DELETE`)
+and every resource. Tokens bind to exactly one Platform; cross-Platform
+records return `404 Not Found`, never `403 Forbidden`.
+
+Failure modes:
+
+| Status | Meaning |
+|---|---|
+| `401` | Header missing / malformed / expired token |
+| `403` | Authenticated but role does not grant this action (or a service-account key is bound to a different Platform) |
+| `404` | Record does not exist *on your Platform* (existence is not leaked across Platforms) |
+| `409` | Conflict — tag already attached, pending invitation exists, or pipeline/stage delete attempted with deals still attached |
+| `422` | Unprocessable — e.g. invite attempted on a person already linked to a Platform user |
+
+## Pagination envelope
+
+Every list endpoint returns:
+
+```json
+{
+  "count": 142,
+  "next_page": 2,
+  "previous_page": null,
+  "results": [ ... ]
+}
+```
+
+- `next_page` and `previous_page` are **integer page numbers** (or
+  `null` at the edges). They are NOT URLs.
+- Walk pages with `?page=N`.
+- `page_size` is configurable per Platform; **max `page_size=100`**.
+  Treat the returned page size as authoritative — do not assume a
+  fixed number of rows.
+
+## The eight resources
+
+| Resource | URL prefix | ID type | Scoped to |
+|---|---|---|---|
+| Person | `/api/crm/persons/` | UUID string | Platform |
+| Organization | `/api/crm/organizations/` | UUID string | Platform |
+| Pipeline | `/api/crm/pipelines/` | integer | Platform |
+| Stage | `/api/crm/pipelines/{pipeline_id}/stages/` | integer | Pipeline |
+| Lead Source | `/api/crm/lead-sources/` | integer | Platform |
+| Deal | `/api/crm/deals/` | integer | Platform |
+| Activity | `/api/crm/activities/` | integer | Platform |
+| Tag | `/api/crm/tags/` | integer | Platform |
+
+Persons and Organizations use UUIDs so they can be minted client-side
+and survive cross-system imports. Everything else uses integer IDs.
+
+## Common envelope fields
+
+Every resource returns three standard fields on read:
+
+- `created_at` — ISO-8601 timestamp, set on insert
+- `updated_at` — ISO-8601 timestamp, refreshed on every save
+- `metadata` — free-form JSON object the integrator owns
+
+`Person`, `Organization`, `Deal`, and `Activity` additionally carry an
+`owner` foreign key (Platform user id). `Person`, `Organization`, and
+`Deal` expose a read-only `tags` array — mutate via the attach/detach
+endpoints, never by `PATCH`ing the host.
+
+Server-managed fields that clients must never send on write:
+
+| Resource | Fields | Why |
+|---|---|---|
+| Person | `platform_user`, `active` | Set by `/link-user/` or auto-link signal |
+| Deal | `status`, `closed_at` | Derived from current stage + won/lost actions |
+| Activity | `done_at`, `reminder_sent` | Stamped on completion / reminder dispatch |
+
+## Side effects on write
+
+Three classes of write trigger automatic follow-up work. All
+notifications dispatch asynchronously **after the transaction
+commits** — a write that rolls back produces no notification.
+
+| Trigger | Side effect |
+|---|---|
+| Create a Person (any code path: API, admin, bulk import) | `CRM_PERSON_CREATED` notification |
+| `POST /deals/{id}/move-stage/`, `/won/`, `/lost/` to a different stage | (1) audit `Activity` row — `type="note"`, `title="Stage changed"`, marked done, with from→to display names in the `comment`; (2) `CRM_DEAL_STAGE_CHANGED` notification to the deal's owner |
+| `POST /persons/{id}/link-user/` (explicit) or signup auto-link by email | `CRM_PERSON_LINKED_TO_USER` notification |
+
+Transitions that resolve to the deal's current stage are suppressed:
+no write, no audit row, no notification.
+
+## Pagination + filtering dialect
+
+Three patterns recur across resources:
+
+- **Date ranges.** Any field suffixed `__gte` / `__lte` accepts an
+  ISO-8601 date or datetime. Both bounds are inclusive.
+- **Foreign-key filters.** Pass the related record's primary
+  identifier — numeric IDs for users / pipelines, UUIDs for persons /
+  organizations / deals.
+- **Tag filters.** `?tags=7&tags=12` or `?tags=7,12`. Both forms use
+  OR semantics; the response never duplicates rows when a record
+  matches multiple tag IDs.
+
+Person and Deal list endpoints additionally support
+`?metadata__has_key=fieldName` — strict key presence (`null` values
+count, missing keys do not). There is no operator for filtering by
+metadata value.
+
+There is **no cross-resource search endpoint** and no substring
+filter on `Person.name`. Combine the filters above and do final
+substring matching client-side if needed.

--- a/skills/iblai-crm-overview/references/rbac-matrix.md
+++ b/skills/iblai-crm-overview/references/rbac-matrix.md
@@ -1,0 +1,107 @@
+# CRM RBAC Matrix
+
+The CRM ships four roles per Platform. Roles are seeded automatically
+on Platform provisioning — there is nothing to create. Assign them
+through the standard Platform role-management surface (`<Admin>` →
+Roles + Policies — see `/iblai-rbac`); the CRM does not expose its own
+role-assignment endpoints. A single user may hold more than one role
+and effective permissions are the union.
+
+## The four roles
+
+**CRM Viewer.** Read-only across the entire CRM. Sees every Person,
+Organization, Pipeline, Stage, Lead Source, Deal, Activity, and Tag,
+but cannot create, update, delete, or send invitations. Right role
+for sales-ops dashboards, finance reviewers, and any audience that
+needs visibility without write access.
+
+**CRM User.** The day-to-day operator. Full create / update / delete
+on people, organizations, deals, activities, and tags — the records
+that move during normal sales work. Pipelines, stages, and lead
+sources are **read-only** for this role — pipeline topology is an
+admin job. Cannot send invitations (that lives in a separate bucket).
+Right role for individual sales reps and account managers.
+
+**CRM Manager.** Wildcard access to every CRM action. Adds
+pipeline / stage / lead-source administration and invitation sending
+on top of everything the CRM User can do. Right role for sales
+leadership and CRM admins.
+
+**CRM Inviter.** A narrow role: read people and send invitations
+only. Cannot edit or create people, cannot see organizations or
+deals. Right role for partner-portal flows, gated onboarding teams,
+or any surface that needs to turn known leads into Platform users
+without exposing the broader pipeline.
+
+## Action-by-action matrix
+
+Action codes follow the bucket convention `Ibl.CRM/<Resource>/<verb>`
+with five canonical verbs: `list`, `read`, `action`, `write`,
+`delete`. `action` covers create (`POST`) and custom verb endpoints
+(`move-stage`, `won`, `lost`, `done`, `link-user`, `merge`).
+
+| Resource bucket | Action codes | Viewer | User | Manager | Inviter |
+|---|---|---|---|---|---|
+| `Ibl.CRM/Persons` | `list`, `read` | ✓ | ✓ | ✓ | ✓ |
+| `Ibl.CRM/Persons` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Organizations` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Organizations` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Pipelines` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Pipelines` | `action`, `write`, `delete` | — | — | ✓ | — |
+| `Ibl.CRM/Deals` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Deals` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Activities` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Activities` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Tags` | `list`, `read` | ✓ | ✓ | ✓ | — |
+| `Ibl.CRM/Tags` | `action`, `write`, `delete` | — | ✓ | ✓ | — |
+| `Ibl.CRM/Invite` | `action` | — | — | ✓ | ✓ |
+
+Notes:
+- **Lead Source endpoints fall under `Ibl.CRM/Pipelines`.** They are
+  administrative — only CRM Manager can create / update / delete a
+  lead source even though CRM Users will reference them on Deals.
+- **Stage CRUD also lives under `Ibl.CRM/Pipelines`.** Moving a
+  *stage* is admin work (Manager only); moving a *deal* between
+  stages is a Deal `action` (User or Manager).
+
+## HTTP verb → action code mapping
+
+| HTTP | Action code |
+|---|---|
+| `GET` (list endpoint) | `list` |
+| `GET` (detail endpoint) | `read` |
+| `POST` (create) | `action` |
+| `POST` (custom: `move-stage`, `won`, `lost`, `done`, `link-user`, `merge`) | `action` |
+| `POST` attach-tag, `DELETE` detach-tag | `write` (on `Ibl.CRM/Tags`) |
+| `PATCH` / `PUT` | `write` |
+| `DELETE` (resource delete) | `delete` |
+
+## Two permissions worth a second look
+
+- **Invitation is its own bucket.** A role with
+  `Ibl.CRM/Persons/write` does **not** have `Ibl.CRM/Invite/action`.
+  Gate the "Invite" affordance independently of the Person edit
+  affordance — they are distinct rights.
+- **Tag attach/detach requires `Ibl.CRM/Tags/write`.** A role with
+  `Ibl.CRM/Persons/write` cannot tag a person without it. This is
+  intentional — it lets you delegate tag-graph mutation separately
+  from person mutation.
+
+## Assigning the roles
+
+The CRM does not ship a role-assignment UI of its own. Use the
+SDK-provided management surface:
+
+- `<Admin>` (mounted via `<Account>` — see `/iblai-account`) →
+  **Roles** tab to inspect / edit the seeded CRM roles, and
+  **Policies** tab to bind a role to a user or group on the
+  Platform resource scope.
+- Or call `POST rbac/policies/` directly (see the REST contract
+  under `/iblai-agent-access` → "Roles CRUD").
+- For per-action gating in your CRM surfaces, hydrate
+  `rbacPermissions` via `POST rbac/permissions/check/` and gate the
+  affordance with `checkRbacPermission(rbacPermissions, path,
+  enableRbac)` from `@iblai/iblai-js/web-utils`.
+
+See `/iblai-rbac` for the full management-UI walkthrough and the
+action-definitions endpoint.

--- a/skills/iblai-crm-overview/references/seeded-defaults.md
+++ b/skills/iblai-crm-overview/references/seeded-defaults.md
@@ -1,0 +1,78 @@
+# CRM Seeded Defaults
+
+Every Platform ships with a working CRM configuration the first time
+it is provisioned. Existing Platforms have the same seeds back-filled
+by a data migration. You do not need to create any of the records
+below — they are present on every Platform and can be edited,
+renamed, or extended.
+
+> **Reference seeds by `code`, not `id`.** The `code` value on
+> stages and lead sources is stable across environments (dev /
+> staging / prod) and survives display-name renames. The numeric `id`
+> values differ between environments and should only be cached for
+> the lifetime of a single request (e.g. saving the pipeline `id`
+> long enough to build a deal payload).
+
+## Default Pipeline
+
+A single Pipeline is seeded and marked as the default:
+
+| Field | Value |
+|---|---|
+| `code` | `default` |
+| `is_default` | `true` |
+| `rotten_days` | `30` |
+
+Filter for it with `GET /api/crm/pipelines/?is_default=true`. The
+response embeds the six default stages inline (no second request
+needed).
+
+## Default Stages (on the default Pipeline)
+
+Six stages, ordered by `sort_order`. The first four are non-terminal
+(in-flight). `won` and `lost` are terminal — moving a deal into one
+of them stamps `closed_at` and updates `Deal.status` automatically.
+
+| `code` | `name` | `probability` | `sort_order` | `is_won` | `is_lost` |
+|---|---|---|---|---|---|
+| `new` | New | 10 | 0 | false | false |
+| `qualified` | Qualified | 25 | 1 | false | false |
+| `proposal` | Proposal | 50 | 2 | false | false |
+| `negotiation` | Negotiation | 75 | 3 | false | false |
+| `won` | Won | 100 | 4 | **true** | false |
+| `lost` | Lost | 0 | 5 | false | **true** |
+
+Notes:
+- `probability` is a 0–100 integer used for weighted-pipeline reports.
+- `sort_order` drives kanban column placement left-to-right.
+- The `/deals/{id}/won/` and `/deals/{id}/lost/` action endpoints
+  resolve to the first stage of the matching kind by `sort_order`
+  (`won` here, `lost` here). Pass `stage_code` only when a Platform
+  has multiple terminal stages of one kind.
+
+## Default Lead Sources
+
+Four lead sources are seeded — the channels that produced a Deal.
+They live under the `Ibl.CRM/Pipelines/` RBAC bucket because shaping
+attribution categories is an administrative job.
+
+| `code` | `name` |
+|---|---|
+| `web` | Web |
+| `referral` | Referral |
+| `cold_call` | Cold Call |
+| `advertisement` | Advertisement |
+
+The `source` field on Deal is a nullable foreign key — leave it
+`null` for an unattributed deal.
+
+## What is not seeded
+
+- **No default Persons / Organizations / Deals / Activities / Tags.**
+  The CRM is empty on Platform creation. The seeds above are the
+  topology you can build on top of, not data.
+- **No default Tag palette.** Tags must be created before they can be
+  attached (see `/iblai-crm-tag`).
+- **No default custom-metadata schema.** `metadata` is an open
+  free-form JSON object on every resource — the integrator owns the
+  shape end-to-end.


### PR DESCRIPTION
## What

- New skill `/iblai-crm-overview` — reference + family index for the Platform-scoped CRM REST API at `/api/crm/`. Covers auth (`Authorization: Token <token>` header, Platform scoping), seeded defaults (default Pipeline + 6 stages + 4 Lead Sources), the four CRM RBAC roles (Viewer / User / Manager / Inviter), and a map of the upcoming workflow sub-skills.
- 3 reference docs: `api-overview.md`, `seeded-defaults.md`, `rbac-matrix.md`
- Generated Cursor + Codex adapter variants
- 1 row added to the Skills table in `CLAUDE.md`
- `.gitignore` now excludes `.daily-work-log/` (personal per-developer notebook)

## Why

Foundation for the `iblai-crm-*` skill family. Future PRs (lead-flow, deal-flow, activity, tag, notification) all cross-reference this skill for shared setup, auth, and RBAC — landing it first lets each follow-up PR stay narrow.

## Test plan

- [ ] `node scripts/build-adapters.mjs` regenerates cleanly
- [ ] `/iblai-crm-overview` invocation loads in Claude Code
- [ ] CLAUDE.md skills table renders correctly