### PR TITLE
feat: add iblai-crm-lead-flow and iblai-crm-deal-flow skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,8 @@ Invoke with `/` in Claude Code:
 | `/iblai-agent-safety` | Add the agent Safety tab (moderation prompts and flagged content) |
 | `/iblai-agent-tool` | Add the agent Tools tab (enable/disable agent tools) |
 | `/iblai-crm-overview` | Reference + family index for the CRM API (auth, seeded defaults, RBAC roles, sub-skill map) |
+| `/iblai-crm-lead-flow` | Add the CRM top-of-funnel surface (lead capture, contacts table, person detail, link/invite/merge) |
+| `/iblai-crm-deal-flow` | Add the CRM revenue surface (pipelines, stages, lead sources, kanban deal board, move-stage/won/lost) |
 
 ### Marketing Skills
 

--- a/adapters/codex/iblai-crm-deal-flow.md
+++ b/adapters/codex/iblai-crm-deal-flow.md
@@ -1,0 +1,383 @@
+# iblai-crm-deal-flow
+
+> Build the revenue funnel CRM surface — pipelines, stages, lead sources, and the kanban deal board with move-stage / won / lost transitions. Use when the user mentions deals, kanban, pipeline, stages, lead sources, move stage, mark won, mark lost, lost reason, deal status, or sales funnel. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for persons (deals require one), /iblai-crm-activity for the timeline + audit rows, and /iblai-crm-notification for CRM_DEAL_STAGE_CHANGED routing.
+
+# /iblai-crm-deal-flow
+
+Build the revenue funnel: a pipeline selector, a kanban deal board (columns = stages, cards = deals), and the move-stage / won / lost state machine with `lost_reason` collection.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — reuse the same token wiring
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- A Person already exists in the CRM. Deals REQUIRE a `person` UUID — if
+  you have not built the lead capture surface yet, do `/iblai-crm-lead-flow`
+  first and come back.
+- RBAC role on the caller:
+  - `CRM User` — list, read, create, update, delete deals; call
+    `move-stage/`, `won/`, `lost/`. This is what 95% of sales reps need.
+  - `CRM Manager` — additionally lets you CRUD pipelines, stages, and
+    lead sources. Only needed if you're building the admin UI in Step 8.
+  - See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+1. **Pipeline selector** — defaults to the seeded `default` pipeline; lets
+   the user switch when more than one exists.
+2. **Kanban board** — one column per stage in `sort_order`, cards grouped
+   by `deal.stage`. Card shows title, `lead_value` + `currency`, person
+   name, and days-in-stage.
+3. **Drag-drop → `move-stage`** — using `@dnd-kit`, fires
+   `POST /deals/{id}/move-stage/` with `{stage_code}`.
+4. **Deal detail panel** — clicking a card opens a slide-over with full
+   deal fields and **Won** / **Lost** buttons.
+5. **Lost modal** — collects required `lost_reason` before hitting
+   `POST /deals/{id}/lost/`.
+6. **(Optional) Admin UI** — pipeline + stage + lead source CRUD for
+   `CRM Manager` users.
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date.
+Run `iblai --version`, then upgrade directly:
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+## Step 1: Install shadcn primitives + dnd-kit
+
+```bash
+npx shadcn@latest add card badge dialog select button input textarea form sheet skeleton
+pnpm add @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+`@dnd-kit` is the recommended dnd primitive — accessible, headless, plays
+well with shadcn `card`. Do not write a custom drag layer.
+
+## Step 2: Typed API client wrappers
+
+Reuse the auth token wiring from `/iblai-auth` — do NOT introduce a new
+token-management layer. Read the same `Token` value the rest of the app
+uses (the SDK persists it; client code can grab it from `localStorage` or
+from the auth context).
+
+Create `lib/iblai/crm.ts` with thin typed fetchers:
+
+```ts
+// lib/iblai/crm.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+type Stage = {
+  id: number; pipeline: number; code: string; name: string;
+  probability: number; sort_order: number;
+  is_won: boolean; is_lost: boolean; metadata: Record<string, unknown>;
+};
+
+type Pipeline = {
+  id: number; name: string; code: string; is_default: boolean;
+  rotten_days: number; stages: Stage[]; metadata: Record<string, unknown>;
+};
+
+type Deal = {
+  id: number; title: string; description: string;
+  lead_value: string; currency: string;
+  status: "open" | "won" | "lost"; lost_reason: string;
+  expected_close_date: string | null; closed_at: string | null;
+  person: string; organization: string | null;
+  pipeline: number; stage: number;
+  source: number | null; owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string; updated_at: string;
+};
+
+const h = (token: string) => ({
+  Authorization: `Token ${token}`,
+  "Content-Type": "application/json",
+});
+
+export const crm = {
+  listPipelines: (token: string, params = "") =>
+    fetch(`${BASE}/pipelines/${params}`, { headers: h(token) }).then(r => r.json()),
+  listLeadSources: (token: string) =>
+    fetch(`${BASE}/lead-sources/`, { headers: h(token) }).then(r => r.json()),
+  listDeals: (token: string, pipelineId: number) =>
+    fetch(`${BASE}/deals/?pipeline=${pipelineId}&status=open`, { headers: h(token) })
+      .then(r => r.json()),
+  createDeal: (token: string, body: Partial<Deal>) =>
+    fetch(`${BASE}/deals/`, { method: "POST", headers: h(token), body: JSON.stringify(body) })
+      .then(r => r.json()),
+  moveStage: (token: string, id: number, stage_code: string) =>
+    fetch(`${BASE}/deals/${id}/move-stage/`, {
+      method: "POST", headers: h(token), body: JSON.stringify({ stage_code }),
+    }).then(r => r.json()),
+  won: (token: string, id: number, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/won/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify(stage_code ? { stage_code } : {}),
+    }).then(r => r.json()),
+  lost: (token: string, id: number, lost_reason: string, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/lost/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify({ lost_reason, ...(stage_code ? { stage_code } : {}) }),
+    }).then(r => r.json()),
+};
+```
+
+Full endpoint catalogs and field tables live in
+[`references/pipelines-api.md`](./references/pipelines-api.md),
+[`references/lead-sources-api.md`](./references/lead-sources-api.md), and
+[`references/deals-api.md`](./references/deals-api.md).
+
+## Step 3: Fetch the default pipeline once on mount
+
+Every Platform is seeded with a default pipeline (`code=default`) carrying
+six stages — `new`, `qualified`, `proposal`, `negotiation`, `won`, `lost`.
+The list response embeds the ordered `stages` array inline, so you do not
+need a second roundtrip.
+
+```ts
+const { results } = await crm.listPipelines(token, "?is_default=true");
+const pipeline = results[0];
+// Index stages by CODE — not id. Codes are stable across environments;
+// ids differ between dev / staging / prod (see the CRM doc's [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)).
+const stagesByCode = Object.fromEntries(pipeline.stages.map((s) => [s.code, s]));
+const stagesById = Object.fromEntries(pipeline.stages.map((s) => [s.id, s]));
+```
+
+Cache `pipeline.id` and the stages object in your store (Zustand, Redux,
+or React state). The board only needs to re-fetch when the user switches
+pipelines.
+
+## Step 4: Render the kanban board
+
+```ts
+const { results: deals } = await crm.listDeals(token, pipeline.id);
+const columns = pipeline.stages
+  .filter((s) => !s.is_won && !s.is_lost)        // hide terminal columns on the open board
+  .sort((a, b) => a.sort_order - b.sort_order);
+const byStage = Object.groupBy(deals, (d) => d.stage); // group cards by Deal.stage (the stage id)
+```
+
+Card content:
+- `title` — bold, truncated to 1 line
+- `lead_value` formatted with `Intl.NumberFormat` + `currency`
+- Person name (look up via `/iblai-crm-lead-flow` person store)
+- Days-in-stage = `dayjs().diff(deal.updated_at, "day")`; flag in red when
+  it exceeds `pipeline.rotten_days` (default 30)
+
+Use shadcn `card` for cards, `badge` for the stage chip, `skeleton` for
+the initial loading state.
+
+## Step 5: Drag-drop → move-stage
+
+Wire `@dnd-kit`'s `DndContext` around the columns. On drop, derive the
+destination stage CODE (never raw id — see [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)) and call:
+
+```ts
+async function onDragEnd(deal: Deal, destStageCode: string) {
+  const dest = stagesByCode[destStageCode];
+  if (!dest) return;
+  if (dest.id === deal.stage) return;      // no-op guard — see [Idempotency](../../../docs/developer/applications/crm.md#96-idempotency)
+  const updated = await crm.moveStage(token, deal.id, destStageCode);
+  setDeals((prev) => prev.map((d) => (d.id === deal.id ? updated : d)));
+}
+```
+
+**Server side effects to call out in the UI:**
+
+- The server appends an audit Activity (`type=note`,
+  `title="Stage changed"`, `comment="<from> → <to>"`,
+  `is_done=true`). This row will appear in the deal timeline — render it
+  with a distinct icon and no edit controls per
+  `/iblai-crm-activity` ([best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- A `CRM_DEAL_STAGE_CHANGED` notification fires. See
+  `/iblai-crm-notification` for recipient routing and channel config.
+- `Deal.status` is recomputed from the destination stage's `is_won` /
+  `is_lost` flags. Do **not** echo the optimistic status — re-read from
+  the server response.
+- Dragging onto the same column is **suppressed server-side** (no write,
+  no notification, no audit row). Gate the call client-side too so the
+  UI does not flash. See `references/state-machine.md`.
+
+## Step 6: Won / Lost buttons
+
+On the deal detail panel, add two buttons:
+
+```ts
+// Won — picks the first is_won stage by sort_order automatically
+const updated = await crm.won(token, deal.id);
+
+// Won — disambiguate when the pipeline has multiple is_won stages
+const updated = await crm.won(token, deal.id, "closed-won-expansion");
+```
+
+**Lost** requires `lost_reason` — the API returns `400` if missing or
+blank (see [best practice: always provide a lost_reason](../../../docs/developer/applications/crm.md#164-always-provide-a-lost_reason)). Always collect it in a modal:
+
+```tsx
+<Dialog open={lostOpen} onOpenChange={setLostOpen}>
+  <DialogContent>
+    <DialogTitle>Mark as Lost</DialogTitle>
+    <Textarea
+      placeholder="Why did this deal slip?"
+      value={reason}
+      onChange={(e) => setReason(e.target.value)}
+      maxLength={255}
+      required
+    />
+    <Button
+      disabled={!reason.trim()}
+      onClick={async () => {
+        const updated = await crm.lost(token, deal.id, reason.trim());
+        setLostOpen(false);
+        // refresh board — deal is now status="lost"
+      }}
+    >
+      Confirm Lost
+    </Button>
+  </DialogContent>
+</Dialog>
+```
+
+**Re-opening a deal.** Won/lost are not one-way doors. To re-open, call
+`crm.moveStage(token, dealId, "<non-terminal-stage-code>")`. The server
+clears `closed_at`, flips `status` back to `open`, writes an audit
+Activity, and fires `CRM_DEAL_STAGE_CHANGED` again. There is no dedicated
+"reopen" endpoint — the stage move IS the reopen.
+
+## Step 7: Client-side footguns (must enforce in the UI)
+
+- **Never PATCH `status` or `closed_at`.** Both are server-managed; sending
+  either on PUT/PATCH returns 400 with the message
+  *"Service-managed — write via move-stage/, won/, or lost/."* Do not
+  surface these fields on a deal edit form.
+- **`Deal.stage` must belong to `Deal.pipeline`.** If you let the user
+  switch a deal's pipeline, also force them to pick a stage from the new
+  pipeline before submit. Mismatch returns 400.
+- **`Deal.organization` must match `Person.organization`** when the person
+  already has one. Pre-fill the organization field from the selected
+  person and disable it when set, or you will hit a 400.
+- **`owner` defaults to the calling user.** Only send it when you are
+  explicitly reassigning the deal.
+
+## Step 8 (optional): Pipeline, Stage, and Lead Source admin
+
+Only build this when the user has the `CRM Manager` role. Gate the menu
+entry behind that role — see `/iblai-rbac`.
+
+Destructive-delete behavior differs across these resources — surface a
+confirmation dialog that explains the consequence:
+
+| Resource | DELETE behavior |
+|---|---|
+| Pipeline | `409 Conflict` if any Deal references it. Migrate deals first. |
+| Stage | `409 Conflict` if any Deal references it. Move those deals to another stage first. |
+| Lead Source | **Not blocked.** SETs `Deal.source = NULL` on every referencing deal. Historical attribution is lost. Treat as destructive. |
+
+Other admin guardrails:
+
+- Pipeline `code` is unique per Platform (duplicate → 400).
+- At most one pipeline can have `is_default=true` per Platform — un-flag
+  the existing default first.
+- Stage `code` is unique within its pipeline.
+- A stage cannot be both `is_won` and `is_lost` (400 if you try).
+- `probability` is 0–100 (400 otherwise).
+
+Full tables, error payloads, and curl examples live in
+[`references/pipelines-api.md`](./references/pipelines-api.md) and
+[`references/lead-sources-api.md`](./references/lead-sources-api.md).
+
+## State machine
+
+A Deal's `status` is **derived** from the stage it currently sits in —
+never written directly. Three endpoints change the stage:
+
+- `POST /deals/{id}/move-stage/` — go anywhere in the pipeline.
+- `POST /deals/{id}/won/` — go to the first `is_won` stage (or a specific
+  one via `stage_code`).
+- `POST /deals/{id}/lost/` — go to the first `is_lost` stage; **requires**
+  `lost_reason`.
+
+Every successful, non-no-op transition:
+1. Recomputes `status` (`is_won` → `won`, `is_lost` → `lost`, else `open`).
+2. Stamps or clears `closed_at`.
+3. Writes a `type=note`, `title="Stage changed"` audit Activity.
+4. Fires `CRM_DEAL_STAGE_CHANGED`.
+
+Idempotency: moving to the current stage is a no-op (no write, no signal,
+no audit row, no notification). `lost/` is the one exception — it overwrites
+`lost_reason` unconditionally even when the stage move is a no-op, so
+pass the original reason on retries.
+
+Concurrency: transitions serialize on a row lock. Two simultaneous
+requests cannot both observe the same `from_stage`. Refresh the deal
+after a transition so the UI matches reality.
+
+Full diagrams + edge cases: [`references/state-machine.md`](./references/state-machine.md).
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and drive the board:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals /tmp/deals.png
+   ```
+3. Drag a card from `qualified` → `negotiation`. Confirm:
+   - The card lands and `updated_at` advances.
+   - The deal timeline (via `/iblai-crm-activity`) shows a new system
+     row: title `"Stage changed"`, comment `"Qualified → Negotiation"`.
+   - The notification bell (via `/iblai-crm-notification` →
+     `/iblai-notification`) shows a fresh `CRM_DEAL_STAGE_CHANGED` entry.
+4. Click **Lost** with an empty textarea → submit button is disabled (or
+   the server returns 400 with `{"lost_reason": ["This field is required."]}`).
+5. Click **Won** on an open deal → confirm `status` flips to `won`,
+   `closed_at` is stamped, and the card moves off the open board.
+
+## Related skills
+
+- `/iblai-crm-overview` — auth, Platform scoping, seeded defaults, RBAC matrix.
+- `/iblai-crm-lead-flow` — deals REQUIRE a person; build that flow first.
+- `/iblai-crm-activity` — deal timeline rendering; system audit rows look
+  different from user-logged activities (see [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- `/iblai-crm-tag` — attach tags to deals; filter the kanban board by tag.
+- `/iblai-crm-notification` — `CRM_DEAL_STAGE_CHANGED` fires from every
+  transition in this skill.
+- `/iblai-rbac` — `CRM User` (deals) vs `CRM Manager` (pipelines, stages,
+  lead sources) permission matrix.
+- `/iblai-auth` — token wiring; do not introduce a parallel token layer.

--- a/adapters/codex/iblai-crm-lead-flow.md
+++ b/adapters/codex/iblai-crm-lead-flow.md
@@ -1,0 +1,430 @@
+# iblai-crm-lead-flow
+
+> Build the CRM top-of-funnel surface — lead-capture form, contacts table with lifecycle filter, organization records, and the three person onboarding actions (link existing Platform user, invite by email, merge duplicates). Use when the user mentions CRM leads, contacts, people, persons, organizations, lead capture, contact intake, link to user, invite by email, merge duplicates, or lifecycle stage. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-deal-flow to open a deal once a person exists, /iblai-crm-activity for the timeline, /iblai-crm-tag for tag chips, /iblai-crm-notification for the events this flow fires, /iblai-rbac for CRM Inviter/User/Manager roles, and /iblai-auth for token wiring.
+
+# /iblai-crm-lead-flow
+
+Build the people-and-organizations surface of the CRM: capture leads, list
+contacts, view person detail, manage organizations, and run the three
+onboarding actions (link, invite, merge).
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for person and organization
+  CRUD. Add the **CRM Inviter** role on top if you need
+  `POST /persons/{id}/invite/`. See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+- A **lead-capture form** that POSTs to `/api/crm/persons/` with
+  `name`, `primary_email`, `lifecycle_stage`, optional `organization`,
+  and free-form `metadata`.
+- A **contacts table** at `/crm/contacts` with a lifecycle-stage
+  filter, owner filter, and tag filter, backed by
+  `GET /api/crm/persons/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **person detail panel** that loads `GET /api/crm/persons/{id}/`
+  and exposes three onboarding action buttons: **Link to user**,
+  **Invite by email**, **Merge duplicates**.
+- An **organizations table + form** at `/crm/organizations` for
+  `GET`/`POST /api/crm/organizations/`.
+- An **action-result toast** layer so the silent-refusal footgun on
+  `link-user/` is surfaced loudly.
+
+Reference tables for every endpoint live in:
+
+- `references/persons-api.md`
+- `references/organizations-api.md`
+- `references/onboarding-flows.md`
+
+## Step 1: Install shadcn primitives
+
+The contacts table, lead form, detail panel, and the link/invite/merge
+dialogs use only shadcn primitives. Install once:
+
+```bash
+npx shadcn@latest add form table dialog select badge input textarea
+```
+
+Do not write custom replacements for these — they share the ibl.ai
+Tailwind theme automatically.
+
+## Step 2: Add a typed CRM API client
+
+Reuse the auth token that `/iblai-auth` wrote into `.env.local`
+(`NEXT_PUBLIC_API_BASE_URL`, and the user token read from localStorage
+under the same key `/iblai-auth` uses). Do NOT introduce a new
+token-management layer.
+
+Create `lib/iblai/crm-client.ts`:
+
+```ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+function token() {
+  // /iblai-auth stores the access token in localStorage. Reuse it.
+  return typeof window !== "undefined"
+    ? localStorage.getItem("ibl_access_token") ?? ""
+    : "";
+}
+
+async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Token ${token()}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw Object.assign(new Error(res.statusText), { status: res.status, body });
+  }
+  return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+}
+
+export type Page<T> = {
+  count: number;
+  next_page: number | null;
+  previous_page: number | null;
+  results: T[];
+};
+
+export type LifecycleStage =
+  | "lead"
+  | "qualified"
+  | "opportunity"
+  | "customer"
+  | "churned";
+
+export type Person = {
+  id: string;
+  platform: number | string;
+  name: string;
+  primary_email: string | null;
+  emails: { label: string; email: string }[];
+  contact_numbers: { label: string; number: string }[];
+  job_title: string;
+  organization: string | null;
+  owner: number | null;
+  platform_user: number | null;
+  lifecycle_stage: LifecycleStage;
+  unique_id: string;
+  active: boolean;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Organization = {
+  id: string;
+  platform: number | string;
+  name: string;
+  address: Record<string, unknown>;
+  owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export const crm = {
+  // Persons
+  listPersons: (q: URLSearchParams) =>
+    call<Page<Person>>(`/persons/?${q.toString()}`),
+  getPerson: (id: string) => call<Person>(`/persons/${id}/`),
+  createPerson: (body: Partial<Person>) =>
+    call<Person>(`/persons/`, { method: "POST", body: JSON.stringify(body) }),
+  patchPerson: (id: string, body: Partial<Person>) =>
+    call<Person>(`/persons/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+  deletePerson: (id: string) =>
+    call<void>(`/persons/${id}/`, { method: "DELETE" }),
+  linkUser: (id: string, user_id: number) =>
+    call<Person>(`/persons/${id}/link-user/`, {
+      method: "POST",
+      body: JSON.stringify({ user_id }),
+    }),
+  invite: (
+    id: string,
+    body: {
+      is_admin?: boolean;
+      is_staff?: boolean;
+      enrollment_config?: Record<string, unknown>;
+      redirect_to?: string;
+    },
+  ) =>
+    call<{
+      person_id: string;
+      invitation_id: number;
+      invitation_email: string;
+      platform_key: string;
+      auto_accept: boolean;
+      active: boolean;
+      redirect_to: string | null;
+      created: string | null;
+    }>(`/persons/${id}/invite/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  merge: (primary_id: string, duplicate_ids: string[]) =>
+    call<{
+      primary_id: string;
+      merged_ids: string[];
+      reparented: { deals: number; activities: number; tags: number };
+    }>(`/persons/merge/`, {
+      method: "POST",
+      body: JSON.stringify({ primary_id, duplicate_ids }),
+    }),
+
+  // Organizations
+  listOrgs: (q: URLSearchParams) =>
+    call<Page<Organization>>(`/organizations/?${q.toString()}`),
+  getOrg: (id: string) => call<Organization>(`/organizations/${id}/`),
+  createOrg: (body: Partial<Organization>) =>
+    call<Organization>(`/organizations/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+};
+```
+
+All examples in the references send `Authorization: Token …` — this
+client does the same.
+
+## Step 3: Lead-capture form
+
+Page route: `app/crm/leads/new/page.tsx`. Fields:
+
+- `name` — required, text input.
+- `primary_email` — recommended; auto-link binds on Platform signup.
+- `lifecycle_stage` — `Select` defaulting to `lead`
+  (`lead | qualified | opportunity | customer | churned`).
+- `organization` — `Select` populated from
+  `crm.listOrgs(new URLSearchParams())`.
+- `metadata` — `textarea`, parsed as JSON before submit.
+
+Submit calls `crm.createPerson({...})`. On `201` redirect to
+`/crm/contacts/{id}`. Handle:
+
+- `400` with a `unique_id` array → show the server message under the
+  `unique_id` field (duplicate import key).
+- `403` → "You need the CRM User role to create contacts" (cross-ref
+  `/iblai-rbac`).
+
+Full field table: [`POST /persons/` in the Persons API reference](references/persons-api.md#post-persons).
+
+## Step 4: Contacts table
+
+Page route: `app/crm/contacts/page.tsx`. Fetch via
+`crm.listPersons(query)` where `query` is built from URL search params:
+
+- `lifecycle_stage` — `Select` with the five stages plus "All".
+- `owner` — numeric input or owner picker.
+- `tags` — multi-select; emit `?tags=1&tags=2` (OR semantics, results
+  de-duplicated server-side).
+- `page` / `page_size` — pagination, max `page_size=100`.
+
+Render rows in a shadcn `Table`. Columns: name, primary_email,
+lifecycle stage (`Badge`), owner, tags (chip per item). Wire pagination
+off the `{count, next_page, previous_page, results}` envelope — do not
+assume cursor pagination.
+
+Each row links to `/crm/contacts/{id}`.
+
+## Step 5: Person detail panel + onboarding actions
+
+Page route: `app/crm/contacts/[id]/page.tsx`. Load via
+`crm.getPerson(id)`. Display name, email, lifecycle stage,
+organization, owner, `platform_user` (when set), tags, metadata, and
+the three action buttons described below.
+
+### 5a. Link to existing Platform user
+
+Dialog with a single `user_id` numeric input. On submit:
+
+```ts
+const linked = await crm.linkUser(person.id, Number(userId));
+
+// SILENT-REFUSAL FOOTGUN: a 200 response whose platform_user
+// does NOT equal the requested user_id means the person was already
+// bound to a different user and the existing binding was preserved.
+// You MUST assert equality client-side before claiming success.
+if (linked.platform_user !== Number(userId)) {
+  toast.error(
+    `This person is already linked to user ${linked.platform_user}. ` +
+      `The existing binding was preserved.`,
+  );
+} else {
+  toast.success("Linked to Platform user.");
+}
+```
+
+Status codes to handle: `400` (missing/wrong `user_id`), `403` (target
+user has no active `UserPlatformLink` — surface "issue an invitation
+instead"), `404` (person or user does not exist). Full table:
+[the Link flow in the onboarding reference](references/onboarding-flows.md#1-link-an-existing-platform-user).
+
+### 5b. Invite by email
+
+Dialog with `is_admin` and `is_staff` checkboxes, optional
+`enrollment_config` (textarea, JSON), and optional `redirect_to` URL.
+Requires the person to have a `primary_email`.
+
+Status codes:
+
+| Code | Meaning |
+|------|---------|
+| `201` | Invitation queued. Show success toast. |
+| `400` | Person has no `primary_email`. Disable the button when null. |
+| `403` | Caller missing `Ibl.CRM/Invite/action` (CRM Inviter role). |
+| `404` | Person not found. |
+| `409` | Active invitation already exists. Body contains `invitation_id` — treat as "already done", offer a "resend" affordance. |
+| `422` | Person already linked to a Platform user. Hide the button when `platform_user` is set. |
+
+Full body and field list: [the Invite flow in the onboarding reference](references/onboarding-flows.md#2-invite-by-email).
+
+### 5c. Merge duplicates
+
+Dialog with a multi-select of duplicate person rows to merge into the
+current (primary) person. Submit:
+
+```ts
+const result = await crm.merge(primaryId, duplicateIds);
+// result.reparented = { deals, activities, tags }
+toast.success(
+  `Merged ${result.merged_ids.length} duplicates. ` +
+    `Reparented ${result.reparented.deals} deals, ` +
+    `${result.reparented.activities} activities, ` +
+    `${result.reparented.tags} tag assignments.`,
+);
+```
+
+Status codes: `400` (primary in `duplicate_ids`, empty
+`duplicate_ids`, cross-Platform duplicate), `403`, `404`. Duplicates
+are **soft-deleted** (`active=false`); their rows are still
+retrievable by id, so list views must filter on `active=true`.
+
+## Step 6: Organizations table + form
+
+Page route: `app/crm/organizations/page.tsx`. Use
+`crm.listOrgs(query)` with `?name=<substring>&owner=<id>&tags=…`.
+Render in a shadcn `Table` with name, owner, tags, created_at.
+
+Create form at `app/crm/organizations/new/page.tsx`:
+
+- `name` — required, must be unique within the Platform
+  (case-sensitive, trimmed). Handle `400 {"name": ["… already exists …"]}`
+  by surfacing the message inline.
+- `address` — free-form JSON `textarea` (the recommended shape
+  `{street, city, state, zip, country}` is a hint, not enforced).
+- `owner` — optional numeric.
+- `metadata` — free-form JSON.
+
+Deleting an organization sets `Person.organization` and
+`Deal.organization` to `null` on every referencing row — there is no
+cascade-delete. Tag assignments on the organization are removed. Full
+shape: `references/organizations-api.md`.
+
+## Auto-link signal
+
+You do not need to call any endpoint for this — but you must build for
+it. When a Platform user is created (signup, invitation acceptance,
+admin) and their email matches a Person's `primary_email`
+(case-insensitive) on a Platform they belong to, the system
+asynchronously sets `platform_user`, flips `active` from `true` to
+`false`, and fires a `CRM_PERSON_LINKED_TO_USER` notification.
+
+Two UI consequences:
+
+- A `GET /persons/{id}/` issued seconds after signup may still show
+  `active: true` and `platform_user: null`. Build polling or a
+  notification-driven refresh into any view that surfaces this state.
+- A row can disappear from an "active people" list between page loads
+  with no operator action in between. Tolerate the transition; do not
+  crash on missing rows.
+
+The notification fires regardless of whether your CRM UI is open.
+Cross-ref `/iblai-crm-notification` for recipient routing and how to
+subscribe an inbox.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done.
+
+```bash
+pnpm build         # must pass with zero errors
+pnpm typecheck
+pnpm dev &
+npx playwright screenshot http://localhost:3000/crm/leads/new       /tmp/crm-lead.png
+npx playwright screenshot http://localhost:3000/crm/contacts        /tmp/crm-contacts.png
+npx playwright screenshot http://localhost:3000/crm/organizations   /tmp/crm-orgs.png
+```
+
+Smoke checklist:
+
+- [ ] Create a Person via the lead form → row appears in contacts table.
+- [ ] Filter the contacts table by `lifecycle_stage=qualified`.
+- [ ] Open the detail panel; click **Link to user** with a known
+      `user_id` and confirm `platform_user === user_id`.
+- [ ] Repeat **Link to user** with the same `user_id` on a person
+      already bound elsewhere — confirm the silent-refusal toast fires
+      (response is 200, but `platform_user` differs).
+- [ ] **Invite by email** a person with a `primary_email`; the second
+      attempt returns 409 with the same `invitation_id`.
+- [ ] **Merge** two duplicates into a primary; confirm
+      `reparented.{deals,activities,tags}` counts are returned.
+- [ ] Create an Organization; deleting it does not cascade-delete
+      Persons that referenced it.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults, links to every sibling skill.
+- `/iblai-crm-deal-flow` — once a person exists, open a deal on the kanban.
+- `/iblai-crm-activity` — log timeline events (calls, meetings, notes, tasks) on a person.
+- `/iblai-crm-tag` — tag CRUD and chip components for people and organizations.
+- `/iblai-crm-notification` — `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER` fire from this flow.
+- `/iblai-rbac` — CRM Inviter / CRM User / CRM Manager roles and the action-definitions endpoint.
+- `/iblai-auth` — token wiring this skill reuses.

--- a/adapters/cursor/iblai-crm-deal-flow.mdc
+++ b/adapters/cursor/iblai-crm-deal-flow.mdc
@@ -1,0 +1,385 @@
+---
+description: "Build the revenue funnel CRM surface — pipelines, stages, lead sources, and the kanban deal board with move-stage / won / lost transitions. Use when the user mentions deals, kanban, pipeline, stages, lead sources, move stage, mark won, mark lost, lost reason, deal status, or sales funnel. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for persons (deals require one), /iblai-crm-activity for the timeline + audit rows, and /iblai-crm-notification for CRM_DEAL_STAGE_CHANGED routing."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-deal-flow
+
+Build the revenue funnel: a pipeline selector, a kanban deal board (columns = stages, cards = deals), and the move-stage / won / lost state machine with `lost_reason` collection.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — reuse the same token wiring
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- A Person already exists in the CRM. Deals REQUIRE a `person` UUID — if
+  you have not built the lead capture surface yet, do `/iblai-crm-lead-flow`
+  first and come back.
+- RBAC role on the caller:
+  - `CRM User` — list, read, create, update, delete deals; call
+    `move-stage/`, `won/`, `lost/`. This is what 95% of sales reps need.
+  - `CRM Manager` — additionally lets you CRUD pipelines, stages, and
+    lead sources. Only needed if you're building the admin UI in Step 8.
+  - See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+1. **Pipeline selector** — defaults to the seeded `default` pipeline; lets
+   the user switch when more than one exists.
+2. **Kanban board** — one column per stage in `sort_order`, cards grouped
+   by `deal.stage`. Card shows title, `lead_value` + `currency`, person
+   name, and days-in-stage.
+3. **Drag-drop → `move-stage`** — using `@dnd-kit`, fires
+   `POST /deals/{id}/move-stage/` with `{stage_code}`.
+4. **Deal detail panel** — clicking a card opens a slide-over with full
+   deal fields and **Won** / **Lost** buttons.
+5. **Lost modal** — collects required `lost_reason` before hitting
+   `POST /deals/{id}/lost/`.
+6. **(Optional) Admin UI** — pipeline + stage + lead source CRUD for
+   `CRM Manager` users.
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date.
+Run `iblai --version`, then upgrade directly:
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+## Step 1: Install shadcn primitives + dnd-kit
+
+```bash
+npx shadcn@latest add card badge dialog select button input textarea form sheet skeleton
+pnpm add @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+`@dnd-kit` is the recommended dnd primitive — accessible, headless, plays
+well with shadcn `card`. Do not write a custom drag layer.
+
+## Step 2: Typed API client wrappers
+
+Reuse the auth token wiring from `/iblai-auth` — do NOT introduce a new
+token-management layer. Read the same `Token` value the rest of the app
+uses (the SDK persists it; client code can grab it from `localStorage` or
+from the auth context).
+
+Create `lib/iblai/crm.ts` with thin typed fetchers:
+
+```ts
+// lib/iblai/crm.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+type Stage = {
+  id: number; pipeline: number; code: string; name: string;
+  probability: number; sort_order: number;
+  is_won: boolean; is_lost: boolean; metadata: Record<string, unknown>;
+};
+
+type Pipeline = {
+  id: number; name: string; code: string; is_default: boolean;
+  rotten_days: number; stages: Stage[]; metadata: Record<string, unknown>;
+};
+
+type Deal = {
+  id: number; title: string; description: string;
+  lead_value: string; currency: string;
+  status: "open" | "won" | "lost"; lost_reason: string;
+  expected_close_date: string | null; closed_at: string | null;
+  person: string; organization: string | null;
+  pipeline: number; stage: number;
+  source: number | null; owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string; updated_at: string;
+};
+
+const h = (token: string) => ({
+  Authorization: `Token ${token}`,
+  "Content-Type": "application/json",
+});
+
+export const crm = {
+  listPipelines: (token: string, params = "") =>
+    fetch(`${BASE}/pipelines/${params}`, { headers: h(token) }).then(r => r.json()),
+  listLeadSources: (token: string) =>
+    fetch(`${BASE}/lead-sources/`, { headers: h(token) }).then(r => r.json()),
+  listDeals: (token: string, pipelineId: number) =>
+    fetch(`${BASE}/deals/?pipeline=${pipelineId}&status=open`, { headers: h(token) })
+      .then(r => r.json()),
+  createDeal: (token: string, body: Partial<Deal>) =>
+    fetch(`${BASE}/deals/`, { method: "POST", headers: h(token), body: JSON.stringify(body) })
+      .then(r => r.json()),
+  moveStage: (token: string, id: number, stage_code: string) =>
+    fetch(`${BASE}/deals/${id}/move-stage/`, {
+      method: "POST", headers: h(token), body: JSON.stringify({ stage_code }),
+    }).then(r => r.json()),
+  won: (token: string, id: number, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/won/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify(stage_code ? { stage_code } : {}),
+    }).then(r => r.json()),
+  lost: (token: string, id: number, lost_reason: string, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/lost/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify({ lost_reason, ...(stage_code ? { stage_code } : {}) }),
+    }).then(r => r.json()),
+};
+```
+
+Full endpoint catalogs and field tables live in
+[`references/pipelines-api.md`](./references/pipelines-api.md),
+[`references/lead-sources-api.md`](./references/lead-sources-api.md), and
+[`references/deals-api.md`](./references/deals-api.md).
+
+## Step 3: Fetch the default pipeline once on mount
+
+Every Platform is seeded with a default pipeline (`code=default`) carrying
+six stages — `new`, `qualified`, `proposal`, `negotiation`, `won`, `lost`.
+The list response embeds the ordered `stages` array inline, so you do not
+need a second roundtrip.
+
+```ts
+const { results } = await crm.listPipelines(token, "?is_default=true");
+const pipeline = results[0];
+// Index stages by CODE — not id. Codes are stable across environments;
+// ids differ between dev / staging / prod (see the CRM doc's [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)).
+const stagesByCode = Object.fromEntries(pipeline.stages.map((s) => [s.code, s]));
+const stagesById = Object.fromEntries(pipeline.stages.map((s) => [s.id, s]));
+```
+
+Cache `pipeline.id` and the stages object in your store (Zustand, Redux,
+or React state). The board only needs to re-fetch when the user switches
+pipelines.
+
+## Step 4: Render the kanban board
+
+```ts
+const { results: deals } = await crm.listDeals(token, pipeline.id);
+const columns = pipeline.stages
+  .filter((s) => !s.is_won && !s.is_lost)        // hide terminal columns on the open board
+  .sort((a, b) => a.sort_order - b.sort_order);
+const byStage = Object.groupBy(deals, (d) => d.stage); // group cards by Deal.stage (the stage id)
+```
+
+Card content:
+- `title` — bold, truncated to 1 line
+- `lead_value` formatted with `Intl.NumberFormat` + `currency`
+- Person name (look up via `/iblai-crm-lead-flow` person store)
+- Days-in-stage = `dayjs().diff(deal.updated_at, "day")`; flag in red when
+  it exceeds `pipeline.rotten_days` (default 30)
+
+Use shadcn `card` for cards, `badge` for the stage chip, `skeleton` for
+the initial loading state.
+
+## Step 5: Drag-drop → move-stage
+
+Wire `@dnd-kit`'s `DndContext` around the columns. On drop, derive the
+destination stage CODE (never raw id — see [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)) and call:
+
+```ts
+async function onDragEnd(deal: Deal, destStageCode: string) {
+  const dest = stagesByCode[destStageCode];
+  if (!dest) return;
+  if (dest.id === deal.stage) return;      // no-op guard — see [Idempotency](../../../docs/developer/applications/crm.md#96-idempotency)
+  const updated = await crm.moveStage(token, deal.id, destStageCode);
+  setDeals((prev) => prev.map((d) => (d.id === deal.id ? updated : d)));
+}
+```
+
+**Server side effects to call out in the UI:**
+
+- The server appends an audit Activity (`type=note`,
+  `title="Stage changed"`, `comment="<from> → <to>"`,
+  `is_done=true`). This row will appear in the deal timeline — render it
+  with a distinct icon and no edit controls per
+  `/iblai-crm-activity` ([best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- A `CRM_DEAL_STAGE_CHANGED` notification fires. See
+  `/iblai-crm-notification` for recipient routing and channel config.
+- `Deal.status` is recomputed from the destination stage's `is_won` /
+  `is_lost` flags. Do **not** echo the optimistic status — re-read from
+  the server response.
+- Dragging onto the same column is **suppressed server-side** (no write,
+  no notification, no audit row). Gate the call client-side too so the
+  UI does not flash. See `references/state-machine.md`.
+
+## Step 6: Won / Lost buttons
+
+On the deal detail panel, add two buttons:
+
+```ts
+// Won — picks the first is_won stage by sort_order automatically
+const updated = await crm.won(token, deal.id);
+
+// Won — disambiguate when the pipeline has multiple is_won stages
+const updated = await crm.won(token, deal.id, "closed-won-expansion");
+```
+
+**Lost** requires `lost_reason` — the API returns `400` if missing or
+blank (see [best practice: always provide a lost_reason](../../../docs/developer/applications/crm.md#164-always-provide-a-lost_reason)). Always collect it in a modal:
+
+```tsx
+<Dialog open={lostOpen} onOpenChange={setLostOpen}>
+  <DialogContent>
+    <DialogTitle>Mark as Lost</DialogTitle>
+    <Textarea
+      placeholder="Why did this deal slip?"
+      value={reason}
+      onChange={(e) => setReason(e.target.value)}
+      maxLength={255}
+      required
+    />
+    <Button
+      disabled={!reason.trim()}
+      onClick={async () => {
+        const updated = await crm.lost(token, deal.id, reason.trim());
+        setLostOpen(false);
+        // refresh board — deal is now status="lost"
+      }}
+    >
+      Confirm Lost
+    </Button>
+  </DialogContent>
+</Dialog>
+```
+
+**Re-opening a deal.** Won/lost are not one-way doors. To re-open, call
+`crm.moveStage(token, dealId, "<non-terminal-stage-code>")`. The server
+clears `closed_at`, flips `status` back to `open`, writes an audit
+Activity, and fires `CRM_DEAL_STAGE_CHANGED` again. There is no dedicated
+"reopen" endpoint — the stage move IS the reopen.
+
+## Step 7: Client-side footguns (must enforce in the UI)
+
+- **Never PATCH `status` or `closed_at`.** Both are server-managed; sending
+  either on PUT/PATCH returns 400 with the message
+  *"Service-managed — write via move-stage/, won/, or lost/."* Do not
+  surface these fields on a deal edit form.
+- **`Deal.stage` must belong to `Deal.pipeline`.** If you let the user
+  switch a deal's pipeline, also force them to pick a stage from the new
+  pipeline before submit. Mismatch returns 400.
+- **`Deal.organization` must match `Person.organization`** when the person
+  already has one. Pre-fill the organization field from the selected
+  person and disable it when set, or you will hit a 400.
+- **`owner` defaults to the calling user.** Only send it when you are
+  explicitly reassigning the deal.
+
+## Step 8 (optional): Pipeline, Stage, and Lead Source admin
+
+Only build this when the user has the `CRM Manager` role. Gate the menu
+entry behind that role — see `/iblai-rbac`.
+
+Destructive-delete behavior differs across these resources — surface a
+confirmation dialog that explains the consequence:
+
+| Resource | DELETE behavior |
+|---|---|
+| Pipeline | `409 Conflict` if any Deal references it. Migrate deals first. |
+| Stage | `409 Conflict` if any Deal references it. Move those deals to another stage first. |
+| Lead Source | **Not blocked.** SETs `Deal.source = NULL` on every referencing deal. Historical attribution is lost. Treat as destructive. |
+
+Other admin guardrails:
+
+- Pipeline `code` is unique per Platform (duplicate → 400).
+- At most one pipeline can have `is_default=true` per Platform — un-flag
+  the existing default first.
+- Stage `code` is unique within its pipeline.
+- A stage cannot be both `is_won` and `is_lost` (400 if you try).
+- `probability` is 0–100 (400 otherwise).
+
+Full tables, error payloads, and curl examples live in
+[`references/pipelines-api.md`](./references/pipelines-api.md) and
+[`references/lead-sources-api.md`](./references/lead-sources-api.md).
+
+## State machine
+
+A Deal's `status` is **derived** from the stage it currently sits in —
+never written directly. Three endpoints change the stage:
+
+- `POST /deals/{id}/move-stage/` — go anywhere in the pipeline.
+- `POST /deals/{id}/won/` — go to the first `is_won` stage (or a specific
+  one via `stage_code`).
+- `POST /deals/{id}/lost/` — go to the first `is_lost` stage; **requires**
+  `lost_reason`.
+
+Every successful, non-no-op transition:
+1. Recomputes `status` (`is_won` → `won`, `is_lost` → `lost`, else `open`).
+2. Stamps or clears `closed_at`.
+3. Writes a `type=note`, `title="Stage changed"` audit Activity.
+4. Fires `CRM_DEAL_STAGE_CHANGED`.
+
+Idempotency: moving to the current stage is a no-op (no write, no signal,
+no audit row, no notification). `lost/` is the one exception — it overwrites
+`lost_reason` unconditionally even when the stage move is a no-op, so
+pass the original reason on retries.
+
+Concurrency: transitions serialize on a row lock. Two simultaneous
+requests cannot both observe the same `from_stage`. Refresh the deal
+after a transition so the UI matches reality.
+
+Full diagrams + edge cases: [`references/state-machine.md`](./references/state-machine.md).
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and drive the board:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals /tmp/deals.png
+   ```
+3. Drag a card from `qualified` → `negotiation`. Confirm:
+   - The card lands and `updated_at` advances.
+   - The deal timeline (via `/iblai-crm-activity`) shows a new system
+     row: title `"Stage changed"`, comment `"Qualified → Negotiation"`.
+   - The notification bell (via `/iblai-crm-notification` →
+     `/iblai-notification`) shows a fresh `CRM_DEAL_STAGE_CHANGED` entry.
+4. Click **Lost** with an empty textarea → submit button is disabled (or
+   the server returns 400 with `{"lost_reason": ["This field is required."]}`).
+5. Click **Won** on an open deal → confirm `status` flips to `won`,
+   `closed_at` is stamped, and the card moves off the open board.
+
+## Related skills
+
+- `/iblai-crm-overview` — auth, Platform scoping, seeded defaults, RBAC matrix.
+- `/iblai-crm-lead-flow` — deals REQUIRE a person; build that flow first.
+- `/iblai-crm-activity` — deal timeline rendering; system audit rows look
+  different from user-logged activities (see [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- `/iblai-crm-tag` — attach tags to deals; filter the kanban board by tag.
+- `/iblai-crm-notification` — `CRM_DEAL_STAGE_CHANGED` fires from every
+  transition in this skill.
+- `/iblai-rbac` — `CRM User` (deals) vs `CRM Manager` (pipelines, stages,
+  lead sources) permission matrix.
+- `/iblai-auth` — token wiring; do not introduce a parallel token layer.

--- a/adapters/cursor/iblai-crm-lead-flow.mdc
+++ b/adapters/cursor/iblai-crm-lead-flow.mdc
@@ -1,0 +1,432 @@
+---
+description: "Build the CRM top-of-funnel surface — lead-capture form, contacts table with lifecycle filter, organization records, and the three person onboarding actions (link existing Platform user, invite by email, merge duplicates). Use when the user mentions CRM leads, contacts, people, persons, organizations, lead capture, contact intake, link to user, invite by email, merge duplicates, or lifecycle stage. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-deal-flow to open a deal once a person exists, /iblai-crm-activity for the timeline, /iblai-crm-tag for tag chips, /iblai-crm-notification for the events this flow fires, /iblai-rbac for CRM Inviter/User/Manager roles, and /iblai-auth for token wiring."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-lead-flow
+
+Build the people-and-organizations surface of the CRM: capture leads, list
+contacts, view person detail, manage organizations, and run the three
+onboarding actions (link, invite, merge).
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for person and organization
+  CRUD. Add the **CRM Inviter** role on top if you need
+  `POST /persons/{id}/invite/`. See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+- A **lead-capture form** that POSTs to `/api/crm/persons/` with
+  `name`, `primary_email`, `lifecycle_stage`, optional `organization`,
+  and free-form `metadata`.
+- A **contacts table** at `/crm/contacts` with a lifecycle-stage
+  filter, owner filter, and tag filter, backed by
+  `GET /api/crm/persons/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **person detail panel** that loads `GET /api/crm/persons/{id}/`
+  and exposes three onboarding action buttons: **Link to user**,
+  **Invite by email**, **Merge duplicates**.
+- An **organizations table + form** at `/crm/organizations` for
+  `GET`/`POST /api/crm/organizations/`.
+- An **action-result toast** layer so the silent-refusal footgun on
+  `link-user/` is surfaced loudly.
+
+Reference tables for every endpoint live in:
+
+- `references/persons-api.md`
+- `references/organizations-api.md`
+- `references/onboarding-flows.md`
+
+## Step 1: Install shadcn primitives
+
+The contacts table, lead form, detail panel, and the link/invite/merge
+dialogs use only shadcn primitives. Install once:
+
+```bash
+npx shadcn@latest add form table dialog select badge input textarea
+```
+
+Do not write custom replacements for these — they share the ibl.ai
+Tailwind theme automatically.
+
+## Step 2: Add a typed CRM API client
+
+Reuse the auth token that `/iblai-auth` wrote into `.env.local`
+(`NEXT_PUBLIC_API_BASE_URL`, and the user token read from localStorage
+under the same key `/iblai-auth` uses). Do NOT introduce a new
+token-management layer.
+
+Create `lib/iblai/crm-client.ts`:
+
+```ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+function token() {
+  // /iblai-auth stores the access token in localStorage. Reuse it.
+  return typeof window !== "undefined"
+    ? localStorage.getItem("ibl_access_token") ?? ""
+    : "";
+}
+
+async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Token ${token()}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw Object.assign(new Error(res.statusText), { status: res.status, body });
+  }
+  return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+}
+
+export type Page<T> = {
+  count: number;
+  next_page: number | null;
+  previous_page: number | null;
+  results: T[];
+};
+
+export type LifecycleStage =
+  | "lead"
+  | "qualified"
+  | "opportunity"
+  | "customer"
+  | "churned";
+
+export type Person = {
+  id: string;
+  platform: number | string;
+  name: string;
+  primary_email: string | null;
+  emails: { label: string; email: string }[];
+  contact_numbers: { label: string; number: string }[];
+  job_title: string;
+  organization: string | null;
+  owner: number | null;
+  platform_user: number | null;
+  lifecycle_stage: LifecycleStage;
+  unique_id: string;
+  active: boolean;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Organization = {
+  id: string;
+  platform: number | string;
+  name: string;
+  address: Record<string, unknown>;
+  owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export const crm = {
+  // Persons
+  listPersons: (q: URLSearchParams) =>
+    call<Page<Person>>(`/persons/?${q.toString()}`),
+  getPerson: (id: string) => call<Person>(`/persons/${id}/`),
+  createPerson: (body: Partial<Person>) =>
+    call<Person>(`/persons/`, { method: "POST", body: JSON.stringify(body) }),
+  patchPerson: (id: string, body: Partial<Person>) =>
+    call<Person>(`/persons/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+  deletePerson: (id: string) =>
+    call<void>(`/persons/${id}/`, { method: "DELETE" }),
+  linkUser: (id: string, user_id: number) =>
+    call<Person>(`/persons/${id}/link-user/`, {
+      method: "POST",
+      body: JSON.stringify({ user_id }),
+    }),
+  invite: (
+    id: string,
+    body: {
+      is_admin?: boolean;
+      is_staff?: boolean;
+      enrollment_config?: Record<string, unknown>;
+      redirect_to?: string;
+    },
+  ) =>
+    call<{
+      person_id: string;
+      invitation_id: number;
+      invitation_email: string;
+      platform_key: string;
+      auto_accept: boolean;
+      active: boolean;
+      redirect_to: string | null;
+      created: string | null;
+    }>(`/persons/${id}/invite/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  merge: (primary_id: string, duplicate_ids: string[]) =>
+    call<{
+      primary_id: string;
+      merged_ids: string[];
+      reparented: { deals: number; activities: number; tags: number };
+    }>(`/persons/merge/`, {
+      method: "POST",
+      body: JSON.stringify({ primary_id, duplicate_ids }),
+    }),
+
+  // Organizations
+  listOrgs: (q: URLSearchParams) =>
+    call<Page<Organization>>(`/organizations/?${q.toString()}`),
+  getOrg: (id: string) => call<Organization>(`/organizations/${id}/`),
+  createOrg: (body: Partial<Organization>) =>
+    call<Organization>(`/organizations/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+};
+```
+
+All examples in the references send `Authorization: Token …` — this
+client does the same.
+
+## Step 3: Lead-capture form
+
+Page route: `app/crm/leads/new/page.tsx`. Fields:
+
+- `name` — required, text input.
+- `primary_email` — recommended; auto-link binds on Platform signup.
+- `lifecycle_stage` — `Select` defaulting to `lead`
+  (`lead | qualified | opportunity | customer | churned`).
+- `organization` — `Select` populated from
+  `crm.listOrgs(new URLSearchParams())`.
+- `metadata` — `textarea`, parsed as JSON before submit.
+
+Submit calls `crm.createPerson({...})`. On `201` redirect to
+`/crm/contacts/{id}`. Handle:
+
+- `400` with a `unique_id` array → show the server message under the
+  `unique_id` field (duplicate import key).
+- `403` → "You need the CRM User role to create contacts" (cross-ref
+  `/iblai-rbac`).
+
+Full field table: [`POST /persons/` in the Persons API reference](references/persons-api.md#post-persons).
+
+## Step 4: Contacts table
+
+Page route: `app/crm/contacts/page.tsx`. Fetch via
+`crm.listPersons(query)` where `query` is built from URL search params:
+
+- `lifecycle_stage` — `Select` with the five stages plus "All".
+- `owner` — numeric input or owner picker.
+- `tags` — multi-select; emit `?tags=1&tags=2` (OR semantics, results
+  de-duplicated server-side).
+- `page` / `page_size` — pagination, max `page_size=100`.
+
+Render rows in a shadcn `Table`. Columns: name, primary_email,
+lifecycle stage (`Badge`), owner, tags (chip per item). Wire pagination
+off the `{count, next_page, previous_page, results}` envelope — do not
+assume cursor pagination.
+
+Each row links to `/crm/contacts/{id}`.
+
+## Step 5: Person detail panel + onboarding actions
+
+Page route: `app/crm/contacts/[id]/page.tsx`. Load via
+`crm.getPerson(id)`. Display name, email, lifecycle stage,
+organization, owner, `platform_user` (when set), tags, metadata, and
+the three action buttons described below.
+
+### 5a. Link to existing Platform user
+
+Dialog with a single `user_id` numeric input. On submit:
+
+```ts
+const linked = await crm.linkUser(person.id, Number(userId));
+
+// SILENT-REFUSAL FOOTGUN: a 200 response whose platform_user
+// does NOT equal the requested user_id means the person was already
+// bound to a different user and the existing binding was preserved.
+// You MUST assert equality client-side before claiming success.
+if (linked.platform_user !== Number(userId)) {
+  toast.error(
+    `This person is already linked to user ${linked.platform_user}. ` +
+      `The existing binding was preserved.`,
+  );
+} else {
+  toast.success("Linked to Platform user.");
+}
+```
+
+Status codes to handle: `400` (missing/wrong `user_id`), `403` (target
+user has no active `UserPlatformLink` — surface "issue an invitation
+instead"), `404` (person or user does not exist). Full table:
+[the Link flow in the onboarding reference](references/onboarding-flows.md#1-link-an-existing-platform-user).
+
+### 5b. Invite by email
+
+Dialog with `is_admin` and `is_staff` checkboxes, optional
+`enrollment_config` (textarea, JSON), and optional `redirect_to` URL.
+Requires the person to have a `primary_email`.
+
+Status codes:
+
+| Code | Meaning |
+|------|---------|
+| `201` | Invitation queued. Show success toast. |
+| `400` | Person has no `primary_email`. Disable the button when null. |
+| `403` | Caller missing `Ibl.CRM/Invite/action` (CRM Inviter role). |
+| `404` | Person not found. |
+| `409` | Active invitation already exists. Body contains `invitation_id` — treat as "already done", offer a "resend" affordance. |
+| `422` | Person already linked to a Platform user. Hide the button when `platform_user` is set. |
+
+Full body and field list: [the Invite flow in the onboarding reference](references/onboarding-flows.md#2-invite-by-email).
+
+### 5c. Merge duplicates
+
+Dialog with a multi-select of duplicate person rows to merge into the
+current (primary) person. Submit:
+
+```ts
+const result = await crm.merge(primaryId, duplicateIds);
+// result.reparented = { deals, activities, tags }
+toast.success(
+  `Merged ${result.merged_ids.length} duplicates. ` +
+    `Reparented ${result.reparented.deals} deals, ` +
+    `${result.reparented.activities} activities, ` +
+    `${result.reparented.tags} tag assignments.`,
+);
+```
+
+Status codes: `400` (primary in `duplicate_ids`, empty
+`duplicate_ids`, cross-Platform duplicate), `403`, `404`. Duplicates
+are **soft-deleted** (`active=false`); their rows are still
+retrievable by id, so list views must filter on `active=true`.
+
+## Step 6: Organizations table + form
+
+Page route: `app/crm/organizations/page.tsx`. Use
+`crm.listOrgs(query)` with `?name=<substring>&owner=<id>&tags=…`.
+Render in a shadcn `Table` with name, owner, tags, created_at.
+
+Create form at `app/crm/organizations/new/page.tsx`:
+
+- `name` — required, must be unique within the Platform
+  (case-sensitive, trimmed). Handle `400 {"name": ["… already exists …"]}`
+  by surfacing the message inline.
+- `address` — free-form JSON `textarea` (the recommended shape
+  `{street, city, state, zip, country}` is a hint, not enforced).
+- `owner` — optional numeric.
+- `metadata` — free-form JSON.
+
+Deleting an organization sets `Person.organization` and
+`Deal.organization` to `null` on every referencing row — there is no
+cascade-delete. Tag assignments on the organization are removed. Full
+shape: `references/organizations-api.md`.
+
+## Auto-link signal
+
+You do not need to call any endpoint for this — but you must build for
+it. When a Platform user is created (signup, invitation acceptance,
+admin) and their email matches a Person's `primary_email`
+(case-insensitive) on a Platform they belong to, the system
+asynchronously sets `platform_user`, flips `active` from `true` to
+`false`, and fires a `CRM_PERSON_LINKED_TO_USER` notification.
+
+Two UI consequences:
+
+- A `GET /persons/{id}/` issued seconds after signup may still show
+  `active: true` and `platform_user: null`. Build polling or a
+  notification-driven refresh into any view that surfaces this state.
+- A row can disappear from an "active people" list between page loads
+  with no operator action in between. Tolerate the transition; do not
+  crash on missing rows.
+
+The notification fires regardless of whether your CRM UI is open.
+Cross-ref `/iblai-crm-notification` for recipient routing and how to
+subscribe an inbox.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done.
+
+```bash
+pnpm build         # must pass with zero errors
+pnpm typecheck
+pnpm dev &
+npx playwright screenshot http://localhost:3000/crm/leads/new       /tmp/crm-lead.png
+npx playwright screenshot http://localhost:3000/crm/contacts        /tmp/crm-contacts.png
+npx playwright screenshot http://localhost:3000/crm/organizations   /tmp/crm-orgs.png
+```
+
+Smoke checklist:
+
+- [ ] Create a Person via the lead form → row appears in contacts table.
+- [ ] Filter the contacts table by `lifecycle_stage=qualified`.
+- [ ] Open the detail panel; click **Link to user** with a known
+      `user_id` and confirm `platform_user === user_id`.
+- [ ] Repeat **Link to user** with the same `user_id` on a person
+      already bound elsewhere — confirm the silent-refusal toast fires
+      (response is 200, but `platform_user` differs).
+- [ ] **Invite by email** a person with a `primary_email`; the second
+      attempt returns 409 with the same `invitation_id`.
+- [ ] **Merge** two duplicates into a primary; confirm
+      `reparented.{deals,activities,tags}` counts are returned.
+- [ ] Create an Organization; deleting it does not cascade-delete
+      Persons that referenced it.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults, links to every sibling skill.
+- `/iblai-crm-deal-flow` — once a person exists, open a deal on the kanban.
+- `/iblai-crm-activity` — log timeline events (calls, meetings, notes, tasks) on a person.
+- `/iblai-crm-tag` — tag CRUD and chip components for people and organizations.
+- `/iblai-crm-notification` — `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER` fire from this flow.
+- `/iblai-rbac` — CRM Inviter / CRM User / CRM Manager roles and the action-definitions endpoint.
+- `/iblai-auth` — token wiring this skill reuses.

--- a/skills/iblai-crm-deal-flow/SKILL.md
+++ b/skills/iblai-crm-deal-flow/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: iblai-crm-deal-flow
+description: Build the revenue funnel CRM surface — pipelines, stages, lead sources, and the kanban deal board with move-stage / won / lost transitions. Use when the user mentions deals, kanban, pipeline, stages, lead sources, move stage, mark won, mark lost, lost reason, deal status, or sales funnel. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for persons (deals require one), /iblai-crm-activity for the timeline + audit rows, and /iblai-crm-notification for CRM_DEAL_STAGE_CHANGED routing.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-deal-flow
+
+Build the revenue funnel: a pipeline selector, a kanban deal board (columns = stages, cards = deals), and the move-stage / won / lost state machine with `lost_reason` collection.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — reuse the same token wiring
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- A Person already exists in the CRM. Deals REQUIRE a `person` UUID — if
+  you have not built the lead capture surface yet, do `/iblai-crm-lead-flow`
+  first and come back.
+- RBAC role on the caller:
+  - `CRM User` — list, read, create, update, delete deals; call
+    `move-stage/`, `won/`, `lost/`. This is what 95% of sales reps need.
+  - `CRM Manager` — additionally lets you CRUD pipelines, stages, and
+    lead sources. Only needed if you're building the admin UI in Step 8.
+  - See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+1. **Pipeline selector** — defaults to the seeded `default` pipeline; lets
+   the user switch when more than one exists.
+2. **Kanban board** — one column per stage in `sort_order`, cards grouped
+   by `deal.stage`. Card shows title, `lead_value` + `currency`, person
+   name, and days-in-stage.
+3. **Drag-drop → `move-stage`** — using `@dnd-kit`, fires
+   `POST /deals/{id}/move-stage/` with `{stage_code}`.
+4. **Deal detail panel** — clicking a card opens a slide-over with full
+   deal fields and **Won** / **Lost** buttons.
+5. **Lost modal** — collects required `lost_reason` before hitting
+   `POST /deals/{id}/lost/`.
+6. **(Optional) Admin UI** — pipeline + stage + lead source CRUD for
+   `CRM Manager` users.
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date.
+Run `iblai --version`, then upgrade directly:
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+## Step 1: Install shadcn primitives + dnd-kit
+
+```bash
+npx shadcn@latest add card badge dialog select button input textarea form sheet skeleton
+pnpm add @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+`@dnd-kit` is the recommended dnd primitive — accessible, headless, plays
+well with shadcn `card`. Do not write a custom drag layer.
+
+## Step 2: Typed API client wrappers
+
+Reuse the auth token wiring from `/iblai-auth` — do NOT introduce a new
+token-management layer. Read the same `Token` value the rest of the app
+uses (the SDK persists it; client code can grab it from `localStorage` or
+from the auth context).
+
+Create `lib/iblai/crm.ts` with thin typed fetchers:
+
+```ts
+// lib/iblai/crm.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+type Stage = {
+  id: number; pipeline: number; code: string; name: string;
+  probability: number; sort_order: number;
+  is_won: boolean; is_lost: boolean; metadata: Record<string, unknown>;
+};
+
+type Pipeline = {
+  id: number; name: string; code: string; is_default: boolean;
+  rotten_days: number; stages: Stage[]; metadata: Record<string, unknown>;
+};
+
+type Deal = {
+  id: number; title: string; description: string;
+  lead_value: string; currency: string;
+  status: "open" | "won" | "lost"; lost_reason: string;
+  expected_close_date: string | null; closed_at: string | null;
+  person: string; organization: string | null;
+  pipeline: number; stage: number;
+  source: number | null; owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string; updated_at: string;
+};
+
+const h = (token: string) => ({
+  Authorization: `Token ${token}`,
+  "Content-Type": "application/json",
+});
+
+export const crm = {
+  listPipelines: (token: string, params = "") =>
+    fetch(`${BASE}/pipelines/${params}`, { headers: h(token) }).then(r => r.json()),
+  listLeadSources: (token: string) =>
+    fetch(`${BASE}/lead-sources/`, { headers: h(token) }).then(r => r.json()),
+  listDeals: (token: string, pipelineId: number) =>
+    fetch(`${BASE}/deals/?pipeline=${pipelineId}&status=open`, { headers: h(token) })
+      .then(r => r.json()),
+  createDeal: (token: string, body: Partial<Deal>) =>
+    fetch(`${BASE}/deals/`, { method: "POST", headers: h(token), body: JSON.stringify(body) })
+      .then(r => r.json()),
+  moveStage: (token: string, id: number, stage_code: string) =>
+    fetch(`${BASE}/deals/${id}/move-stage/`, {
+      method: "POST", headers: h(token), body: JSON.stringify({ stage_code }),
+    }).then(r => r.json()),
+  won: (token: string, id: number, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/won/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify(stage_code ? { stage_code } : {}),
+    }).then(r => r.json()),
+  lost: (token: string, id: number, lost_reason: string, stage_code?: string) =>
+    fetch(`${BASE}/deals/${id}/lost/`, {
+      method: "POST", headers: h(token),
+      body: JSON.stringify({ lost_reason, ...(stage_code ? { stage_code } : {}) }),
+    }).then(r => r.json()),
+};
+```
+
+Full endpoint catalogs and field tables live in
+[`references/pipelines-api.md`](./references/pipelines-api.md),
+[`references/lead-sources-api.md`](./references/lead-sources-api.md), and
+[`references/deals-api.md`](./references/deals-api.md).
+
+## Step 3: Fetch the default pipeline once on mount
+
+Every Platform is seeded with a default pipeline (`code=default`) carrying
+six stages — `new`, `qualified`, `proposal`, `negotiation`, `won`, `lost`.
+The list response embeds the ordered `stages` array inline, so you do not
+need a second roundtrip.
+
+```ts
+const { results } = await crm.listPipelines(token, "?is_default=true");
+const pipeline = results[0];
+// Index stages by CODE — not id. Codes are stable across environments;
+// ids differ between dev / staging / prod (see the CRM doc's [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)).
+const stagesByCode = Object.fromEntries(pipeline.stages.map((s) => [s.code, s]));
+const stagesById = Object.fromEntries(pipeline.stages.map((s) => [s.id, s]));
+```
+
+Cache `pipeline.id` and the stages object in your store (Zustand, Redux,
+or React state). The board only needs to re-fetch when the user switches
+pipelines.
+
+## Step 4: Render the kanban board
+
+```ts
+const { results: deals } = await crm.listDeals(token, pipeline.id);
+const columns = pipeline.stages
+  .filter((s) => !s.is_won && !s.is_lost)        // hide terminal columns on the open board
+  .sort((a, b) => a.sort_order - b.sort_order);
+const byStage = Object.groupBy(deals, (d) => d.stage); // group cards by Deal.stage (the stage id)
+```
+
+Card content:
+- `title` — bold, truncated to 1 line
+- `lead_value` formatted with `Intl.NumberFormat` + `currency`
+- Person name (look up via `/iblai-crm-lead-flow` person store)
+- Days-in-stage = `dayjs().diff(deal.updated_at, "day")`; flag in red when
+  it exceeds `pipeline.rotten_days` (default 30)
+
+Use shadcn `card` for cards, `badge` for the stage chip, `skeleton` for
+the initial loading state.
+
+## Step 5: Drag-drop → move-stage
+
+Wire `@dnd-kit`'s `DndContext` around the columns. On drop, derive the
+destination stage CODE (never raw id — see [best practice: reference stages by code, not by display name](../../../docs/developer/applications/crm.md#162-reference-stages-by-code-not-by-display-name)) and call:
+
+```ts
+async function onDragEnd(deal: Deal, destStageCode: string) {
+  const dest = stagesByCode[destStageCode];
+  if (!dest) return;
+  if (dest.id === deal.stage) return;      // no-op guard — see [Idempotency](../../../docs/developer/applications/crm.md#96-idempotency)
+  const updated = await crm.moveStage(token, deal.id, destStageCode);
+  setDeals((prev) => prev.map((d) => (d.id === deal.id ? updated : d)));
+}
+```
+
+**Server side effects to call out in the UI:**
+
+- The server appends an audit Activity (`type=note`,
+  `title="Stage changed"`, `comment="<from> → <to>"`,
+  `is_done=true`). This row will appear in the deal timeline — render it
+  with a distinct icon and no edit controls per
+  `/iblai-crm-activity` ([best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- A `CRM_DEAL_STAGE_CHANGED` notification fires. See
+  `/iblai-crm-notification` for recipient routing and channel config.
+- `Deal.status` is recomputed from the destination stage's `is_won` /
+  `is_lost` flags. Do **not** echo the optimistic status — re-read from
+  the server response.
+- Dragging onto the same column is **suppressed server-side** (no write,
+  no notification, no audit row). Gate the call client-side too so the
+  UI does not flash. See `references/state-machine.md`.
+
+## Step 6: Won / Lost buttons
+
+On the deal detail panel, add two buttons:
+
+```ts
+// Won — picks the first is_won stage by sort_order automatically
+const updated = await crm.won(token, deal.id);
+
+// Won — disambiguate when the pipeline has multiple is_won stages
+const updated = await crm.won(token, deal.id, "closed-won-expansion");
+```
+
+**Lost** requires `lost_reason` — the API returns `400` if missing or
+blank (see [best practice: always provide a lost_reason](../../../docs/developer/applications/crm.md#164-always-provide-a-lost_reason)). Always collect it in a modal:
+
+```tsx
+<Dialog open={lostOpen} onOpenChange={setLostOpen}>
+  <DialogContent>
+    <DialogTitle>Mark as Lost</DialogTitle>
+    <Textarea
+      placeholder="Why did this deal slip?"
+      value={reason}
+      onChange={(e) => setReason(e.target.value)}
+      maxLength={255}
+      required
+    />
+    <Button
+      disabled={!reason.trim()}
+      onClick={async () => {
+        const updated = await crm.lost(token, deal.id, reason.trim());
+        setLostOpen(false);
+        // refresh board — deal is now status="lost"
+      }}
+    >
+      Confirm Lost
+    </Button>
+  </DialogContent>
+</Dialog>
+```
+
+**Re-opening a deal.** Won/lost are not one-way doors. To re-open, call
+`crm.moveStage(token, dealId, "<non-terminal-stage-code>")`. The server
+clears `closed_at`, flips `status` back to `open`, writes an audit
+Activity, and fires `CRM_DEAL_STAGE_CHANGED` again. There is no dedicated
+"reopen" endpoint — the stage move IS the reopen.
+
+## Step 7: Client-side footguns (must enforce in the UI)
+
+- **Never PATCH `status` or `closed_at`.** Both are server-managed; sending
+  either on PUT/PATCH returns 400 with the message
+  *"Service-managed — write via move-stage/, won/, or lost/."* Do not
+  surface these fields on a deal edit form.
+- **`Deal.stage` must belong to `Deal.pipeline`.** If you let the user
+  switch a deal's pipeline, also force them to pick a stage from the new
+  pipeline before submit. Mismatch returns 400.
+- **`Deal.organization` must match `Person.organization`** when the person
+  already has one. Pre-fill the organization field from the selected
+  person and disable it when set, or you will hit a 400.
+- **`owner` defaults to the calling user.** Only send it when you are
+  explicitly reassigning the deal.
+
+## Step 8 (optional): Pipeline, Stage, and Lead Source admin
+
+Only build this when the user has the `CRM Manager` role. Gate the menu
+entry behind that role — see `/iblai-rbac`.
+
+Destructive-delete behavior differs across these resources — surface a
+confirmation dialog that explains the consequence:
+
+| Resource | DELETE behavior |
+|---|---|
+| Pipeline | `409 Conflict` if any Deal references it. Migrate deals first. |
+| Stage | `409 Conflict` if any Deal references it. Move those deals to another stage first. |
+| Lead Source | **Not blocked.** SETs `Deal.source = NULL` on every referencing deal. Historical attribution is lost. Treat as destructive. |
+
+Other admin guardrails:
+
+- Pipeline `code` is unique per Platform (duplicate → 400).
+- At most one pipeline can have `is_default=true` per Platform — un-flag
+  the existing default first.
+- Stage `code` is unique within its pipeline.
+- A stage cannot be both `is_won` and `is_lost` (400 if you try).
+- `probability` is 0–100 (400 otherwise).
+
+Full tables, error payloads, and curl examples live in
+[`references/pipelines-api.md`](./references/pipelines-api.md) and
+[`references/lead-sources-api.md`](./references/lead-sources-api.md).
+
+## State machine
+
+A Deal's `status` is **derived** from the stage it currently sits in —
+never written directly. Three endpoints change the stage:
+
+- `POST /deals/{id}/move-stage/` — go anywhere in the pipeline.
+- `POST /deals/{id}/won/` — go to the first `is_won` stage (or a specific
+  one via `stage_code`).
+- `POST /deals/{id}/lost/` — go to the first `is_lost` stage; **requires**
+  `lost_reason`.
+
+Every successful, non-no-op transition:
+1. Recomputes `status` (`is_won` → `won`, `is_lost` → `lost`, else `open`).
+2. Stamps or clears `closed_at`.
+3. Writes a `type=note`, `title="Stage changed"` audit Activity.
+4. Fires `CRM_DEAL_STAGE_CHANGED`.
+
+Idempotency: moving to the current stage is a no-op (no write, no signal,
+no audit row, no notification). `lost/` is the one exception — it overwrites
+`lost_reason` unconditionally even when the stage move is a no-op, so
+pass the original reason on retries.
+
+Concurrency: transitions serialize on a row lock. Two simultaneous
+requests cannot both observe the same `from_stage`. Refresh the deal
+after a transition so the UI matches reality.
+
+Full diagrams + edge cases: [`references/state-machine.md`](./references/state-machine.md).
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and drive the board:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals /tmp/deals.png
+   ```
+3. Drag a card from `qualified` → `negotiation`. Confirm:
+   - The card lands and `updated_at` advances.
+   - The deal timeline (via `/iblai-crm-activity`) shows a new system
+     row: title `"Stage changed"`, comment `"Qualified → Negotiation"`.
+   - The notification bell (via `/iblai-crm-notification` →
+     `/iblai-notification`) shows a fresh `CRM_DEAL_STAGE_CHANGED` entry.
+4. Click **Lost** with an empty textarea → submit button is disabled (or
+   the server returns 400 with `{"lost_reason": ["This field is required."]}`).
+5. Click **Won** on an open deal → confirm `status` flips to `won`,
+   `closed_at` is stamped, and the card moves off the open board.
+
+## Related skills
+
+- `/iblai-crm-overview` — auth, Platform scoping, seeded defaults, RBAC matrix.
+- `/iblai-crm-lead-flow` — deals REQUIRE a person; build that flow first.
+- `/iblai-crm-activity` — deal timeline rendering; system audit rows look
+  different from user-logged activities (see [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)).
+- `/iblai-crm-tag` — attach tags to deals; filter the kanban board by tag.
+- `/iblai-crm-notification` — `CRM_DEAL_STAGE_CHANGED` fires from every
+  transition in this skill.
+- `/iblai-rbac` — `CRM User` (deals) vs `CRM Manager` (pipelines, stages,
+  lead sources) permission matrix.
+- `/iblai-auth` — token wiring; do not introduce a parallel token layer.

--- a/skills/iblai-crm-deal-flow/references/deals-api.md
+++ b/skills/iblai-crm-deal-flow/references/deals-api.md
@@ -1,0 +1,223 @@
+# Deals API
+
+Condensed from the CRM doc [Deals API](../../../../docs/developer/applications/crm.md#75-deals).
+
+> **Base URL:** `${NEXT_PUBLIC_API_BASE_URL}/api/crm/`
+> **Auth:** `Authorization: Token <token>`
+> All responses are scoped to the Platform on the token. Cross-Platform
+> deals return `404 Not Found` — never `403` — so existence is never leaked.
+
+## Endpoint catalog
+
+| Method | Path | RBAC | Purpose |
+|---|---|---|---|
+| GET | `/deals/` | `Ibl.CRM/Deals/list` | Paginated list |
+| POST | `/deals/` | `Ibl.CRM/Deals/action` | Create |
+| GET | `/deals/{id}/` | `Ibl.CRM/Deals/read` | Retrieve one |
+| PUT | `/deals/{id}/` | `Ibl.CRM/Deals/write` | Replace editable fields |
+| PATCH | `/deals/{id}/` | `Ibl.CRM/Deals/write` | Patch editable fields |
+| DELETE | `/deals/{id}/` | `Ibl.CRM/Deals/delete` | Delete (cascades audit Activities + tag assignments) |
+| POST | `/deals/{id}/move-stage/` | `Ibl.CRM/Deals/write` | Move to any stage in the deal's pipeline |
+| POST | `/deals/{id}/won/` | `Ibl.CRM/Deals/write` | Move to first `is_won` stage (or `stage_code`-specified) |
+| POST | `/deals/{id}/lost/` | `Ibl.CRM/Deals/write` | Move to first `is_lost` stage; **requires `lost_reason`** |
+| POST | `/deals/{id}/tags/` | `Ibl.CRM/Tags/write` | Attach a tag (see /iblai-crm-tag) |
+| DELETE | `/deals/{id}/tags/{tag_id}/` | `Ibl.CRM/Tags/write` | Detach a tag |
+
+Holding `Ibl.CRM/Deals/write` is **not** sufficient for tag attach/detach
+— they require `Ibl.CRM/Tags/write`.
+
+## Query parameters — `GET /deals/`
+
+| Param | Type | Description |
+|---|---|---|
+| `status` | string | `open`, `won`, `lost` |
+| `pipeline` | integer | Pipeline id |
+| `stage` | integer | PipelineStage id |
+| `owner` | integer | Owning user id |
+| `source` | integer | LeadSource id |
+| `person` | UUID | Primary person on the deal |
+| `organization` | UUID | Organization on the deal |
+| `expected_close_date__gte` / `__lte` | ISO 8601 | Forecast close window |
+| `created_at__gte` / `__lte` | ISO 8601 | Creation window |
+| `metadata__has_key` | string | Top-level key in `metadata` |
+| `tags` | int (repeatable) or CSV | OR-match on tag ids. `?tags=1&tags=2` or `?tags=1,2`. Non-numeric pieces dropped silently |
+| `page` / `page_size` | integer | Pagination |
+
+## Deal fields
+
+| Field | Type | Write rules |
+|---|---|---|
+| `id` | int | Server-assigned |
+| `platform` | int | Server-set from auth token |
+| `title` | string | **Required on POST** |
+| `description` | string | Defaults to `""` |
+| `lead_value` | decimal string | Defaults to `"0"` |
+| `currency` | string | ISO 4217, defaults to `"USD"` |
+| `status` | string | **Server-managed. READ-ONLY.** Derived from current stage's `is_won`/`is_lost` flags. PUT/PATCH with `status` → 400 |
+| `lost_reason` | string | Persisted by the `lost/` action; empty otherwise. Max 255 chars |
+| `expected_close_date` | datetime\|null | Forecast close date |
+| `closed_at` | datetime\|null | **Server-managed. READ-ONLY.** Stamped on entry to terminal stage; cleared on re-open |
+| `person` | UUID | **Required on POST.** Must belong to your Platform |
+| `organization` | UUID\|null | Must belong to your Platform. If the Person has an organization, this MUST match it |
+| `pipeline` | int | **Required on POST.** Must belong to your Platform |
+| `stage` | int | **Required on POST.** Must belong to `pipeline`. Not directly writable on update — use `move-stage/`, `won/`, or `lost/` |
+| `source` | int\|null | LeadSource id; must belong to your Platform |
+| `owner` | int\|null | Defaults to the calling user. Must be an active member of your Platform |
+| `tags` | array | Flat `[{id, name, color}]` — read-only here, mutate via tag sub-routes |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+| `created_at` / `updated_at` | datetime | Timestamps |
+
+### Server-managed fields rule
+
+The serializer rejects writes to `status` and `closed_at` on POST, PUT,
+and PATCH. The only way to change either is via one of the three
+transition endpoints — they recompute both atomically from the destination
+stage's `is_won`/`is_lost` flags.
+
+## POST `/deals/` errors
+
+```json
+{"status": "Service-managed — write via `POST /deals/{id}/move-stage/`, `won/`, or `lost/`."}
+```
+
+```json
+{"stage": "Stage does not belong to the supplied pipeline."}
+```
+
+```json
+{"organization": "Organization does not match the Person's Organization."}
+```
+
+```json
+{"person": "Person belongs to a different platform."}
+```
+
+```json
+{"owner": "User is not an active member of this Platform."}
+```
+
+`403 Forbidden` — caller missing `Ibl.CRM/Deals/action`.
+
+## PUT/PATCH `/deals/{id}/` errors
+
+```json
+{
+  "status": "Service-managed — write via `POST /deals/{id}/move-stage/`, `won/`, or `lost/`.",
+  "closed_at": "Service-managed — write via `POST /deals/{id}/move-stage/`, `won/`, or `lost/`."
+}
+```
+
+## Transition endpoint bodies
+
+### `POST /deals/{id}/move-stage/`
+
+```json
+{"stage_code": "negotiation"}
+```
+
+or:
+
+```json
+{"stage_id": 12}
+```
+
+Provide **one** of `stage_id` or `stage_code`. `stage_code` is the
+integration-safe choice (ids differ across environments).
+
+Errors:
+
+```json
+{"detail": "Provide either `stage_id` or `stage_code`."}
+```
+
+```json
+{"detail": "Destination stage does not belong to this Deal's pipeline."}
+```
+
+```json
+{"detail": "Stage 'negotiation' not found in Deal's pipeline."}
+```
+
+### `POST /deals/{id}/won/`
+
+```json
+{}
+```
+
+or:
+
+```json
+{"stage_code": "closed-won-expansion"}
+```
+
+Errors:
+
+```json
+{"detail": "Pipeline 3 has no is_won=True stage configured."}
+```
+
+```json
+{"detail": "Stage 'closed-won-expansion' is not marked is_won=True."}
+```
+
+### `POST /deals/{id}/lost/`
+
+```json
+{
+  "lost_reason": "Chose competitor — Pied Piper undercut us on price.",
+  "stage_code": "closed-lost-price"
+}
+```
+
+`lost_reason` is **required** and must be non-blank. Max 255 chars.
+
+Errors:
+
+```json
+{"lost_reason": ["This field is required."]}
+```
+
+```json
+{"detail": "Pipeline 3 has no is_lost=True stage configured."}
+```
+
+```json
+{"detail": "Stage 'closed-lost-price' is not marked is_lost=True."}
+```
+
+## Sample list response (truncated)
+
+```json
+{
+  "count": 47,
+  "next_page": 2,
+  "previous_page": null,
+  "results": [
+    {
+      "id": 184,
+      "platform": 1,
+      "title": "Acme renewal — 2026",
+      "description": "Multi-year renewal, 220 seats.",
+      "lead_value": "48000.00",
+      "currency": "USD",
+      "status": "open",
+      "lost_reason": "",
+      "expected_close_date": "2026-09-30T00:00:00Z",
+      "closed_at": null,
+      "person": "c4d2b1a8-7c3e-4f9a-9d6b-9a2c4f1e7b80",
+      "organization": "b2a1e7d3-6f4c-4b2a-8e9d-1c3a5b7d9f10",
+      "pipeline": 3,
+      "stage": 12,
+      "source": 5,
+      "owner": 91,
+      "tags": [
+        {"id": 7, "name": "Enterprise", "color": "#3F6BFF"},
+        {"id": 11, "name": "Renewal", "color": "#22A06B"}
+      ],
+      "metadata": {"region": "NA", "campaign_id": "fy26-renewals"},
+      "created_at": "2026-04-12T08:14:22Z",
+      "updated_at": "2026-05-30T17:02:11Z"
+    }
+  ]
+}
+```

--- a/skills/iblai-crm-deal-flow/references/lead-sources-api.md
+++ b/skills/iblai-crm-deal-flow/references/lead-sources-api.md
@@ -1,0 +1,100 @@
+# Lead Sources API
+
+Condensed from the CRM doc [Lead Sources API](../../../../docs/developer/applications/crm.md#74-lead-sources).
+
+> **Base URL:** `${NEXT_PUBLIC_API_BASE_URL}/api/crm/`
+> **Auth:** `Authorization: Token <token>`
+
+Lead Sources record where a Deal originated (web traffic, referral,
+outbound campaign…). They live under the `Ibl.CRM/Pipelines/` RBAC
+bucket — anyone who can shape pipelines can shape lead sources.
+
+## Seeded defaults
+
+Every Platform ships with four lead sources, created automatically and
+backfilled into existing Platforms via data migration:
+
+| `code` | `name` |
+|---|---|
+| `web` | Web |
+| `referral` | Referral |
+| `cold_call` | Cold Call |
+| `advertisement` | Advertisement |
+
+`code` is the stable identifier. The display `name` can be renamed
+freely without breaking integrations.
+
+## Endpoints
+
+| Method | Path | RBAC | Purpose |
+|---|---|---|---|
+| GET | `/lead-sources/` | `Ibl.CRM/Pipelines/list` | Paginated list |
+| POST | `/lead-sources/` | `Ibl.CRM/Pipelines/action` | Create |
+| GET | `/lead-sources/{id}/` | `Ibl.CRM/Pipelines/read` | Retrieve one |
+| PUT | `/lead-sources/{id}/` | `Ibl.CRM/Pipelines/write` | Replace |
+| PATCH | `/lead-sources/{id}/` | `Ibl.CRM/Pipelines/write` | Patch |
+| DELETE | `/lead-sources/{id}/` | `Ibl.CRM/Pipelines/delete` | Delete — **SET NULL on referencing deals (destructive)** |
+
+## Query parameters — `GET /lead-sources/`
+
+| Name | Type | Description |
+|---|---|---|
+| `code` | string | Case-insensitive exact match |
+| `name` | string | Case-insensitive substring match |
+| `page` / `page_size` | integer | Pagination, `page_size` max 100 |
+
+## Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | int | Server-assigned, stable across renames |
+| `platform` | int | Server-set from auth token |
+| `name` | string | Display name |
+| `code` | string | Unique per Platform, lowercase letters/digits/hyphens |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+| `created_at` / `updated_at` | ISO 8601 | Timestamps |
+
+## Error catalog
+
+`400` on POST/PATCH with duplicate code:
+
+```json
+{"code": ["A LeadSource with code 'linkedin-outbound' already exists on this Platform."]}
+```
+
+`403 Forbidden` — caller missing `Ibl.CRM/Pipelines/action` (POST) /
+`/write` (PATCH/PUT) / `/delete` (DELETE).
+
+## Destructive-delete footgun
+
+Unlike Pipelines and Stages — which return `409 Conflict` when Deals
+reference them — deleting a Lead Source is **not blocked**. Instead, the
+server clears the foreign key on every referencing Deal:
+
+```
+Deal.source = NULL  -- on every Deal that referenced this source
+```
+
+Treat this as destructive. Once the source is gone, the historical
+"where did this Deal come from?" attribution is lost permanently. Surface
+a confirmation dialog that explicitly says so — do not lean on the
+generic shadcn confirm wording.
+
+If you only want to retire the source without losing attribution,
+PATCH the `name` instead (e.g. prefix with `[archived]`) and stop
+offering it in the create-deal UI.
+
+## Sample list response
+
+```json
+{
+  "count": 5,
+  "results": [
+    {"id": 1, "platform": 1, "name": "Web", "code": "web", "metadata": {}},
+    {"id": 2, "platform": 1, "name": "Referral", "code": "referral", "metadata": {}},
+    {"id": 3, "platform": 1, "name": "Cold Call", "code": "cold_call", "metadata": {}},
+    {"id": 4, "platform": 1, "name": "Advertisement", "code": "advertisement", "metadata": {}},
+    {"id": 5, "platform": 1, "name": "LinkedIn Outbound", "code": "linkedin-outbound", "metadata": {"campaign": "q3-saas"}}
+  ]
+}
+```

--- a/skills/iblai-crm-deal-flow/references/pipelines-api.md
+++ b/skills/iblai-crm-deal-flow/references/pipelines-api.md
@@ -1,0 +1,171 @@
+# Pipelines & Stages API
+
+Condensed from the CRM doc [Pipelines & Stages API](../../../../docs/developer/applications/crm.md#73-pipelines--stages).
+
+> **Base URL:** `${NEXT_PUBLIC_API_BASE_URL}/api/crm/`
+> **Auth:** `Authorization: Token <token>`
+> All responses are scoped to the Platform on the token.
+
+## Seeded defaults
+
+Every Platform is seeded with one pipeline and six stages on creation
+(existing Platforms were backfilled via data migration).
+
+| Pipeline `code` | `name` | `is_default` | `rotten_days` |
+|---|---|---|---|
+| `default` | Default Pipeline | `true` | `30` |
+
+Stages on the default pipeline, in `sort_order`:
+
+| `code` | `name` | `probability` | `sort_order` | `is_won` | `is_lost` |
+|---|---|---|---|---|---|
+| `new` | New | 10 | 0 | false | false |
+| `qualified` | Qualified | 25 | 1 | false | false |
+| `proposal` | Proposal | 50 | 2 | false | false |
+| `negotiation` | Negotiation | 75 | 3 | false | false |
+| `won` | Won | 100 | 4 | **true** | false |
+| `lost` | Lost | 0 | 5 | false | **true** |
+
+Treat `code` as the stable identifier in client payloads. `id` differs
+across environments.
+
+## Endpoint summary
+
+| Method | Path | RBAC | Purpose |
+|---|---|---|---|
+| GET | `/pipelines/` | `Ibl.CRM/Pipelines/list` | List pipelines (each carries `stages` inline) |
+| POST | `/pipelines/` | `Ibl.CRM/Pipelines/action` | Create a pipeline |
+| GET | `/pipelines/{id}/` | `Ibl.CRM/Pipelines/read` | Retrieve one |
+| PUT | `/pipelines/{id}/` | `Ibl.CRM/Pipelines/write` | Replace editable fields |
+| PATCH | `/pipelines/{id}/` | `Ibl.CRM/Pipelines/write` | Patch editable fields |
+| DELETE | `/pipelines/{id}/` | `Ibl.CRM/Pipelines/delete` | Delete pipeline (cascades stages) |
+| GET | `/pipelines/{pipeline_id}/stages/` | `Ibl.CRM/Pipelines/list` | List stages (ordered by `sort_order`) |
+| POST | `/pipelines/{pipeline_id}/stages/` | `Ibl.CRM/Pipelines/action` | Create stage in this pipeline |
+| GET | `/pipelines/{pipeline_id}/stages/{id}/` | `Ibl.CRM/Pipelines/read` | Retrieve one stage |
+| PUT | `/pipelines/{pipeline_id}/stages/{id}/` | `Ibl.CRM/Pipelines/write` | Replace stage fields |
+| PATCH | `/pipelines/{pipeline_id}/stages/{id}/` | `Ibl.CRM/Pipelines/write` | Patch stage fields |
+| DELETE | `/pipelines/{pipeline_id}/stages/{id}/` | `Ibl.CRM/Pipelines/delete` | Delete stage |
+
+Stages are nested — they cannot be moved between pipelines, and the
+nested route refuses access to stages of pipelines on other Platforms.
+
+## Query parameters
+
+### `GET /pipelines/`
+
+| Name | Type | Description |
+|---|---|---|
+| `code` | string | Case-insensitive exact match |
+| `name` | string | Case-insensitive substring match |
+| `is_default` | boolean | Filter to default (or non-default) |
+| `page` / `page_size` | integer | Pagination, max `page_size=100` |
+
+### `GET /pipelines/{pipeline_id}/stages/`
+
+| Name | Type | Description |
+|---|---|---|
+| `code` | string | Case-insensitive exact match |
+| `is_won` | boolean | Filter terminal won stages |
+| `is_lost` | boolean | Filter terminal lost stages |
+| `page` / `page_size` | integer | Pagination |
+
+## Pipeline fields
+
+| Field | Type | Write rules |
+|---|---|---|
+| `id` | int | Server-assigned |
+| `platform` | int | Server-set from auth token |
+| `name` | string | Required on create |
+| `code` | string | Required, unique per Platform, lowercase letters/digits/hyphens |
+| `is_default` | boolean | At most one default per Platform — un-flag the existing default first |
+| `rotten_days` | int | Defaults to `30` |
+| `stages` | array | **Read-only on pipeline.** Manage via nested endpoints |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+| `created_at` / `updated_at` | ISO 8601 | Timestamps |
+
+## Stage fields
+
+| Field | Type | Write rules |
+|---|---|---|
+| `id` | int | Server-assigned |
+| `pipeline` | int | **Immutable** — set automatically from URL on POST, read-only thereafter |
+| `code` | string | Required, unique within the pipeline |
+| `name` | string | Required, shown on kanban cards |
+| `probability` | int | 0–100, defaults to `0`, used for revenue forecasting |
+| `sort_order` | int | Left-to-right column order, defaults to `0` |
+| `is_won` | boolean | Terminal won. Moving a deal here sets `Deal.status="won"` |
+| `is_lost` | boolean | Terminal lost. Moving a deal here sets `Deal.status="lost"` |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+
+A stage cannot be both `is_won` and `is_lost`.
+
+## Error catalog
+
+### POST/PATCH pipeline
+
+```json
+{"code": ["A Pipeline with code 'b2b-sales' already exists on this Platform."]}
+```
+
+```json
+{"is_default": ["Another Pipeline on this Platform is already the default. Un-flag the existing default first."]}
+```
+
+### POST/PATCH stage
+
+```json
+{"code": ["A stage with code 'discovery' already exists in this Pipeline."]}
+```
+
+```json
+{"probability": ["probability must be between 0 and 100."]}
+```
+
+```json
+{"detail": ["A stage cannot be both is_won and is_lost."]}
+```
+
+`404 Not Found` — parent pipeline does not exist or belongs to another
+Platform.
+
+### DELETE pipeline
+
+`409 Conflict`:
+
+```json
+{"detail": "Pipeline still has Deals attached."}
+```
+
+Stages cascade-delete with the pipeline when no deals reference them.
+
+### DELETE stage
+
+`409 Conflict`:
+
+```json
+{"detail": "Stage still has Deals attached."}
+```
+
+Migrate deals off the stage first.
+
+## Sample list response (truncated)
+
+```json
+{
+  "count": 1,
+  "next_page": null,
+  "previous_page": null,
+  "results": [
+    {
+      "id": 1, "platform": 1, "name": "Default Pipeline", "code": "default",
+      "is_default": true, "rotten_days": 30,
+      "stages": [
+        {"id": 1, "pipeline": 1, "code": "new", "name": "New", "probability": 10, "sort_order": 0, "is_won": false, "is_lost": false, "metadata": {}},
+        {"id": 5, "pipeline": 1, "code": "won", "name": "Won", "probability": 100, "sort_order": 4, "is_won": true, "is_lost": false, "metadata": {}},
+        {"id": 6, "pipeline": 1, "code": "lost", "name": "Lost", "probability": 0, "sort_order": 5, "is_won": false, "is_lost": true, "metadata": {}}
+      ],
+      "metadata": {}
+    }
+  ]
+}
+```

--- a/skills/iblai-crm-deal-flow/references/state-machine.md
+++ b/skills/iblai-crm-deal-flow/references/state-machine.md
@@ -1,0 +1,205 @@
+# Deal Lifecycle — State Machine
+
+Full text of the CRM doc [Deal Lifecycle](../../../../docs/developer/applications/crm.md#9-deal-lifecycle).
+
+A Deal moves through the stages of its Pipeline and reports a high-level
+`status` of `open`, `won`, or `lost`. Both `status` and `closed_at` are
+**derived** from the stage the Deal currently sits in — they are never
+written directly. Anything that needs to change where a Deal lives in the
+pipeline goes through one of three action endpoints, and each one writes
+an audit row and fires a notification so the timeline and the inbox stay
+in sync with the kanban.
+
+This is the contract for that flow: which endpoints to call, which fields
+are off-limits to PATCH, what the audit row looks like, what happens under
+concurrency, and what counts as a no-op.
+
+## 1. The three transitions
+
+There are exactly three endpoints that change a Deal's stage. Everything
+else — list, retrieve, create, partial update of metadata — leaves the
+stage alone.
+
+### `POST /api/crm/deals/{id}/move-stage/`
+
+- Body: `{"stage_id": <int>}` OR `{"stage_code": "<slug>"}`
+- Moves the Deal to any stage in its Pipeline (initial, intermediate, or
+  terminal).
+- Use this for kanban drag-and-drop and for explicit stage pickers.
+
+### `POST /api/crm/deals/{id}/won/`
+
+- Body (optional): `{"stage_code": "<slug>"}`
+- Moves the Deal to a terminal won stage. If `stage_code` is omitted, the
+  API resolves the first stage in the Pipeline with `is_won: true`, ordered
+  by `sort_order`.
+- Use this for the "Mark as Won" button on a Deal detail page.
+
+### `POST /api/crm/deals/{id}/lost/`
+
+- Body: `{"lost_reason": "<string>", "stage_code": "<slug>?"}`
+- `lost_reason` is **REQUIRED** — the API returns 400 if it is missing or
+  blank. `stage_code` is optional and falls back to the first terminal
+  lost stage by `sort_order`.
+- Use this for the "Mark as Lost" modal, which should always collect a
+  reason before submitting.
+
+All three return the updated Deal on success and the standard error
+envelope on failure.
+
+## 2. Read-only fields
+
+`status` and `closed_at` are server-managed and cannot be set by the client.
+
+- A PATCH or PUT against `/api/crm/deals/{id}/` that includes `status` or
+  `closed_at` returns `400` with a field-level error message naming the
+  offending field.
+- The fix is to call one of the three action endpoints above. Do not
+  surface `status` or `closed_at` in a Deal edit form; they belong on the
+  transition controls.
+
+`stage` is also not directly writable on update — to change the stage,
+call `move-stage/`, `won/`, or `lost/`. Direct stage assignment is reserved
+for Deal creation.
+
+## 3. Audit trail
+
+Every successful stage move that actually changes the Deal's stage writes
+a system Activity. No-ops (see [Idempotency](#6-idempotency)) do not.
+
+The audit Activity is shaped like this:
+
+| Field | Value |
+|---|---|
+| `type` | `note` |
+| `is_done` | `true` |
+| `done_at` | transition time |
+| `title` | `"Stage changed"` |
+| `comment` | `"<From Display Name> → <To Display Name>"` — uses the human-readable stage names, not slugs (for example `"Negotiation → Closed Won"`, not `"negotiation → closed-won"`) |
+| `owner` | the user who triggered the transition (the authenticated caller; null for service-account callers without an underlying user) |
+| `deal` | the Deal that moved |
+| `person` | the Deal's `person`, so the audit row also surfaces in person-centric timelines |
+
+Listing activities filtered by `?deal={id}` returns these system rows
+interleaved with user-logged Activities (calls, meetings, tasks, notes).
+To make the timeline readable:
+
+- Render system stage-change rows with a distinct icon (an arrow or
+  pipeline glyph works well) and a muted background.
+- Do not show edit or "mark done" controls on them — they are already
+  `is_done: true` and they describe an event, not a task.
+- Keep them in chronological order with the rest of the timeline so reps
+  can read the full story of the Deal in one pass.
+
+See `/iblai-crm-activity` for the full timeline rendering contract.
+
+## 4. Notification
+
+Every successful, non-no-op stage move fires a `CRM_DEAL_STAGE_CHANGED`
+notification. The notification carries the Deal, the from-stage, the
+to-stage, and the user who triggered the move. Routing follows the
+standard CRM `RecipientsConfig` rules — owner, configured admins, or a
+custom list per Platform.
+
+See `/iblai-crm-notification` for the full context payload, the available
+channels, and how to wire recipient routing per Platform.
+
+## 5. Concurrency
+
+Stage moves on the same Deal are serialized.
+
+When the API processes any of the three transition endpoints, it acquires
+a row lock on the Deal before reading its current stage, writing the new
+one, recording the audit row, and firing the notification. If two requests
+land at the same time — a kanban drag racing with someone clicking the
+Won button, or two reps acting on the same Deal — one wins and runs to
+completion, then the other proceeds against the now-updated state.
+
+The practical consequences:
+
+- Exactly one stage transition is recorded per logical move. You never
+  get two audit rows for what was conceptually one drag.
+- Exactly one `CRM_DEAL_STAGE_CHANGED` notification is fired per logical
+  move. Recipients do not get duplicates.
+- The losing request still gets a successful response (or a no-op
+  response, if the winner happened to move the Deal to the same stage the
+  loser was targeting).
+
+The UI does not need to coordinate clients. The lock does the work. What
+the UI should do is **refresh the Deal after a successful transition** so
+the displayed stage matches reality, since another user's action may have
+run in between.
+
+## 6. Idempotency
+
+The three transitions are idempotent with respect to the Deal's current
+stage. Calling them when the Deal is already where you are asking it to
+go is a no-op:
+
+- `move-stage/` to the current stage: no write, no audit row, no signal,
+  no notification. Returns `200` with the unchanged Deal.
+- `won/` on a Deal already in its won stage: no-op. Returns `200`.
+- `lost/` on a Deal already in its lost stage: the stage transition is a
+  no-op (no audit row, no signal, no notification), **but `lost_reason`
+  is overwritten unconditionally with whatever value is in the request
+  body**. Pass the original reason on retries, or PATCH the Deal directly
+  if you want to change only the reason without re-firing the lost action.
+
+This means clients can safely retry transition requests on transient
+network failures without worrying about double-recording the move.
+
+## 7. Re-opening a Deal
+
+Won and lost are not one-way doors. Moving a Deal in a terminal stage
+back to a non-terminal stage re-opens it:
+
+- `status` flips back to `open`.
+- `closed_at` is cleared.
+- An audit Activity is still written (`"Closed Won → Negotiation"`, for
+  example).
+- A `CRM_DEAL_STAGE_CHANGED` notification still fires, so the owner and
+  configured admins know the Deal is live again.
+
+Use `move-stage/` to re-open. There is no dedicated "reopen" endpoint —
+the stage move IS the reopen, and the derived `status` follows the
+destination stage's `is_won` / `is_lost` flags.
+
+## 8. Diagram — winning a deal
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant API as CRM API
+    participant Recipients as Notification recipients
+    C->>API: POST /deals/{id}/won/
+    API->>API: Resolve target stage (first is_won)
+    API->>API: Lock deal row
+    API->>API: Update stage + status + closed_at
+    API->>API: Write audit Activity ("Stage changed: Negotiation → Closed Won")
+    API->>Recipients: CRM_DEAL_STAGE_CHANGED notification
+    API-->>C: 200 Deal (status: won, closed_at set)
+```
+
+## State diagram — derived status
+
+```
+                  move-stage(non-terminal)
+                 ┌───────────────────────────────┐
+                 │                               ▼
+            ┌────────┐   move-stage(is_won)   ┌────────┐
+            │  open  │ ─────── won/ ────────► │  won   │
+            └────────┘                        └────────┘
+                 │                               │
+                 │ move-stage(is_lost)           │ move-stage(non-terminal) → re-open
+                 │      lost/                    ▼
+                 │                          ┌────────┐
+                 └────────────────────────► │  lost  │
+                                            └────────┘
+                                                │
+                                                │ move-stage(non-terminal) → re-open
+                                                ▼
+                                            (back to open)
+```
+
+Every arrow above (except no-op self-loops) writes one audit Activity
+and fires one `CRM_DEAL_STAGE_CHANGED` notification.

--- a/skills/iblai-crm-lead-flow/SKILL.md
+++ b/skills/iblai-crm-lead-flow/SKILL.md
@@ -1,0 +1,433 @@
+---
+name: iblai-crm-lead-flow
+description: Build the CRM top-of-funnel surface — lead-capture form, contacts table with lifecycle filter, organization records, and the three person onboarding actions (link existing Platform user, invite by email, merge duplicates). Use when the user mentions CRM leads, contacts, people, persons, organizations, lead capture, contact intake, link to user, invite by email, merge duplicates, or lifecycle stage. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-deal-flow to open a deal once a person exists, /iblai-crm-activity for the timeline, /iblai-crm-tag for tag chips, /iblai-crm-notification for the events this flow fires, /iblai-rbac for CRM Inviter/User/Manager roles, and /iblai-auth for token wiring.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-lead-flow
+
+Build the people-and-organizations surface of the CRM: capture leads, list
+contacts, view person detail, manage organizations, and run the three
+onboarding actions (link, invite, merge).
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for person and organization
+  CRUD. Add the **CRM Inviter** role on top if you need
+  `POST /persons/{id}/invite/`. See `/iblai-rbac` for the full matrix.
+
+## What you'll build
+
+- A **lead-capture form** that POSTs to `/api/crm/persons/` with
+  `name`, `primary_email`, `lifecycle_stage`, optional `organization`,
+  and free-form `metadata`.
+- A **contacts table** at `/crm/contacts` with a lifecycle-stage
+  filter, owner filter, and tag filter, backed by
+  `GET /api/crm/persons/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **person detail panel** that loads `GET /api/crm/persons/{id}/`
+  and exposes three onboarding action buttons: **Link to user**,
+  **Invite by email**, **Merge duplicates**.
+- An **organizations table + form** at `/crm/organizations` for
+  `GET`/`POST /api/crm/organizations/`.
+- An **action-result toast** layer so the silent-refusal footgun on
+  `link-user/` is surfaced loudly.
+
+Reference tables for every endpoint live in:
+
+- `references/persons-api.md`
+- `references/organizations-api.md`
+- `references/onboarding-flows.md`
+
+## Step 1: Install shadcn primitives
+
+The contacts table, lead form, detail panel, and the link/invite/merge
+dialogs use only shadcn primitives. Install once:
+
+```bash
+npx shadcn@latest add form table dialog select badge input textarea
+```
+
+Do not write custom replacements for these — they share the ibl.ai
+Tailwind theme automatically.
+
+## Step 2: Add a typed CRM API client
+
+Reuse the auth token that `/iblai-auth` wrote into `.env.local`
+(`NEXT_PUBLIC_API_BASE_URL`, and the user token read from localStorage
+under the same key `/iblai-auth` uses). Do NOT introduce a new
+token-management layer.
+
+Create `lib/iblai/crm-client.ts`:
+
+```ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+
+function token() {
+  // /iblai-auth stores the access token in localStorage. Reuse it.
+  return typeof window !== "undefined"
+    ? localStorage.getItem("ibl_access_token") ?? ""
+    : "";
+}
+
+async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Token ${token()}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw Object.assign(new Error(res.statusText), { status: res.status, body });
+  }
+  return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+}
+
+export type Page<T> = {
+  count: number;
+  next_page: number | null;
+  previous_page: number | null;
+  results: T[];
+};
+
+export type LifecycleStage =
+  | "lead"
+  | "qualified"
+  | "opportunity"
+  | "customer"
+  | "churned";
+
+export type Person = {
+  id: string;
+  platform: number | string;
+  name: string;
+  primary_email: string | null;
+  emails: { label: string; email: string }[];
+  contact_numbers: { label: string; number: string }[];
+  job_title: string;
+  organization: string | null;
+  owner: number | null;
+  platform_user: number | null;
+  lifecycle_stage: LifecycleStage;
+  unique_id: string;
+  active: boolean;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Organization = {
+  id: string;
+  platform: number | string;
+  name: string;
+  address: Record<string, unknown>;
+  owner: number | null;
+  tags: { id: number; name: string; color: string }[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export const crm = {
+  // Persons
+  listPersons: (q: URLSearchParams) =>
+    call<Page<Person>>(`/persons/?${q.toString()}`),
+  getPerson: (id: string) => call<Person>(`/persons/${id}/`),
+  createPerson: (body: Partial<Person>) =>
+    call<Person>(`/persons/`, { method: "POST", body: JSON.stringify(body) }),
+  patchPerson: (id: string, body: Partial<Person>) =>
+    call<Person>(`/persons/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+  deletePerson: (id: string) =>
+    call<void>(`/persons/${id}/`, { method: "DELETE" }),
+  linkUser: (id: string, user_id: number) =>
+    call<Person>(`/persons/${id}/link-user/`, {
+      method: "POST",
+      body: JSON.stringify({ user_id }),
+    }),
+  invite: (
+    id: string,
+    body: {
+      is_admin?: boolean;
+      is_staff?: boolean;
+      enrollment_config?: Record<string, unknown>;
+      redirect_to?: string;
+    },
+  ) =>
+    call<{
+      person_id: string;
+      invitation_id: number;
+      invitation_email: string;
+      platform_key: string;
+      auto_accept: boolean;
+      active: boolean;
+      redirect_to: string | null;
+      created: string | null;
+    }>(`/persons/${id}/invite/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  merge: (primary_id: string, duplicate_ids: string[]) =>
+    call<{
+      primary_id: string;
+      merged_ids: string[];
+      reparented: { deals: number; activities: number; tags: number };
+    }>(`/persons/merge/`, {
+      method: "POST",
+      body: JSON.stringify({ primary_id, duplicate_ids }),
+    }),
+
+  // Organizations
+  listOrgs: (q: URLSearchParams) =>
+    call<Page<Organization>>(`/organizations/?${q.toString()}`),
+  getOrg: (id: string) => call<Organization>(`/organizations/${id}/`),
+  createOrg: (body: Partial<Organization>) =>
+    call<Organization>(`/organizations/`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+};
+```
+
+All examples in the references send `Authorization: Token …` — this
+client does the same.
+
+## Step 3: Lead-capture form
+
+Page route: `app/crm/leads/new/page.tsx`. Fields:
+
+- `name` — required, text input.
+- `primary_email` — recommended; auto-link binds on Platform signup.
+- `lifecycle_stage` — `Select` defaulting to `lead`
+  (`lead | qualified | opportunity | customer | churned`).
+- `organization` — `Select` populated from
+  `crm.listOrgs(new URLSearchParams())`.
+- `metadata` — `textarea`, parsed as JSON before submit.
+
+Submit calls `crm.createPerson({...})`. On `201` redirect to
+`/crm/contacts/{id}`. Handle:
+
+- `400` with a `unique_id` array → show the server message under the
+  `unique_id` field (duplicate import key).
+- `403` → "You need the CRM User role to create contacts" (cross-ref
+  `/iblai-rbac`).
+
+Full field table: [`POST /persons/` in the Persons API reference](references/persons-api.md#post-persons).
+
+## Step 4: Contacts table
+
+Page route: `app/crm/contacts/page.tsx`. Fetch via
+`crm.listPersons(query)` where `query` is built from URL search params:
+
+- `lifecycle_stage` — `Select` with the five stages plus "All".
+- `owner` — numeric input or owner picker.
+- `tags` — multi-select; emit `?tags=1&tags=2` (OR semantics, results
+  de-duplicated server-side).
+- `page` / `page_size` — pagination, max `page_size=100`.
+
+Render rows in a shadcn `Table`. Columns: name, primary_email,
+lifecycle stage (`Badge`), owner, tags (chip per item). Wire pagination
+off the `{count, next_page, previous_page, results}` envelope — do not
+assume cursor pagination.
+
+Each row links to `/crm/contacts/{id}`.
+
+## Step 5: Person detail panel + onboarding actions
+
+Page route: `app/crm/contacts/[id]/page.tsx`. Load via
+`crm.getPerson(id)`. Display name, email, lifecycle stage,
+organization, owner, `platform_user` (when set), tags, metadata, and
+the three action buttons described below.
+
+### 5a. Link to existing Platform user
+
+Dialog with a single `user_id` numeric input. On submit:
+
+```ts
+const linked = await crm.linkUser(person.id, Number(userId));
+
+// SILENT-REFUSAL FOOTGUN: a 200 response whose platform_user
+// does NOT equal the requested user_id means the person was already
+// bound to a different user and the existing binding was preserved.
+// You MUST assert equality client-side before claiming success.
+if (linked.platform_user !== Number(userId)) {
+  toast.error(
+    `This person is already linked to user ${linked.platform_user}. ` +
+      `The existing binding was preserved.`,
+  );
+} else {
+  toast.success("Linked to Platform user.");
+}
+```
+
+Status codes to handle: `400` (missing/wrong `user_id`), `403` (target
+user has no active `UserPlatformLink` — surface "issue an invitation
+instead"), `404` (person or user does not exist). Full table:
+[the Link flow in the onboarding reference](references/onboarding-flows.md#1-link-an-existing-platform-user).
+
+### 5b. Invite by email
+
+Dialog with `is_admin` and `is_staff` checkboxes, optional
+`enrollment_config` (textarea, JSON), and optional `redirect_to` URL.
+Requires the person to have a `primary_email`.
+
+Status codes:
+
+| Code | Meaning |
+|------|---------|
+| `201` | Invitation queued. Show success toast. |
+| `400` | Person has no `primary_email`. Disable the button when null. |
+| `403` | Caller missing `Ibl.CRM/Invite/action` (CRM Inviter role). |
+| `404` | Person not found. |
+| `409` | Active invitation already exists. Body contains `invitation_id` — treat as "already done", offer a "resend" affordance. |
+| `422` | Person already linked to a Platform user. Hide the button when `platform_user` is set. |
+
+Full body and field list: [the Invite flow in the onboarding reference](references/onboarding-flows.md#2-invite-by-email).
+
+### 5c. Merge duplicates
+
+Dialog with a multi-select of duplicate person rows to merge into the
+current (primary) person. Submit:
+
+```ts
+const result = await crm.merge(primaryId, duplicateIds);
+// result.reparented = { deals, activities, tags }
+toast.success(
+  `Merged ${result.merged_ids.length} duplicates. ` +
+    `Reparented ${result.reparented.deals} deals, ` +
+    `${result.reparented.activities} activities, ` +
+    `${result.reparented.tags} tag assignments.`,
+);
+```
+
+Status codes: `400` (primary in `duplicate_ids`, empty
+`duplicate_ids`, cross-Platform duplicate), `403`, `404`. Duplicates
+are **soft-deleted** (`active=false`); their rows are still
+retrievable by id, so list views must filter on `active=true`.
+
+## Step 6: Organizations table + form
+
+Page route: `app/crm/organizations/page.tsx`. Use
+`crm.listOrgs(query)` with `?name=<substring>&owner=<id>&tags=…`.
+Render in a shadcn `Table` with name, owner, tags, created_at.
+
+Create form at `app/crm/organizations/new/page.tsx`:
+
+- `name` — required, must be unique within the Platform
+  (case-sensitive, trimmed). Handle `400 {"name": ["… already exists …"]}`
+  by surfacing the message inline.
+- `address` — free-form JSON `textarea` (the recommended shape
+  `{street, city, state, zip, country}` is a hint, not enforced).
+- `owner` — optional numeric.
+- `metadata` — free-form JSON.
+
+Deleting an organization sets `Person.organization` and
+`Deal.organization` to `null` on every referencing row — there is no
+cascade-delete. Tag assignments on the organization are removed. Full
+shape: `references/organizations-api.md`.
+
+## Auto-link signal
+
+You do not need to call any endpoint for this — but you must build for
+it. When a Platform user is created (signup, invitation acceptance,
+admin) and their email matches a Person's `primary_email`
+(case-insensitive) on a Platform they belong to, the system
+asynchronously sets `platform_user`, flips `active` from `true` to
+`false`, and fires a `CRM_PERSON_LINKED_TO_USER` notification.
+
+Two UI consequences:
+
+- A `GET /persons/{id}/` issued seconds after signup may still show
+  `active: true` and `platform_user: null`. Build polling or a
+  notification-driven refresh into any view that surfaces this state.
+- A row can disappear from an "active people" list between page loads
+  with no operator action in between. Tolerate the transition; do not
+  crash on missing rows.
+
+The notification fires regardless of whether your CRM UI is open.
+Cross-ref `/iblai-crm-notification` for recipient routing and how to
+subscribe an inbox.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done.
+
+```bash
+pnpm build         # must pass with zero errors
+pnpm typecheck
+pnpm dev &
+npx playwright screenshot http://localhost:3000/crm/leads/new       /tmp/crm-lead.png
+npx playwright screenshot http://localhost:3000/crm/contacts        /tmp/crm-contacts.png
+npx playwright screenshot http://localhost:3000/crm/organizations   /tmp/crm-orgs.png
+```
+
+Smoke checklist:
+
+- [ ] Create a Person via the lead form → row appears in contacts table.
+- [ ] Filter the contacts table by `lifecycle_stage=qualified`.
+- [ ] Open the detail panel; click **Link to user** with a known
+      `user_id` and confirm `platform_user === user_id`.
+- [ ] Repeat **Link to user** with the same `user_id` on a person
+      already bound elsewhere — confirm the silent-refusal toast fires
+      (response is 200, but `platform_user` differs).
+- [ ] **Invite by email** a person with a `primary_email`; the second
+      attempt returns 409 with the same `invitation_id`.
+- [ ] **Merge** two duplicates into a primary; confirm
+      `reparented.{deals,activities,tags}` counts are returned.
+- [ ] Create an Organization; deleting it does not cascade-delete
+      Persons that referenced it.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults, links to every sibling skill.
+- `/iblai-crm-deal-flow` — once a person exists, open a deal on the kanban.
+- `/iblai-crm-activity` — log timeline events (calls, meetings, notes, tasks) on a person.
+- `/iblai-crm-tag` — tag CRUD and chip components for people and organizations.
+- `/iblai-crm-notification` — `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER` fire from this flow.
+- `/iblai-rbac` — CRM Inviter / CRM User / CRM Manager roles and the action-definitions endpoint.
+- `/iblai-auth` — token wiring this skill reuses.

--- a/skills/iblai-crm-lead-flow/references/onboarding-flows.md
+++ b/skills/iblai-crm-lead-flow/references/onboarding-flows.md
@@ -1,0 +1,268 @@
+# Person Onboarding — Link / Invite / Merge
+
+Condensed from the [Person Onboarding section of the CRM doc](../../../../docs/developer/applications/crm.md#8-person-onboarding-link-invite-merge). People in the CRM start as records — rows
+holding emails, lifecycle stage, ownership, tags — that are not yet
+real Platform accounts. They become first-class Platform users in one
+of three explicit ways (link, invite, merge), plus one implicit signal
+(auto-link). All examples send `Authorization: Token <token>`.
+
+## Decision tree
+
+Pick the right endpoint before you call anything.
+
+```
+Is there already a Platform user for this person?
+├── Yes, user_id is known         → POST /persons/{id}/link-user/
+├── No, but the person has email  → POST /persons/{id}/invite/
+└── Duplicate person rows         → POST /persons/merge/
+```
+
+The three branches are **not interchangeable**:
+
+| Branch | Precondition | What it produces |
+|--------|--------------|------------------|
+| Link   | Target Platform user already exists with an active membership | Person bound immediately (`platform_user` set, `active=false`) |
+| Invite | Person has a `primary_email` | Platform invitation row; user is created **only** when the invitee accepts |
+| Merge  | Two or more person rows for the same human | Deals / activities / tags re-parented onto a primary; duplicates soft-deleted |
+
+---
+
+## 1. Link an existing Platform user
+
+`POST /api/crm/persons/{id}/link-user/`
+
+**Request**
+
+```json
+{ "user_id": 1184 }
+```
+
+**Response** `200 OK` — full Person object. On success:
+`platform_user` is set to the requested `user_id` and `active` flips
+to `false`. Once bound, the Platform user is the source of truth and
+the person row becomes historical sales context.
+
+### Silent-refusal footgun
+
+The link service refuses to rebind a person that is already bound to a
+**different** Platform user. There is no error response — the call
+returns **200 OK** with the existing binding untouched. Clients
+**MUST** verify equality:
+
+```ts
+const linked = await crm.linkUser(personId, requestedUserId);
+if (linked.platform_user !== requestedUserId) {
+  // Refusal: this person is already linked to someone else.
+  // Surface "already linked to user X" — DO NOT claim success.
+}
+```
+
+Silent rebinds would erase a prior link without trace, so they are
+forbidden by design.
+
+### Status codes
+
+| Code | When |
+|------|------|
+| `200` | Linked **OR** silent refusal — compare `platform_user` to your request. |
+| `400` | `user_id` missing or wrong type. |
+| `403` | Target user has no active `UserPlatformLink` to this Platform — *"issue an invitation instead."* |
+| `404` | Person not found in this Platform, or `user_id` does not exist. |
+
+**RBAC:** `Ibl.CRM/Persons/write`. The target user must additionally
+have an active membership in the same Platform.
+
+---
+
+## 2. Invite by email
+
+`POST /api/crm/persons/{id}/invite/`
+
+Use this when the person is **not** yet a Platform user. The
+invitation reuses the standard Platform invitation pipeline. On
+acceptance a Platform user is created and the auto-link signal
+(section 4) binds the person automatically.
+
+**Request**
+
+```json
+{
+  "is_admin": false,
+  "is_staff": false,
+  "redirect_to": "https://app.example.com/dashboard"
+}
+```
+
+- `is_admin` / `is_staff` — privileges granted on acceptance. Both
+  default to `false`.
+- `redirect_to` — URL the invitee lands on after accepting. Omit for
+  the Platform default. Max 255 chars.
+- `enrollment_config` — optional object forwarded to the invitation
+  for auto-enrollment in courses, programs, or pathways.
+
+**Response** `201 Created`
+
+```json
+{
+  "person_id": "<uuid>",
+  "invitation_id": 9821,
+  "invitation_email": "alice@example.com",
+  "platform_key": "acme",
+  "auto_accept": true,
+  "active": true,
+  "redirect_to": "https://app.example.com/dashboard",
+  "created": "2026-06-04T09:24:01Z"
+}
+```
+
+The response confirms the invitation row was created — it does **not**
+guarantee the email landed; delivery happens out-of-band.
+
+### Status codes
+
+| Code | When |
+|------|------|
+| `201` | Invitation created and queued for delivery. |
+| `400` | Person has no `primary_email` — cannot invite. Disable the button when `primary_email` is null. |
+| `403` | Caller missing `Ibl.CRM/Invite/action`. |
+| `404` | Person not found in this Platform. |
+| `409` | Active invitation already exists for this email + Platform. **Informational, not a hard error** — the body carries the pre-existing `invitation_id`. Treat as "already done"; offer a "resend" affordance. |
+| `422` | Person already linked to a Platform user (`platform_user` is set). Hide the button. |
+
+**409 body shape**
+
+```json
+{
+  "detail": "Active PlatformInvitation already exists for this email + platform.",
+  "invitation_id": 9821,
+  "person_id": "<uuid>",
+  "platform_key": "acme"
+}
+```
+
+**RBAC:** `Ibl.CRM/Invite/action` — a **separate bucket** from
+person-write. A role that can fully edit and delete people but does
+not carry `Ibl.CRM/Invite/action` cannot send invitations. This is
+deliberate: invitations send email and grant Platform access, so the
+privilege is split out. See `/iblai-rbac` for the CRM Inviter role.
+
+---
+
+## 3. Merge duplicates
+
+`POST /api/crm/persons/merge/`
+
+Duplicates appear when the same human shows up through two channels —
+a CSV import plus a webform submission, two integrations pointing at
+the same address, a marketing list collision. Merge re-parents related
+records onto a chosen primary and marks the rest inactive.
+
+**Request**
+
+```json
+{
+  "primary_id": "<uuid>",
+  "duplicate_ids": ["<uuid>", "<uuid>"]
+}
+```
+
+**Response** `200 OK`
+
+```json
+{
+  "primary_id": "<uuid>",
+  "merged_ids": ["<uuid>", "<uuid>"],
+  "reparented": { "deals": 7, "activities": 23, "tags": 4 }
+}
+```
+
+### What re-parents
+
+In a single transaction:
+
+- **Deals** — every deal that pointed at a duplicate now points at the primary.
+- **Activities** — calls, meetings, tasks, notes are re-attached to the primary.
+- **Tag assignments** — moved across, with one wrinkle: if the primary already carries the same tag, the duplicate's assignment is **dropped silently** (the `(tag, person)` unique constraint forbids stacking). The `reparented.tags` count reflects every assignment **touched** — both moves and drops — not just successful moves. For exact post-merge counts, compare before/after listings.
+
+### What happens to duplicates
+
+Duplicates are **not deleted**. Each duplicate's `active` flag is set
+to `false` and the row remains retrievable by id. This preserves audit
+trail and lets you investigate later — but it also means a
+`GET /persons/{duplicate_id}/` after a merge returns the inactive row,
+not a 404. Filter on `active=true` if your UI should hide them.
+
+### Status codes
+
+| Code | When |
+|------|------|
+| `200` | Merge complete (or no-op rerun — counts are zero). |
+| `400` | `primary_id` appears in `duplicate_ids`, `duplicate_ids` empty, or cross-Platform duplicate. |
+| `403` | Caller missing `Ibl.CRM/Persons/write`. |
+| `404` | Primary not found in this Platform. |
+
+**RBAC:** `Ibl.CRM/Persons/write`. Cross-Platform merges are
+explicitly forbidden — every id must resolve to a person on the
+caller's Platform.
+
+---
+
+## 4. Auto-link signal (implicit)
+
+There is a fourth, implicit path. When a Platform user is created —
+through signup, invitation acceptance, or admin action — the system
+asynchronously walks the CRM and binds any matching person records
+automatically. This is what makes bulk-imported person rows
+"come to life" as their invitees register.
+
+### Matching rules
+
+After a Platform user is created with an active membership for a
+Platform, the system searches that Platform for person rows where:
+
+- `primary_email` equals the new user's email (case-insensitive), **or** `platform_user` is already set to that user,
+- `active` is `true`,
+- the person belongs to a Platform the user is an active member of.
+
+For every match: `platform_user` is set, `active` is flipped to
+`false`, and a **`CRM_PERSON_LINKED_TO_USER`** notification is
+dispatched. Cross-ref `/iblai-crm-notification`.
+
+The match is gated by Platform membership — a new user with email
+`alice@example.com` only auto-links to person rows on Platforms they
+actually belong to. Cross-Platform leakage is not possible through
+this path.
+
+### Sequence
+
+```
+1. App                POST /persons/  { primary_email: "alice@x.com" }
+2. CRM API            201 Person       (active: true, platform_user: null)
+   ... later ...
+3. alice@x.com signs up as a Platform user
+4. Background worker  matches persons by primary_email
+5. CRM API            sets platform_user, flips active → false
+6. Notification       CRM_PERSON_LINKED_TO_USER dispatched
+```
+
+### State-transition callout — build for it
+
+The auto-link runs in the background, so the response that created
+the Platform user returns **before** the link completes. Two
+consequences for clients:
+
+- A `GET /persons/{id}/` issued moments after a signup may still show
+  `active: true` and `platform_user: null`. A retry seconds later
+  shows the linked state. Build polling or a notification-driven
+  refresh into any UI that surfaces this.
+- A person can flip from `active: true` to `active: false` between
+  page loads with no operator action in between. UIs that render a
+  list of "active people" must tolerate rows disappearing on the next
+  fetch; never crash on the transition.
+
+### Edge cases
+
+- A user with no email is **skipped** — the system will not bulk-link every blank-`primary_email` person to a fresh emailless user.
+- A user with no active Platform memberships is **skipped** — no Platforms to scan.
+- A person already bound to a different Platform user is **left alone** (the silent-refusal rule from [Link an existing Platform user](../../../../docs/developer/applications/crm.md#81-link-an-existing-platform-user) applies here too).
+- Re-running auto-link for the same user is a no-op once everything is bound; it is safe to retry on background-task failures.

--- a/skills/iblai-crm-lead-flow/references/organizations-api.md
+++ b/skills/iblai-crm-lead-flow/references/organizations-api.md
@@ -1,0 +1,156 @@
+# Organizations API — Reference
+
+Condensed from the [Organizations API section of the CRM doc](../../../../docs/developer/applications/crm.md#72-organizations). Every endpoint is scoped to the caller's
+Platform. All examples send `Authorization: Token <token>`.
+
+**Base path:** `/api/crm/organizations/`
+
+**Pagination envelope** (shared across the CRM):
+
+```json
+{
+  "count": 0,
+  "next_page": null,
+  "previous_page": null,
+  "results": []
+}
+```
+
+## Endpoint summary
+
+| Method | Path | RBAC | Purpose |
+|--------|------|------|---------|
+| `GET`    | `/organizations/`                            | `Ibl.CRM/Organizations/list`   | List organizations in your Platform |
+| `POST`   | `/organizations/`                            | `Ibl.CRM/Organizations/action` | Create an organization |
+| `GET`    | `/organizations/{id}/`                       | `Ibl.CRM/Organizations/read`   | Retrieve one organization |
+| `PUT`    | `/organizations/{id}/`                       | `Ibl.CRM/Organizations/write`  | Replace all editable fields |
+| `PATCH`  | `/organizations/{id}/`                       | `Ibl.CRM/Organizations/write`  | Patch a subset of fields |
+| `DELETE` | `/organizations/{id}/`                       | `Ibl.CRM/Organizations/delete` | Hard-delete an organization |
+| `POST`   | `/organizations/{id}/tags/`                  | `Ibl.CRM/Tags/write`           | Attach a Tag (see `/iblai-crm-tag`) |
+| `DELETE` | `/organizations/{id}/tags/{tag_id}/`         | `Ibl.CRM/Tags/write`           | Detach a Tag |
+
+## Organization object
+
+| Field | Type | R/W | Notes |
+|-------|------|-----|-------|
+| `id` | UUID | R | Server-assigned. |
+| `platform` | string/int | R | Set server-side from the auth token. |
+| `name` | string | RW | Display name. **Unique per Platform**, case-sensitive, trimmed of surrounding whitespace before comparison. Max 255 chars. |
+| `address` | object | RW | **Free-form JSON.** Recommended (but not enforced) shape: `{street, city, state, zip, country}`. |
+| `owner` | int \| null | RW | Platform user id of the internal account manager. Must be an active member of your Platform. |
+| `tags` | `{id,name,color}[]` | R | Always present; empty array when none. |
+| `metadata` | object | RW | Free-form JSON. |
+| `created_at` / `updated_at` | ISO 8601 | R | Server-managed. |
+
+---
+
+## `GET /organizations/`
+
+Paginated list.
+
+**Query parameters**
+
+| Name | Type | Notes |
+|------|------|-------|
+| `owner` | int | Filter by owning Platform user id |
+| `name` | string | Case-insensitive substring match |
+| `tags` | int (repeatable) | OR semantics; results de-duplicated |
+| `page` / `page_size` | int | `page_size` max 100 |
+
+Response is the pagination envelope with `results: Organization[]`.
+
+```bash
+curl "https://api.iblai.app/dm/api/crm/organizations/?name=acme" \
+  -H "Authorization: Token <token>"
+```
+
+---
+
+## `POST /organizations/`
+
+Create an organization. `platform` is set server-side.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Unique per Platform (case-sensitive, trimmed). Max 255 chars. |
+| `address` | object | No | Free-form JSON. Defaults to `{}`. |
+| `owner` | int | No | Active member of your Platform. |
+| `metadata` | object | No | Free-form JSON. Defaults to `{}`. |
+
+**Response** `201 Created` — full Organization object.
+
+**Errors**
+
+| Code | Cause | Sample body |
+|------|-------|-------------|
+| `400` | Duplicate name | `{"name":["An Organization with name 'Acme Inc' already exists on this Platform."]}` |
+| `400` | Blank name | `{"name":["Name must not be blank."]}` |
+| `403` | Missing `Ibl.CRM/Organizations/action` | — |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/organizations/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Acme Inc","address":{"city":"New York"},"metadata":{"industry":"edtech"}}'
+```
+
+---
+
+## `GET /organizations/{id}/`
+
+Retrieve one. `200 OK` returns the full Organization; `404 Not Found`
+when the row is missing or belongs to another Platform (existence is
+not leaked).
+
+---
+
+## `PUT /organizations/{id}/`
+
+Replace every editable field. Same body shape as `POST /organizations/`.
+Server-managed fields (`id`, `platform`, `created_at`, `updated_at`)
+are ignored if sent.
+
+**Responses:** `200 OK`, `400`, `404`.
+
+---
+
+## `PATCH /organizations/{id}/`
+
+Partial update — only fields present in the body are touched.
+
+**Responses:** `200 OK`, `400`, `404`.
+
+---
+
+## `DELETE /organizations/{id}/`
+
+Hard-delete the organization.
+
+**No cascade.** Persons and Deals that referenced the deleted org are
+**kept**; their `organization` foreign key is set to `null` on every
+row. Tag assignments on the organization are removed.
+
+Practical UI implication: deleting an org from this skill's
+organizations table will not delete its Persons (rendered in the
+contacts table by `/iblai-crm-lead-flow`) or Deals (rendered by
+`/iblai-crm-deal-flow`) — those rows will simply lose their
+`organization` link. Surface this in the confirm dialog.
+
+**Responses:** `204 No Content`, `404`.
+
+---
+
+## `POST /organizations/{id}/tags/` and `DELETE /organizations/{id}/tags/{tag_id}/`
+
+Same shape as the person tag endpoints.
+
+| Code | Meaning |
+|------|---------|
+| `201` | Attached. Response: `{ "assignment_id": <int>, "tag": {id,name,color} }`. |
+| `409` | Already attached. Body includes existing `assignment_id`. |
+| `404` | Tag not found / wrong Platform (attach), or tag was not attached (detach). |
+| `204` | Detach success. |
+
+See `/iblai-crm-tag` for tag CRUD.

--- a/skills/iblai-crm-lead-flow/references/persons-api.md
+++ b/skills/iblai-crm-lead-flow/references/persons-api.md
@@ -1,0 +1,323 @@
+# Persons API — Reference
+
+Condensed from the [Persons API section of the CRM doc](../../../../docs/developer/applications/crm.md#71-persons). Every endpoint is scoped to the caller's
+Platform; cross-Platform reads return `404` and cross-Platform writes
+are rejected. All examples send `Authorization: Token <token>`.
+
+**Base path:** `/api/crm/persons/`
+
+**Pagination envelope** (used by every list endpoint in the CRM):
+
+```json
+{
+  "count": 0,
+  "next_page": null,
+  "previous_page": null,
+  "results": []
+}
+```
+
+## Endpoint summary
+
+| Method | Path | RBAC | Purpose |
+|--------|------|------|---------|
+| `GET`    | `/persons/`                            | `Ibl.CRM/Persons/list`   | List persons in your Platform |
+| `POST`   | `/persons/`                            | `Ibl.CRM/Persons/action` | Create a person |
+| `GET`    | `/persons/{id}/`                       | `Ibl.CRM/Persons/read`   | Retrieve one person |
+| `PUT`    | `/persons/{id}/`                       | `Ibl.CRM/Persons/write`  | Replace all editable fields |
+| `PATCH`  | `/persons/{id}/`                       | `Ibl.CRM/Persons/write`  | Patch a subset of fields |
+| `DELETE` | `/persons/{id}/`                       | `Ibl.CRM/Persons/delete` | Hard-delete a person |
+| `POST`   | `/persons/{id}/link-user/`             | `Ibl.CRM/Persons/write`  | Bind a person to an existing Platform user |
+| `POST`   | `/persons/{id}/invite/`                | `Ibl.CRM/Invite/action`  | Send a Platform invitation to `primary_email` |
+| `POST`   | `/persons/merge/`                      | `Ibl.CRM/Persons/write`  | Merge duplicates into a primary |
+| `POST`   | `/persons/{id}/tags/`                  | `Ibl.CRM/Tags/write`     | Attach a Tag (see `/iblai-crm-tag`) |
+| `DELETE` | `/persons/{id}/tags/{tag_id}/`         | `Ibl.CRM/Tags/write`     | Detach a Tag |
+
+## Person object
+
+| Field | Type | R/W | Notes |
+|-------|------|-----|-------|
+| `id` | UUID | R | Server-assigned. Stable across renames and merges. |
+| `platform` | string/int | R | Set server-side from the auth token. |
+| `name` | string | RW | Display name (required on create). |
+| `primary_email` | string \| null | RW | Canonical email. Drives the auto-link signal (case-insensitive match). |
+| `emails` | `{label, email}[]` | RW | Free-form additional emails. |
+| `contact_numbers` | `{label, number}[]` | RW | Free-form phone numbers. |
+| `job_title` | string | RW | Display only; not validated. |
+| `organization` | UUID \| null | RW | Org in your Platform. Cross-Platform refs rejected. |
+| `owner` | int \| null | RW | Platform user id of the internal account manager (must be an active member). |
+| `platform_user` | int \| null | R | Set once the person is bound to a Platform user. |
+| `lifecycle_stage` | enum | RW | `lead \| qualified \| opportunity \| customer \| churned`. Default `lead`. |
+| `unique_id` | string | RW | External import key; unique per Platform when non-blank; ≤128 chars. |
+| `active` | boolean | R | Flipped to `false` on link / merge-as-duplicate. |
+| `tags` | `{id,name,color}[]` | R | Always present; empty array when none. |
+| `metadata` | object | RW | Free-form JSON. |
+| `created_at` / `updated_at` | ISO 8601 | R | Server-managed timestamps. |
+
+---
+
+## `GET /persons/`
+
+Paginated list.
+
+**Query parameters**
+
+| Name | Type | Notes |
+|------|------|-------|
+| `lifecycle_stage` | enum | `lead \| qualified \| opportunity \| customer \| churned` |
+| `owner` | int | Platform user id of the account manager |
+| `organization` | UUID | Organization id |
+| `created_at__gte` / `created_at__lte` | ISO 8601 | Created-at window |
+| `metadata__has_key` | string | Persons whose `metadata` has the given top-level key |
+| `tags` | int (repeatable) | OR semantics: `?tags=1&tags=2` or `?tags=1,2`. Results de-duplicated. |
+| `page` / `page_size` | int | `page_size` max 100 |
+
+Response is the pagination envelope above with `results: Person[]`.
+
+```bash
+curl "https://api.iblai.app/dm/api/crm/persons/?lifecycle_stage=qualified&page=1&page_size=25" \
+  -H "Authorization: Token <token>"
+```
+
+---
+
+## `POST /persons/`
+
+Create a person. `platform` is set server-side.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Display name |
+| `primary_email` | string | No | Auto-link binding key |
+| `emails` | `{label,email}[]` | No | Defaults to `[]` |
+| `contact_numbers` | `{label,number}[]` | No | Defaults to `[]` |
+| `job_title` | string | No | Defaults to `""` |
+| `organization` | UUID | No | Must belong to your Platform |
+| `owner` | int | No | Active member of your Platform |
+| `lifecycle_stage` | enum | No | Defaults to `lead` |
+| `unique_id` | string | No | Unique per Platform when non-blank |
+| `metadata` | object | No | Defaults to `{}` |
+
+**Response** `201 Created` — full Person object.
+
+**Errors**
+
+| Code | Cause |
+|------|-------|
+| `400` | Validation: duplicate `unique_id`, cross-Platform `organization`, owner not in Platform, etc. Body has per-field arrays. |
+| `403` | Missing `Ibl.CRM/Persons/action`. |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/persons/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice Chen","primary_email":"alice@example.com","lifecycle_stage":"lead"}'
+```
+
+---
+
+## `GET /persons/{id}/`
+
+Retrieve one person.
+
+**Responses:** `200 OK` (full Person), `404 Not Found` (existence is
+not leaked across Platforms).
+
+---
+
+## `PUT /persons/{id}/`
+
+Replace every editable field. Omitted fields are reset to their
+serializer defaults. Server-managed fields (`id`, `platform`,
+`platform_user`, `active`, `created_at`, `updated_at`) are ignored if
+sent.
+
+**Responses:** `200 OK`, `400`, `404`.
+
+---
+
+## `PATCH /persons/{id}/`
+
+Partial update — only fields present in the body are touched.
+
+**Responses:** `200 OK`, `400`, `404`.
+
+---
+
+## `DELETE /persons/{id}/`
+
+Hard delete.
+
+**Responses:** `204 No Content`, `404`.
+
+---
+
+## `POST /persons/{id}/link-user/`
+
+Bind a person to an existing Platform user.
+
+**Request body**
+
+```json
+{ "user_id": 1184 }
+```
+
+**Response** `200 OK` — full Person object. On a successful bind,
+`platform_user` is set to the requested `user_id` and `active` flips
+to `false`.
+
+### Silent-refusal footgun
+
+A `200` response whose `platform_user` does **not** equal the
+requested `user_id` means the person was **already bound to a
+different Platform user** — the existing binding was preserved and
+the API will not silently re-parent. There is **no error response**
+for this case.
+
+Clients **MUST** assert:
+
+```ts
+if (response.platform_user !== requested_user_id) {
+  // Refusal — surface "already linked to user X" instead of "success".
+}
+```
+
+**Status codes**
+
+| Code | When |
+|------|------|
+| `200` | Success **or** silent refusal (compare `platform_user`). |
+| `400` | `user_id` missing or not an integer. |
+| `403` | Caller missing `Ibl.CRM/Persons/write`, **or** target user has no active `UserPlatformLink` to your Platform. |
+| `404` | Person or user does not exist. |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/persons/<id>/link-user/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": 1184}'
+```
+
+---
+
+## `POST /persons/{id}/invite/`
+
+Send a Platform invitation to the person's `primary_email`. On
+acceptance, the invitee joins the Platform with the privileges
+configured here and the auto-link signal binds the person to the new
+user account.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `is_admin` | boolean | No | Defaults to `false`. |
+| `is_staff` | boolean | No | Defaults to `false`. |
+| `enrollment_config` | object | No | Forwarded to the invitation (courses / programs / pathways auto-enrollment). |
+| `redirect_to` | string | No | Post-acceptance URL. Max 255 chars. |
+
+**Response** `201 Created`
+
+```json
+{
+  "person_id": "<uuid>",
+  "invitation_id": 8821,
+  "invitation_email": "alice@example.com",
+  "platform_key": "acme-learning",
+  "auto_accept": true,
+  "active": true,
+  "redirect_to": "https://acme.iblai.app/welcome",
+  "created": "2026-06-04T08:12:01Z"
+}
+```
+
+**Status codes**
+
+| Code | When |
+|------|------|
+| `201` | Invitation queued. |
+| `400` | Person has no `primary_email`. |
+| `403` | Caller missing `Ibl.CRM/Invite/action`. |
+| `404` | Person not found. |
+| `409` | Active invitation already exists. Body carries the pre-existing `invitation_id` — treat as "already done". |
+| `422` | Person already linked to a Platform user. |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/persons/<id>/invite/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"is_admin":false,"is_staff":false,"redirect_to":"https://acme.iblai.app/welcome"}'
+```
+
+---
+
+## `POST /persons/merge/`
+
+Re-parent Deals, Activities, and Tag assignments from duplicates onto
+a primary in a single transaction; soft-delete the duplicates.
+
+**Request body**
+
+```json
+{
+  "primary_id": "<uuid>",
+  "duplicate_ids": ["<uuid>", "<uuid>"]
+}
+```
+
+- `primary_id` must belong to your Platform.
+- `duplicate_ids` must be non-empty, belong to your Platform, and not
+  include `primary_id`.
+
+**Response** `200 OK`
+
+```json
+{
+  "primary_id": "<uuid>",
+  "merged_ids": ["<uuid>"],
+  "reparented": { "deals": 4, "activities": 11, "tags": 3 }
+}
+```
+
+Notes:
+
+- Duplicates are **soft-deleted** — `active=false`, row still
+  retrievable by id. `GET /persons/{duplicate_id}/` returns the
+  inactive row, not `404`. Filter on `active=true` to hide.
+- `reparented.tags` counts every assignment *touched* — both moved
+  and dropped (the `(tag, person)` unique constraint forbids
+  stacking, so a tag the primary already carries is dropped silently
+  but still counted).
+
+**Status codes**
+
+| Code | When |
+|------|------|
+| `200` | Merge complete (also returned on no-op rerun). |
+| `400` | `primary_id` appears in `duplicate_ids`, `duplicate_ids` empty, or cross-Platform duplicate. |
+| `403` | Caller missing `Ibl.CRM/Persons/write`. |
+| `404` | Primary person not found in your Platform. |
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/persons/merge/" \
+  -H "Authorization: Token <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"primary_id":"<uuid>","duplicate_ids":["<uuid>"]}'
+```
+
+---
+
+## `POST /persons/{id}/tags/` and `DELETE /persons/{id}/tags/{tag_id}/`
+
+Tag attach/detach. Body for attach: `{ "tag_id": <int> }`.
+
+| Code | Meaning |
+|------|---------|
+| `201` | Attached. Response: `{ "assignment_id": <int>, "tag": {id,name,color} }`. |
+| `409` | Already attached. Body includes the existing `assignment_id`. |
+| `404` | Tag not found / wrong Platform (attach), or tag was not attached (detach). |
+| `204` | Detach success. |
+
+See `/iblai-crm-tag` for tag CRUD.


### PR DESCRIPTION
## What

Two build-UI skills that produce the core CRM funnel:

- **`/iblai-crm-lead-flow`** — top of funnel. Guides building the lead-capture form (`POST /persons/`), contacts table with lifecycle filter, person detail panel, organization records, and the three onboarding actions: link existing platform user, invite by email, merge duplicates. Calls out the silent-refusal footgun on `link-user/`.
- **`/iblai-crm-deal-flow`** — revenue surface. Guides building the pipeline selector, kanban deal board, drag-to-move via `POST /deals/{id}/move-stage/` with `stage_code`, and the `won/` / `lost/` action buttons with `lost_reason` modal. Documents move-stage side effects (audit Activity, `CRM_DEAL_STAGE_CHANGED` notification, status recompute) and the same-stage suppression rule.

Each ships condensed `references/` (persons-api, organizations-api, onboarding-flows for lead-flow; pipelines-api, lead-sources-api, deals-api, state-machine for deal-flow), Cursor + Codex adapters, and a row in the `CLAUDE.md` skill table.

## Why

These are the two skills most developers will actually invoke when building a CRM surface — capturing leads and moving deals through stages. Splitting them out of the family-introduction PR (`crm-1-overview`) keeps review focused on the API contract and UX choices for the funnel itself.

## Depends on

PR 1 (`crm-1-overview`) — references `/iblai-crm-overview` for shared setup, auth, RBAC, and seeded defaults.