### PR TITLE
feat: add iblai-crm-activity, iblai-crm-tag, iblai-crm-notification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,9 @@ Invoke with `/` in Claude Code:
 | `/iblai-crm-overview` | Reference + family index for the CRM API (auth, seeded defaults, RBAC roles, sub-skill map) |
 | `/iblai-crm-lead-flow` | Add the CRM top-of-funnel surface (lead capture, contacts table, person detail, link/invite/merge) |
 | `/iblai-crm-deal-flow` | Add the CRM revenue surface (pipelines, stages, lead sources, kanban deal board, move-stage/won/lost) |
+| `/iblai-crm-activity` | Add the CRM activity timeline panel for persons and deals (calls, meetings, notes, tasks, reminders, mark-done) |
+| `/iblai-crm-tag` | Add the CRM tag manager + chips + attach/detach controls + tag filters across persons/orgs/deals |
+| `/iblai-crm-notification` | Reference for the three CRM notification types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) and recipient routing |
 
 ### Marketing Skills
 

--- a/adapters/codex/iblai-crm-activity.md
+++ b/adapters/codex/iblai-crm-activity.md
@@ -1,0 +1,285 @@
+# iblai-crm-activity
+
+> Build the CRM activity timeline panel that mounts inside a Person or a Deal detail surface — list calls, meetings, emails, notes, tasks, lunches, and deadlines, schedule them, set reminders, mark them done idempotently, and render server-emitted stage-change audit rows distinctly. Use when the user mentions CRM activity, activities, timeline, log a call, schedule a meeting, sales notes, tasks, deadlines, reminders, or mark done. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-lead-flow for the person host, /iblai-crm-deal-flow for the deal host and stage-change audit rows, /iblai-notification for the bell that surfaces reminders, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring.
+
+# /iblai-crm-activity
+
+Build the activity timeline panel that lives inside a Person or Deal detail
+surface: list activities, create them (call, meeting, email, note, task,
+lunch, deadline), schedule + remind, mark done, and render server-emitted
+audit rows distinctly.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for activity CRUD and the
+  `done/` action. See `/iblai-rbac` for the full matrix.
+- A host surface must already exist. The timeline is a **panel**, not a
+  standalone page. Either:
+  - `/iblai-crm-lead-flow` — for the Person detail timeline, OR
+  - `/iblai-crm-deal-flow` — for the Deal detail timeline (which is
+    also the source of the server-emitted `Stage changed` audit rows
+    you will render).
+
+## What you'll build
+
+- A **timeline panel** that mounts inside the existing Person detail
+  page (filtered by `person=<uuid>`) and inside the existing Deal
+  detail page (filtered by `deal=<id>`), backed by
+  `GET /api/crm/activities/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **create-activity form** with a type selector covering all seven
+  types — `call`, `meeting`, `email`, `note`, `task`, `lunch`,
+  `deadline` — plus `title`, `comment`, optional `location`,
+  `schedule_from`, `schedule_to`, `reminder_at`, and free-form
+  `metadata`.
+- A **done checkbox** on each open user row that calls
+  `POST /api/crm/activities/{id}/done/` — idempotent, safe to retry.
+- A **system-row renderer** that visually de-emphasizes
+  server-emitted stage-change audit rows
+  (`type === "note" && title === "Stage changed"`) and suppresses
+  their edit / delete / done controls per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently).
+
+Reference tables for every endpoint and field live in:
+
+- `references/activities-api.md`
+- `references/timeline-rendering.md`
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date. Run
+`iblai --version` to check the current version, then upgrade directly:
+
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+This is safe to run even if already at the latest version.
+
+## Step 1: Install shadcn primitives
+
+There is no dedicated `iblai add` generator for the timeline panel — it is
+plain shadcn/ui glued to the CRM REST API. Install the primitives you need:
+
+```bash
+npx shadcn@latest add card select input textarea checkbox button dialog calendar popover badge
+```
+
+You will use `card` for each row, `select` for the type picker, `input`
+and `textarea` for title/comment, `calendar` + `popover` for date
+pickers, `checkbox` for the done toggle, `dialog` for the create form,
+and `badge` for the type chip.
+
+## Step 2: Wrap the activities REST API
+
+Create `lib/iblai/crm-activities.ts`. Read the token and base URL the way
+`/iblai-auth` already wired them — do not introduce a parallel auth layer.
+
+Endpoints (every activity row is scoped to your Platform; cross-Platform
+rows return 404):
+
+| Verb | Path | Use |
+|---|---|---|
+| `GET` | `/api/crm/activities/?person={uuid}` | List a person's timeline |
+| `GET` | `/api/crm/activities/?deal={id}` | List a deal's timeline |
+| `POST` | `/api/crm/activities/` | Create — body MUST set EXACTLY one of `person`/`deal` (or both, where the person equals the deal's person). Neither = 400. |
+| `PATCH` | `/api/crm/activities/{id}/` | Edit user-authored rows. Do NOT call on system rows. |
+| `DELETE` | `/api/crm/activities/{id}/` | Delete user-authored rows. Do NOT call on system rows. |
+| `POST` | `/api/crm/activities/{id}/done/` | Mark done — idempotent, no body |
+
+Every list call uses the standard pagination envelope
+`{count, next_page, previous_page, results[]}`. Default ordering is
+newest-first by `created_at`.
+
+Server-managed fields you MUST NOT write from the client:
+
+- `done_at` — stamped server-side the first time `is_done` flips true
+- `reminder_sent` — flipped server-side after reminder dispatch
+
+See `references/activities-api.md` for the full field list, every
+filter, the attachment-rule errors, and curl examples.
+
+## Step 3: Activity-type selector
+
+Render a shadcn `select` whose values map 1:1 to the `type` field on the
+POST body. All seven types are first-class — none are aliases.
+
+| Value | Suggested chip color | Suggested icon |
+|---|---|---|
+| `call` | sky | Phone |
+| `meeting` | indigo | CalendarClock |
+| `email` | violet | Mail |
+| `note` | slate | StickyNote |
+| `task` | amber | CheckSquare |
+| `lunch` | rose | Utensils |
+| `deadline` | red | AlarmClock |
+
+The chip color is cosmetic — drive it from a small lookup table next to
+your renderer. The `type` you POST must be one of the seven strings
+above verbatim.
+
+## Step 4: Scheduling and reminders
+
+Collect three ISO-8601 datetime fields in the create form. Match the
+shape to the intent — do not invent dates to fill empty slots:
+
+| `schedule_from` | `schedule_to` | Read as |
+|---|---|---|
+| null | null | A past log entry recorded after the fact (a logged call, a written note) |
+| set | null | A scheduled task or deadline with a start time but no fixed end |
+| set | set | A meeting or other time-bounded event |
+
+Add an optional `reminder_at` — typically a fixed offset before
+`schedule_from` (15 minutes before is a common meeting default). The
+server stamps `reminder_sent` after dispatch — DO NOT set it from the
+client. The server also stamps `done_at` on completion — DO NOT set it
+from the client.
+
+> Reminder delivery is not yet dispatched server-side (see [Reminders](../../../docs/developer/applications/crm.md#105-reminders)).
+> `reminder_at` round-trips and you can surface a local in-app prompt
+> from it today; `reminder_sent` will stay `false` until the dispatcher
+> ships.
+
+## Step 5: Mark-done checkbox
+
+Render a shadcn `checkbox` on every open user row. When checked, POST
+to `/api/crm/activities/{id}/done/` with no body. The response is the
+full updated activity object — splice it into your local list so the
+row re-renders with `is_done=true` and `done_at` populated without a
+follow-up GET.
+
+This action is **idempotent**: repeat calls on an already-done activity
+return the SAME `done_at` the server stamped on the first call. That
+makes the checkbox safe to retry from a flaky network without drifting
+completion timestamps that downstream reports depend on.
+
+Do not render the checkbox on system rows — see Step 7.
+
+## Step 6: Render the timeline
+
+Order rows newest-first. Default to `created_at` desc (which is what
+the API returns); when you want a calendar-style view (e.g. an
+upcoming-meetings panel), sort by `schedule_from` instead and filter
+`?is_done=false` to hide completed entries.
+
+Each row should show, at minimum: the type chip (with the color +
+icon from Step 3), `title`, `comment`, the relative time, the owner,
+and — for scheduled rows — `schedule_from` (and `schedule_to` when
+present). Combine list filters to drive panel variants — for example
+`?deal=314&type=call&is_done=false` powers an "upcoming calls" panel
+on a deal.
+
+## Step 7: Render system audit rows distinctly
+
+Per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently), the CRM writes a system Activity every time a deal moves
+stage, wins, or is lost. Detect them client-side with one predicate:
+
+```ts
+const isStageChangeAudit = (a: Activity): boolean =>
+  a.type === "note" && a.title === "Stage changed";
+```
+
+For rows where that returns true:
+
+- Use a distinct system icon (a small arrow / system glyph)
+- Render at smaller size with muted text
+- Suppress edit, delete, and done controls — the row is server-authored
+  and arrives already complete (`is_done: true`, `done_at` set to the
+  transition timestamp)
+- Use the `comment` body (e.g. `"Discovery → Proposal"`) as the line
+  of record
+
+See `references/timeline-rendering.md` for the full rationale and the
+schedule / reminder / attachment semantics.
+
+## Filters
+
+The list endpoint accepts a focused set of query parameters useful for
+the panel variants you will build. The most commonly used here:
+
+| Param | Type | Use |
+|---|---|---|
+| `person` | UUID | Person timeline (mount on person detail) |
+| `deal` | integer | Deal timeline (mount on deal detail) |
+| `type` | string | One of the seven types — narrow to a single kind |
+| `is_done` | boolean | Hide completed / show only open |
+| `owner` | integer | Filter by owning user id |
+| `schedule_from__gte` | datetime | Calendar window start |
+| `schedule_from__lte` | datetime | Calendar window end |
+| `metadata__has_key` | string | Activities whose `metadata` JSON contains this top-level key |
+| `page`, `page_size` | integer | Standard pagination |
+
+The full list — including `metadata__has_key` semantics and combining
+rules — lives in `references/activities-api.md`.
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and open the relevant detail pages:
+   - Open a Person detail page from `/iblai-crm-lead-flow`. Create an
+     activity with `type=call`, no schedule, a short comment. Confirm
+     it appears at the top of the timeline. Mark it done with the
+     checkbox; confirm `is_done` flips and `done_at` populates.
+   - Open a Deal detail page from `/iblai-crm-deal-flow`. Create a
+     `meeting` with `schedule_from` and `schedule_to` set 30 minutes
+     apart, and `reminder_at` 15 minutes before `schedule_from`.
+     Confirm the row renders with the type chip, scheduled time, and
+     reminder.
+   - From the deal kanban, move the deal to a new stage. Reload the
+     deal timeline and confirm a server-emitted row appears with
+     `type="note"`, `title="Stage changed"`, `is_done=true`, and is
+     rendered distinctly (smaller, muted, system icon, no edit /
+     delete / done controls).
+3. Screenshot the timeline so the user can see it:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals/<id> /tmp/deal-timeline.png
+   npx playwright screenshot http://localhost:3000/crm/contacts/<uuid> /tmp/person-timeline.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — person timeline host
+- `/iblai-crm-deal-flow` — deal timeline host + audit row source (stage moves emit notes)
+- `/iblai-notification` — bell UI for activity reminders + CRM events
+- `/iblai-rbac` — CRM User role
+- `/iblai-auth` — token wiring

--- a/adapters/codex/iblai-crm-notification.md
+++ b/adapters/codex/iblai-crm-notification.md
@@ -1,0 +1,185 @@
+# iblai-crm-notification
+
+> Reference for the three CRM notification event types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) the ibl.ai CRM dispatches after a write commits — payload shapes, recipient routing modes (default / per-Platform configured), and how to surface them in your app. Use when the user mentions CRM notifications, lead/deal alerts, "who gets notified when a deal moves stages", recipient mode configuration, or wiring a CRM-only inbox; see /iblai-crm-overview for setup, /iblai-crm-lead-flow and /iblai-crm-deal-flow for the events' source skills, and /iblai-notification for the bell UI that actually renders these events. This is a REFERENCE skill — it documents the contract; it does NOT build the bell UI.
+
+# /iblai-crm-notification
+
+Reference skill for the three CRM notification event types. Documents
+when each one fires, the context keys included in the payload, the
+recipient-routing modes available per Platform, and where the developer
+goes next to surface these events in the UI. This skill does NOT build
+the notification bell — that is `/iblai-notification`.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth set up (`/iblai-auth`)
+- MCP and skills set up (`iblai add mcp`)
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user holds a CRM role (`CRM Viewer` is enough to read
+  inbox entries that target them; see `/iblai-rbac`)
+
+## The three CRM notification types
+
+Every CRM write that produces a notification routes through exactly one
+of these three event types. Full payload tables (every `context` key)
+live in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+| `event_type` | Fires when | Source skill | Default recipients |
+|---|---|---|---|
+| `CRM_PERSON_CREATED` | A person row is created via any path — REST `POST /persons/`, the Django admin, or bulk import | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+| `CRM_DEAL_STAGE_CHANGED` | A deal moves between stages via `POST /deals/{id}/move-stage/`, `POST /deals/{id}/won/`, or `POST /deals/{id}/lost/`. No-op transitions (destination stage equals current stage) are SUPPRESSED — no notification | `/iblai-crm-deal-flow` | Platform admins + `deal.owner` |
+| `CRM_PERSON_LINKED_TO_USER` | A person is bound to a Platform user — either by explicit `POST /persons/{id}/link-user/` or implicitly by the auto-link signal when a new user registers with a matching email | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+
+"Object owner" is `person.owner` for the two person-scoped events and
+`deal.owner` for the stage-change event. If the owner field is unset on
+the triggering object, the configured recipient mode decides whether to
+fall back to admins or drop the notification — see `## Recipient routing`
+below.
+
+## After-commit dispatch
+
+All three event types dispatch **asynchronously after the writing
+transaction commits**. The CRM signal is observed inside the request, but
+the actual notification send fires from a post-commit hook on the
+database transaction. The practical consequences:
+
+- A write that rolls back — failed validation, database constraint, a
+  `move-stage` call that raises mid-transition — produces no
+  notification. The signal is observed, the dispatch is not.
+- By the time a recipient sees the email, push entry, or inbox row, the
+  underlying record is durably on disk. There are no ghost notifications
+  for state that never persisted.
+- Context keys are snapshotted at signal time from the live object. A
+  template that references `{{ deal_lead_value }}` reads the value as it
+  stood the moment the stage transition committed; later edits to the
+  deal do not re-render or re-send.
+
+Cross-reference: this is the same after-commit rule the [System Overview](../../../docs/developer/applications/crm.md#2-system-overview) "Side
+Effects" block describes, and it is shared with the audit `Activity` row
+that `move-stage`/`won`/`lost` writes alongside the notification (see
+`/iblai-crm-activity`).
+
+## Recipient routing
+
+Every CRM notification template — and any notification type that opts
+into the shared recipients pipeline — can be configured per Platform
+with one of five recipient modes:
+
+| Mode | Effect |
+|---|---|
+| `platform_admins_only` | Deliver to active Platform admins only. The object's owner is ignored. |
+| `object_owner_only` | Deliver to the object's owner. If the owner field is unset, fall back to Platform admins so nothing is silently dropped. |
+| `object_owner_only_strict` | Deliver to the object's owner only. If the owner is unset, no one is notified. Use when the notification is meaningless without an owner. |
+| `platform_admins_and_object_owner` | **Default.** Both audiences receive the notification, deduplicated so an admin who is also the owner does not get two copies. |
+| `custom` | Deliver to a hand-picked list of users, user groups, or RBAC role-policy holders. Admins and the owner are NOT implicitly included. |
+
+When the mode is `custom`, the template's `recipients_custom_recipients`
+field holds a list of dicts. Each entry takes one of three shapes:
+
+```json
+{ "type": "user",        "id": 123 }
+{ "type": "user_group",  "id": 7 }
+{ "type": "rbac_policy", "policy_name": "CRM Manager" }
+```
+
+Entries compose freely — a single list can mix individual users, groups,
+and policy holders. The resolver expands each entry, unions the results,
+deduplicates, and runs the active-Platform-membership filter as a final
+gate. Stale entries (departed users, reassigned policies, drained
+groups) simply contribute zero recipients on that dispatch.
+
+Recipient configuration lives on the **notification template, not the
+CRM models**. Changing it for `CRM_DEAL_STAGE_CHANGED` on a given
+Platform is a `PATCH` against that Platform's template for that type,
+setting `recipients_recipient_mode` and (if `custom`) populating
+`recipients_custom_recipients`. The CRM does not add a separate API
+surface for this — the same template-management endpoints documented in
+`/iblai-notification` handle these three types alongside every other
+notification type on the platform. This skill does NOT modify those
+endpoints; it just documents which event types route through them.
+
+Full mode table, custom-shape examples, the change-recipients workflow,
+and the active-membership filter rules are in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+## Channels
+
+Email delivery is wired by default for all three CRM event types.
+Per-user notification preferences are honored by the underlying delivery
+machinery — the CRM does not bypass them. Additional channels (in-app
+inbox feed, push notification) follow the template's channel
+configuration, inspected and changed via the same templates API.
+
+The **in-app bell + notification center** that surfaces inbox entries is
+NOT in scope for this skill. Send the developer to `/iblai-notification`
+for the drop-in `<NotificationDropdown>` and `<NotificationDisplay>`
+components.
+
+## Consuming the events in your UI
+
+This is a reference skill. To actually show a user the three CRM event
+types in the browser:
+
+1. Install the bell + center via `/iblai-notification`. That skill ships
+   `components/iblai/notification-bell.tsx` and the
+   `<NotificationDisplay>` page surface (Inbox + Alerts tabs).
+2. The bell's inbox list is a standard notification feed — every
+   delivered notification carries an `event_type` matching one of the
+   three values from the table above. Filter the inbox query to those
+   three values (or any subset) when you want a CRM-only inbox view.
+3. For deeper drill-down (clicking an inbox entry that says "Deal moved
+   to Negotiation" and jumping to the kanban card), wire the
+   `onViewNotifications` callback on `<NotificationDropdown>` to route
+   to the deal detail page built by `/iblai-crm-deal-flow`.
+
+## Verify
+
+End-to-end smoke once the bell is wired:
+
+1. From the kanban built in `/iblai-crm-deal-flow`, move a deal from one
+   stage to another via `POST /deals/{id}/move-stage/`. Make sure the
+   destination stage actually differs from the current one (same-stage
+   moves are suppressed and produce nothing).
+2. Within a few seconds, confirm a `CRM_DEAL_STAGE_CHANGED` row appears
+   in the inbox bell installed by `/iblai-notification` for the deal's
+   owner.
+3. Open the deal's activity timeline (`/iblai-crm-activity`) and confirm
+   the corresponding audit `Activity` row exists with `type=note`,
+   `done=true`, `title="Stage changed"`. The notification and the audit
+   row are written together — if one is missing while the other is
+   present, the transaction split unexpectedly and is worth filing.
+4. Re-run the same `move-stage` call with `stage_code` set to the
+   destination it just reached. The API should return the deal
+   unchanged, no new audit row, and no new notification.
+
+Run `/iblai-ops-test` before reporting done.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — source of `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER`
+- `/iblai-crm-deal-flow` — source of `CRM_DEAL_STAGE_CHANGED`
+- `/iblai-notification` — bell UI + notification center that consumes these events
+- `/iblai-rbac` — required CRM roles
+- `/iblai-auth` — token wiring

--- a/adapters/codex/iblai-crm-tag.md
+++ b/adapters/codex/iblai-crm-tag.md
@@ -1,0 +1,349 @@
+# iblai-crm-tag
+
+> Build the CRM tag manager — CRUD on /api/crm/tags/ with hex color picker, a reusable tag chip, attach/detach controls on Person/Organization/Deal detail pages, and tag filters on list views with OR semantics. Use when the user mentions CRM tags, labels, tagging, color chips, tag manager, attach tag, detach tag, filter by tag, or wants to add segmentation labels to people/orgs/deals. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for the person/org host pages, /iblai-crm-deal-flow for the deal host pages, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring.
+
+# /iblai-crm-tag
+
+Build the CRM tag surface — tag CRUD dialog, color chip, attach/detach
+controls on Person, Organization, and Deal pages, plus a `?tags=` filter
+on every CRM list view.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — provides the platform
+  `Authorization: Token <token>` header used by every call below.
+- MCP and skills must be set up: `iblai add mcp`.
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user must hold the **CRM User** role (or higher) on the
+  Platform. CRM User unlocks `Ibl.CRM/Tags/list`, `read`, `action`,
+  `write`, and `delete`. CRM Viewer can only see tags, not write or
+  attach them. See `/iblai-rbac` for the role matrix and how to assign
+  CRM roles to a user.
+- At least one host surface should already exist so there is something
+  to tag. Run `/iblai-crm-lead-flow` (people + organizations) or
+  `/iblai-crm-deal-flow` (deals) first if you have not yet.
+
+## What you'll build
+
+1. A **tag manager dialog** — list, create, edit, and delete tags. Color
+   input is validated client-side against `^#[0-9A-Fa-f]{6}$` before
+   submit so the user sees errors immediately (the server applies the
+   same regex).
+2. A **tag chip** component — renders `{id, name, color}` with the hex
+   color as background. Optional `x` button for detach.
+3. **Attach / detach controls** on Person, Organization, and Deal detail
+   pages. The contract is uniform: `POST /{host}/{id}/tags/` with
+   `{tag_id}`, `DELETE /{host}/{id}/tags/{tag_id}/`.
+4. A **tag filter** on Person, Organization, and Deal list views —
+   `?tags=<id>&tags=<id2>` with **OR** semantics. Results are
+   de-duplicated by the backend.
+
+## Step 0: Check for CLI updates
+
+```bash
+iblai --version    # upgrade if outdated: pip install --upgrade iblai-app-cli OR npm i -g @iblai/cli@latest
+```
+
+## Step 1: Install shadcn primitives
+
+```bash
+npx shadcn@latest add dialog input form popover command badge button
+```
+
+`dialog` powers the tag manager and the delete-confirmation modal.
+`popover` + `command` together make a searchable tag combobox for the
+attach control. `badge` is the visual base for the tag chip. `input`
++ `form` cover the create/edit form. `button` covers actions.
+
+## Step 2: Typed API client wrapper
+
+Reuse the auth token wired in `/iblai-auth`. Create
+`lib/iblai/crm-tags.ts` with one wrapper per route. Base URL is
+`${NEXT_PUBLIC_API_BASE_URL}/api/crm`.
+
+```typescript
+// lib/iblai/crm-tags.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+const HEX = /^#[0-9A-Fa-f]{6}$/;
+
+export type Tag = {
+  id: number;
+  platform: number;
+  name: string;
+  color: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TagChip = Pick<Tag, "id" | "name" | "color">;
+
+export type Assignment = { assignment_id: number; tag: TagChip };
+
+function authHeaders(token: string) {
+  return {
+    Authorization: `Token ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+// Tag CRUD
+export async function listTags(token: string, params: { name?: string; page?: number } = {}) {
+  const qs = new URLSearchParams();
+  if (params.name) qs.set("name", params.name);
+  if (params.page) qs.set("page", String(params.page));
+  const r = await fetch(`${BASE}/tags/?${qs}`, { headers: authHeaders(token) });
+  if (!r.ok) throw new Error(`listTags ${r.status}`);
+  return r.json() as Promise<{ count: number; results: Tag[]; next_page: number | null; previous_page: number | null }>;
+}
+
+export async function createTag(token: string, body: { name: string; color?: string; metadata?: Record<string, unknown> }) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/`, { method: "POST", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function patchTag(token: string, id: number, body: Partial<Pick<Tag, "name" | "color" | "metadata">>) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "PATCH", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function deleteTag(token: string, id: number) {
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "DELETE", headers: authHeaders(token) });
+  if (!r.ok && r.status !== 204) throw new Error(`deleteTag ${r.status}`);
+}
+
+// Uniform host attach / detach. `host` is "persons" | "organizations" | "deals".
+export type Host = "persons" | "organizations" | "deals";
+
+export async function attachTag(token: string, host: Host, hostId: string | number, tagId: number): Promise<Assignment> {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ tag_id: tagId }),
+  });
+  // 201 = created; 409 = already attached, body still carries assignment_id + tag.
+  if (r.status === 201 || r.status === 409) return r.json();
+  throw await r.json();
+}
+
+export async function detachTag(token: string, host: Host, hostId: string | number, tagId: number) {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/${tagId}/`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+  // 204 = removed; 404 = not attached (treat as no-op success).
+  if (r.status !== 204 && r.status !== 404) throw new Error(`detachTag ${r.status}`);
+}
+```
+
+See `references/tags-api.md` for full endpoint table, error shapes, and
+filter semantics.
+
+## Step 3: Tag manager dialog
+
+Create `components/crm/tag-manager-dialog.tsx`. It is a single dialog
+that lists all tags from `GET /tags/`, lets the user create a new tag,
+edit an existing tag, or delete one.
+
+Requirements:
+
+- **Create form**: `name` (required, ≤ 64 chars, unique-per-Platform —
+  server-enforced) and `color` (`<input type="color">` is fine; on
+  submit, validate the value against `^#[0-9A-Fa-f]{6}$` before
+  calling `createTag`). Surface the server's 400 errors verbatim —
+  duplicate name, blank name, > 64 chars, bad hex.
+- **Edit**: inline rename + recolor calls `patchTag`. Renames take
+  effect immediately on every host chip — the chip renders from the
+  Tag row, not from the assignment.
+- **Delete**: opens a confirmation modal — see the destructive cascade
+  callout below. Disable the delete button until the user types the
+  tag name to confirm, or at minimum require a second click.
+
+The dialog reads the token from the auth store wired by `/iblai-auth`.
+
+## Step 4: Tag chip component
+
+Create `components/crm/tag-chip.tsx`. Renders `{id, name, color}` as a
+shadcn `Badge` with `style={{ backgroundColor: tag.color, color: '#fff' }}`.
+Accept an optional `onDetach: () => void` prop — when supplied, render
+a small `x` icon button inside the chip; otherwise render the chip as
+read-only.
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import type { TagChip as TTagChip } from "@/lib/iblai/crm-tags";
+
+export function TagChip({ tag, onDetach }: { tag: TTagChip; onDetach?: () => void }) {
+  return (
+    <Badge style={{ backgroundColor: tag.color, color: "#fff" }} className="gap-1">
+      {tag.name}
+      {onDetach ? (
+        <button onClick={onDetach} aria-label={`Detach ${tag.name}`} className="ml-1">
+          <X className="h-3 w-3" />
+        </button>
+      ) : null}
+    </Badge>
+  );
+}
+```
+
+The `tags` array is **always present** on every Person, Organization,
+and Deal list/detail response — empty array, never `null`. So your
+renderer can iterate unconditionally.
+
+## Step 5: Attach control on host detail pages
+
+On Person, Organization, and Deal detail pages, add an "Add tag"
+button that opens a shadcn `Popover` containing a `Command` combobox.
+Populate the combobox with `listTags(token)` (search-as-you-type by
+filtering client-side, or pass `name=` to the API for large libraries).
+
+On select:
+
+```typescript
+const { assignment_id, tag } = await attachTag(token, host, hostId, selectedTagId);
+// Optimistically add `tag` to the local host.tags array; assignment_id is for
+// future detach reconciliation, not required for the chip itself.
+```
+
+Edge cases:
+
+- **409 Conflict** — the tag is already attached. The response body
+  still carries the existing `assignment_id` + `tag`, so you can
+  reconcile local state without a re-fetch and **must not** show a red
+  error toast. Treat 409 as a no-op success.
+- **404 Not Found** — the tag id is not in this Platform. Show
+  "Tag not found." The API never leaks existence across Platforms.
+
+## Step 6: Detach control
+
+Render the host's `tags` array as `TagChip` components with `onDetach`
+wired to `detachTag(token, host, hostId, tag.id)`.
+
+Edge case:
+
+- **404 Not Found** on detach means the tag was not attached. Detach
+  is **not** idempotent server-side — a retried DELETE returns 404,
+  not 204. Client code should treat both as the same success state.
+  The wrapper above already does this.
+
+## Step 7: Tag filter on list views
+
+Wire a multi-select tag picker into the Person, Organization, and Deal
+list pages.
+
+The list endpoints accept repeated or comma-separated `tags`:
+
+```
+GET /api/crm/persons/?tags=7&tags=12
+GET /api/crm/persons/?tags=7,12
+```
+
+Both forms have **OR** semantics — a record matching any selected tag
+appears once (the backend de-duplicates). The filter composes with
+every other filter on the same endpoint, e.g.:
+
+```
+GET /api/crm/persons/?tags=7&lifecycle_stage=customer&owner=4
+```
+
+Implementation: bind the selected tag-ids to `URLSearchParams.append`
+so a `tags` array becomes repeated params, then refetch the list.
+
+## Destructive cascade callout
+
+> **Deleting a tag silently removes it from every Person, Organization,
+> and Deal it is attached to.** `DELETE /tags/{id}/` cascades — there
+> is no preview, no soft-delete, and no undo.
+
+Best practice [confirm before deleting a tag](../../../docs/developer/applications/crm.md#167-confirm-before-deleting-a-tag): gate the delete button behind a confirmation modal
+that **names the tag explicitly** ("Delete tag *Enterprise*?"), states
+the consequence ("This will remove the tag from N records across people,
+organizations, and deals."), and requires an affirmative second action
+(typing the tag name or clicking a destructive button), not a single
+"OK". Optionally pre-fetch impact counts:
+
+```
+GET /api/crm/persons/?tags={id}&page_size=1   → response.count
+GET /api/crm/organizations/?tags={id}&page_size=1
+GET /api/crm/deals/?tags={id}&page_size=1
+```
+
+See `references/tags-api.md` for the full endpoint contract, error
+shapes, and host attach/detach matrix.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and visit the surface in the browser:
+   - Open the tag manager. Try to create a tag with color `#FFF`
+     (three digits) — the client should reject it before the request
+     leaves; if you bypass the client check, the server returns
+     `400 {"color": ["Color must be a hex string like \`#3F6BFF\`."]}`.
+   - Create a valid tag (`name`: `Enterprise`, `color`: `#3F6BFF`).
+   - On a Person detail page, attach the tag. Confirm the chip
+     renders. Click attach a second time — UI must not flash an
+     error (409 path).
+   - On an Organization detail page, attach the same tag.
+   - On a Deal detail page, attach the same tag.
+   - Detach the tag from the Person — chip disappears.
+   - On the Person list view, filter by the tag (`?tags=<id>`) and
+     confirm only tagged people remain.
+   - Trigger the delete-tag confirmation modal — confirm copy names
+     the tag and warns about cascade.
+3. Screenshot:
+   ```bash
+   npx playwright screenshot http://localhost:3000/crm/tags /tmp/tags.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC
+- `/iblai-crm-lead-flow` — attach tags to persons and organizations
+- `/iblai-crm-deal-flow` — attach tags to deals; filter board by tag
+- `/iblai-rbac` — CRM User role required for tag writes
+- `/iblai-auth` — token wiring

--- a/adapters/cursor/iblai-crm-activity.mdc
+++ b/adapters/cursor/iblai-crm-activity.mdc
@@ -1,0 +1,287 @@
+---
+description: "Build the CRM activity timeline panel that mounts inside a Person or a Deal detail surface — list calls, meetings, emails, notes, tasks, lunches, and deadlines, schedule them, set reminders, mark them done idempotently, and render server-emitted stage-change audit rows distinctly. Use when the user mentions CRM activity, activities, timeline, log a call, schedule a meeting, sales notes, tasks, deadlines, reminders, or mark done. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-lead-flow for the person host, /iblai-crm-deal-flow for the deal host and stage-change audit rows, /iblai-notification for the bell that surfaces reminders, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-activity
+
+Build the activity timeline panel that lives inside a Person or Deal detail
+surface: list activities, create them (call, meeting, email, note, task,
+lunch, deadline), schedule + remind, mark done, and render server-emitted
+audit rows distinctly.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for activity CRUD and the
+  `done/` action. See `/iblai-rbac` for the full matrix.
+- A host surface must already exist. The timeline is a **panel**, not a
+  standalone page. Either:
+  - `/iblai-crm-lead-flow` — for the Person detail timeline, OR
+  - `/iblai-crm-deal-flow` — for the Deal detail timeline (which is
+    also the source of the server-emitted `Stage changed` audit rows
+    you will render).
+
+## What you'll build
+
+- A **timeline panel** that mounts inside the existing Person detail
+  page (filtered by `person=<uuid>`) and inside the existing Deal
+  detail page (filtered by `deal=<id>`), backed by
+  `GET /api/crm/activities/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **create-activity form** with a type selector covering all seven
+  types — `call`, `meeting`, `email`, `note`, `task`, `lunch`,
+  `deadline` — plus `title`, `comment`, optional `location`,
+  `schedule_from`, `schedule_to`, `reminder_at`, and free-form
+  `metadata`.
+- A **done checkbox** on each open user row that calls
+  `POST /api/crm/activities/{id}/done/` — idempotent, safe to retry.
+- A **system-row renderer** that visually de-emphasizes
+  server-emitted stage-change audit rows
+  (`type === "note" && title === "Stage changed"`) and suppresses
+  their edit / delete / done controls per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently).
+
+Reference tables for every endpoint and field live in:
+
+- `references/activities-api.md`
+- `references/timeline-rendering.md`
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date. Run
+`iblai --version` to check the current version, then upgrade directly:
+
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+This is safe to run even if already at the latest version.
+
+## Step 1: Install shadcn primitives
+
+There is no dedicated `iblai add` generator for the timeline panel — it is
+plain shadcn/ui glued to the CRM REST API. Install the primitives you need:
+
+```bash
+npx shadcn@latest add card select input textarea checkbox button dialog calendar popover badge
+```
+
+You will use `card` for each row, `select` for the type picker, `input`
+and `textarea` for title/comment, `calendar` + `popover` for date
+pickers, `checkbox` for the done toggle, `dialog` for the create form,
+and `badge` for the type chip.
+
+## Step 2: Wrap the activities REST API
+
+Create `lib/iblai/crm-activities.ts`. Read the token and base URL the way
+`/iblai-auth` already wired them — do not introduce a parallel auth layer.
+
+Endpoints (every activity row is scoped to your Platform; cross-Platform
+rows return 404):
+
+| Verb | Path | Use |
+|---|---|---|
+| `GET` | `/api/crm/activities/?person={uuid}` | List a person's timeline |
+| `GET` | `/api/crm/activities/?deal={id}` | List a deal's timeline |
+| `POST` | `/api/crm/activities/` | Create — body MUST set EXACTLY one of `person`/`deal` (or both, where the person equals the deal's person). Neither = 400. |
+| `PATCH` | `/api/crm/activities/{id}/` | Edit user-authored rows. Do NOT call on system rows. |
+| `DELETE` | `/api/crm/activities/{id}/` | Delete user-authored rows. Do NOT call on system rows. |
+| `POST` | `/api/crm/activities/{id}/done/` | Mark done — idempotent, no body |
+
+Every list call uses the standard pagination envelope
+`{count, next_page, previous_page, results[]}`. Default ordering is
+newest-first by `created_at`.
+
+Server-managed fields you MUST NOT write from the client:
+
+- `done_at` — stamped server-side the first time `is_done` flips true
+- `reminder_sent` — flipped server-side after reminder dispatch
+
+See `references/activities-api.md` for the full field list, every
+filter, the attachment-rule errors, and curl examples.
+
+## Step 3: Activity-type selector
+
+Render a shadcn `select` whose values map 1:1 to the `type` field on the
+POST body. All seven types are first-class — none are aliases.
+
+| Value | Suggested chip color | Suggested icon |
+|---|---|---|
+| `call` | sky | Phone |
+| `meeting` | indigo | CalendarClock |
+| `email` | violet | Mail |
+| `note` | slate | StickyNote |
+| `task` | amber | CheckSquare |
+| `lunch` | rose | Utensils |
+| `deadline` | red | AlarmClock |
+
+The chip color is cosmetic — drive it from a small lookup table next to
+your renderer. The `type` you POST must be one of the seven strings
+above verbatim.
+
+## Step 4: Scheduling and reminders
+
+Collect three ISO-8601 datetime fields in the create form. Match the
+shape to the intent — do not invent dates to fill empty slots:
+
+| `schedule_from` | `schedule_to` | Read as |
+|---|---|---|
+| null | null | A past log entry recorded after the fact (a logged call, a written note) |
+| set | null | A scheduled task or deadline with a start time but no fixed end |
+| set | set | A meeting or other time-bounded event |
+
+Add an optional `reminder_at` — typically a fixed offset before
+`schedule_from` (15 minutes before is a common meeting default). The
+server stamps `reminder_sent` after dispatch — DO NOT set it from the
+client. The server also stamps `done_at` on completion — DO NOT set it
+from the client.
+
+> Reminder delivery is not yet dispatched server-side (see [Reminders](../../../docs/developer/applications/crm.md#105-reminders)).
+> `reminder_at` round-trips and you can surface a local in-app prompt
+> from it today; `reminder_sent` will stay `false` until the dispatcher
+> ships.
+
+## Step 5: Mark-done checkbox
+
+Render a shadcn `checkbox` on every open user row. When checked, POST
+to `/api/crm/activities/{id}/done/` with no body. The response is the
+full updated activity object — splice it into your local list so the
+row re-renders with `is_done=true` and `done_at` populated without a
+follow-up GET.
+
+This action is **idempotent**: repeat calls on an already-done activity
+return the SAME `done_at` the server stamped on the first call. That
+makes the checkbox safe to retry from a flaky network without drifting
+completion timestamps that downstream reports depend on.
+
+Do not render the checkbox on system rows — see Step 7.
+
+## Step 6: Render the timeline
+
+Order rows newest-first. Default to `created_at` desc (which is what
+the API returns); when you want a calendar-style view (e.g. an
+upcoming-meetings panel), sort by `schedule_from` instead and filter
+`?is_done=false` to hide completed entries.
+
+Each row should show, at minimum: the type chip (with the color +
+icon from Step 3), `title`, `comment`, the relative time, the owner,
+and — for scheduled rows — `schedule_from` (and `schedule_to` when
+present). Combine list filters to drive panel variants — for example
+`?deal=314&type=call&is_done=false` powers an "upcoming calls" panel
+on a deal.
+
+## Step 7: Render system audit rows distinctly
+
+Per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently), the CRM writes a system Activity every time a deal moves
+stage, wins, or is lost. Detect them client-side with one predicate:
+
+```ts
+const isStageChangeAudit = (a: Activity): boolean =>
+  a.type === "note" && a.title === "Stage changed";
+```
+
+For rows where that returns true:
+
+- Use a distinct system icon (a small arrow / system glyph)
+- Render at smaller size with muted text
+- Suppress edit, delete, and done controls — the row is server-authored
+  and arrives already complete (`is_done: true`, `done_at` set to the
+  transition timestamp)
+- Use the `comment` body (e.g. `"Discovery → Proposal"`) as the line
+  of record
+
+See `references/timeline-rendering.md` for the full rationale and the
+schedule / reminder / attachment semantics.
+
+## Filters
+
+The list endpoint accepts a focused set of query parameters useful for
+the panel variants you will build. The most commonly used here:
+
+| Param | Type | Use |
+|---|---|---|
+| `person` | UUID | Person timeline (mount on person detail) |
+| `deal` | integer | Deal timeline (mount on deal detail) |
+| `type` | string | One of the seven types — narrow to a single kind |
+| `is_done` | boolean | Hide completed / show only open |
+| `owner` | integer | Filter by owning user id |
+| `schedule_from__gte` | datetime | Calendar window start |
+| `schedule_from__lte` | datetime | Calendar window end |
+| `metadata__has_key` | string | Activities whose `metadata` JSON contains this top-level key |
+| `page`, `page_size` | integer | Standard pagination |
+
+The full list — including `metadata__has_key` semantics and combining
+rules — lives in `references/activities-api.md`.
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and open the relevant detail pages:
+   - Open a Person detail page from `/iblai-crm-lead-flow`. Create an
+     activity with `type=call`, no schedule, a short comment. Confirm
+     it appears at the top of the timeline. Mark it done with the
+     checkbox; confirm `is_done` flips and `done_at` populates.
+   - Open a Deal detail page from `/iblai-crm-deal-flow`. Create a
+     `meeting` with `schedule_from` and `schedule_to` set 30 minutes
+     apart, and `reminder_at` 15 minutes before `schedule_from`.
+     Confirm the row renders with the type chip, scheduled time, and
+     reminder.
+   - From the deal kanban, move the deal to a new stage. Reload the
+     deal timeline and confirm a server-emitted row appears with
+     `type="note"`, `title="Stage changed"`, `is_done=true`, and is
+     rendered distinctly (smaller, muted, system icon, no edit /
+     delete / done controls).
+3. Screenshot the timeline so the user can see it:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals/<id> /tmp/deal-timeline.png
+   npx playwright screenshot http://localhost:3000/crm/contacts/<uuid> /tmp/person-timeline.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — person timeline host
+- `/iblai-crm-deal-flow` — deal timeline host + audit row source (stage moves emit notes)
+- `/iblai-notification` — bell UI for activity reminders + CRM events
+- `/iblai-rbac` — CRM User role
+- `/iblai-auth` — token wiring

--- a/adapters/cursor/iblai-crm-notification.mdc
+++ b/adapters/cursor/iblai-crm-notification.mdc
@@ -1,0 +1,187 @@
+---
+description: "Reference for the three CRM notification event types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) the ibl.ai CRM dispatches after a write commits — payload shapes, recipient routing modes (default / per-Platform configured), and how to surface them in your app. Use when the user mentions CRM notifications, lead/deal alerts, \"who gets notified when a deal moves stages\", recipient mode configuration, or wiring a CRM-only inbox; see /iblai-crm-overview for setup, /iblai-crm-lead-flow and /iblai-crm-deal-flow for the events' source skills, and /iblai-notification for the bell UI that actually renders these events. This is a REFERENCE skill — it documents the contract; it does NOT build the bell UI."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-notification
+
+Reference skill for the three CRM notification event types. Documents
+when each one fires, the context keys included in the payload, the
+recipient-routing modes available per Platform, and where the developer
+goes next to surface these events in the UI. This skill does NOT build
+the notification bell — that is `/iblai-notification`.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth set up (`/iblai-auth`)
+- MCP and skills set up (`iblai add mcp`)
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user holds a CRM role (`CRM Viewer` is enough to read
+  inbox entries that target them; see `/iblai-rbac`)
+
+## The three CRM notification types
+
+Every CRM write that produces a notification routes through exactly one
+of these three event types. Full payload tables (every `context` key)
+live in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+| `event_type` | Fires when | Source skill | Default recipients |
+|---|---|---|---|
+| `CRM_PERSON_CREATED` | A person row is created via any path — REST `POST /persons/`, the Django admin, or bulk import | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+| `CRM_DEAL_STAGE_CHANGED` | A deal moves between stages via `POST /deals/{id}/move-stage/`, `POST /deals/{id}/won/`, or `POST /deals/{id}/lost/`. No-op transitions (destination stage equals current stage) are SUPPRESSED — no notification | `/iblai-crm-deal-flow` | Platform admins + `deal.owner` |
+| `CRM_PERSON_LINKED_TO_USER` | A person is bound to a Platform user — either by explicit `POST /persons/{id}/link-user/` or implicitly by the auto-link signal when a new user registers with a matching email | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+
+"Object owner" is `person.owner` for the two person-scoped events and
+`deal.owner` for the stage-change event. If the owner field is unset on
+the triggering object, the configured recipient mode decides whether to
+fall back to admins or drop the notification — see `## Recipient routing`
+below.
+
+## After-commit dispatch
+
+All three event types dispatch **asynchronously after the writing
+transaction commits**. The CRM signal is observed inside the request, but
+the actual notification send fires from a post-commit hook on the
+database transaction. The practical consequences:
+
+- A write that rolls back — failed validation, database constraint, a
+  `move-stage` call that raises mid-transition — produces no
+  notification. The signal is observed, the dispatch is not.
+- By the time a recipient sees the email, push entry, or inbox row, the
+  underlying record is durably on disk. There are no ghost notifications
+  for state that never persisted.
+- Context keys are snapshotted at signal time from the live object. A
+  template that references `{{ deal_lead_value }}` reads the value as it
+  stood the moment the stage transition committed; later edits to the
+  deal do not re-render or re-send.
+
+Cross-reference: this is the same after-commit rule the [System Overview](../../../docs/developer/applications/crm.md#2-system-overview) "Side
+Effects" block describes, and it is shared with the audit `Activity` row
+that `move-stage`/`won`/`lost` writes alongside the notification (see
+`/iblai-crm-activity`).
+
+## Recipient routing
+
+Every CRM notification template — and any notification type that opts
+into the shared recipients pipeline — can be configured per Platform
+with one of five recipient modes:
+
+| Mode | Effect |
+|---|---|
+| `platform_admins_only` | Deliver to active Platform admins only. The object's owner is ignored. |
+| `object_owner_only` | Deliver to the object's owner. If the owner field is unset, fall back to Platform admins so nothing is silently dropped. |
+| `object_owner_only_strict` | Deliver to the object's owner only. If the owner is unset, no one is notified. Use when the notification is meaningless without an owner. |
+| `platform_admins_and_object_owner` | **Default.** Both audiences receive the notification, deduplicated so an admin who is also the owner does not get two copies. |
+| `custom` | Deliver to a hand-picked list of users, user groups, or RBAC role-policy holders. Admins and the owner are NOT implicitly included. |
+
+When the mode is `custom`, the template's `recipients_custom_recipients`
+field holds a list of dicts. Each entry takes one of three shapes:
+
+```json
+{ "type": "user",        "id": 123 }
+{ "type": "user_group",  "id": 7 }
+{ "type": "rbac_policy", "policy_name": "CRM Manager" }
+```
+
+Entries compose freely — a single list can mix individual users, groups,
+and policy holders. The resolver expands each entry, unions the results,
+deduplicates, and runs the active-Platform-membership filter as a final
+gate. Stale entries (departed users, reassigned policies, drained
+groups) simply contribute zero recipients on that dispatch.
+
+Recipient configuration lives on the **notification template, not the
+CRM models**. Changing it for `CRM_DEAL_STAGE_CHANGED` on a given
+Platform is a `PATCH` against that Platform's template for that type,
+setting `recipients_recipient_mode` and (if `custom`) populating
+`recipients_custom_recipients`. The CRM does not add a separate API
+surface for this — the same template-management endpoints documented in
+`/iblai-notification` handle these three types alongside every other
+notification type on the platform. This skill does NOT modify those
+endpoints; it just documents which event types route through them.
+
+Full mode table, custom-shape examples, the change-recipients workflow,
+and the active-membership filter rules are in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+## Channels
+
+Email delivery is wired by default for all three CRM event types.
+Per-user notification preferences are honored by the underlying delivery
+machinery — the CRM does not bypass them. Additional channels (in-app
+inbox feed, push notification) follow the template's channel
+configuration, inspected and changed via the same templates API.
+
+The **in-app bell + notification center** that surfaces inbox entries is
+NOT in scope for this skill. Send the developer to `/iblai-notification`
+for the drop-in `<NotificationDropdown>` and `<NotificationDisplay>`
+components.
+
+## Consuming the events in your UI
+
+This is a reference skill. To actually show a user the three CRM event
+types in the browser:
+
+1. Install the bell + center via `/iblai-notification`. That skill ships
+   `components/iblai/notification-bell.tsx` and the
+   `<NotificationDisplay>` page surface (Inbox + Alerts tabs).
+2. The bell's inbox list is a standard notification feed — every
+   delivered notification carries an `event_type` matching one of the
+   three values from the table above. Filter the inbox query to those
+   three values (or any subset) when you want a CRM-only inbox view.
+3. For deeper drill-down (clicking an inbox entry that says "Deal moved
+   to Negotiation" and jumping to the kanban card), wire the
+   `onViewNotifications` callback on `<NotificationDropdown>` to route
+   to the deal detail page built by `/iblai-crm-deal-flow`.
+
+## Verify
+
+End-to-end smoke once the bell is wired:
+
+1. From the kanban built in `/iblai-crm-deal-flow`, move a deal from one
+   stage to another via `POST /deals/{id}/move-stage/`. Make sure the
+   destination stage actually differs from the current one (same-stage
+   moves are suppressed and produce nothing).
+2. Within a few seconds, confirm a `CRM_DEAL_STAGE_CHANGED` row appears
+   in the inbox bell installed by `/iblai-notification` for the deal's
+   owner.
+3. Open the deal's activity timeline (`/iblai-crm-activity`) and confirm
+   the corresponding audit `Activity` row exists with `type=note`,
+   `done=true`, `title="Stage changed"`. The notification and the audit
+   row are written together — if one is missing while the other is
+   present, the transaction split unexpectedly and is worth filing.
+4. Re-run the same `move-stage` call with `stage_code` set to the
+   destination it just reached. The API should return the deal
+   unchanged, no new audit row, and no new notification.
+
+Run `/iblai-ops-test` before reporting done.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — source of `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER`
+- `/iblai-crm-deal-flow` — source of `CRM_DEAL_STAGE_CHANGED`
+- `/iblai-notification` — bell UI + notification center that consumes these events
+- `/iblai-rbac` — required CRM roles
+- `/iblai-auth` — token wiring

--- a/adapters/cursor/iblai-crm-tag.mdc
+++ b/adapters/cursor/iblai-crm-tag.mdc
@@ -1,0 +1,351 @@
+---
+description: "Build the CRM tag manager — CRUD on /api/crm/tags/ with hex color picker, a reusable tag chip, attach/detach controls on Person/Organization/Deal detail pages, and tag filters on list views with OR semantics. Use when the user mentions CRM tags, labels, tagging, color chips, tag manager, attach tag, detach tag, filter by tag, or wants to add segmentation labels to people/orgs/deals. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for the person/org host pages, /iblai-crm-deal-flow for the deal host pages, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring."
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-tag
+
+Build the CRM tag surface — tag CRUD dialog, color chip, attach/detach
+controls on Person, Organization, and Deal pages, plus a `?tags=` filter
+on every CRM list view.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — provides the platform
+  `Authorization: Token <token>` header used by every call below.
+- MCP and skills must be set up: `iblai add mcp`.
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user must hold the **CRM User** role (or higher) on the
+  Platform. CRM User unlocks `Ibl.CRM/Tags/list`, `read`, `action`,
+  `write`, and `delete`. CRM Viewer can only see tags, not write or
+  attach them. See `/iblai-rbac` for the role matrix and how to assign
+  CRM roles to a user.
+- At least one host surface should already exist so there is something
+  to tag. Run `/iblai-crm-lead-flow` (people + organizations) or
+  `/iblai-crm-deal-flow` (deals) first if you have not yet.
+
+## What you'll build
+
+1. A **tag manager dialog** — list, create, edit, and delete tags. Color
+   input is validated client-side against `^#[0-9A-Fa-f]{6}$` before
+   submit so the user sees errors immediately (the server applies the
+   same regex).
+2. A **tag chip** component — renders `{id, name, color}` with the hex
+   color as background. Optional `x` button for detach.
+3. **Attach / detach controls** on Person, Organization, and Deal detail
+   pages. The contract is uniform: `POST /{host}/{id}/tags/` with
+   `{tag_id}`, `DELETE /{host}/{id}/tags/{tag_id}/`.
+4. A **tag filter** on Person, Organization, and Deal list views —
+   `?tags=<id>&tags=<id2>` with **OR** semantics. Results are
+   de-duplicated by the backend.
+
+## Step 0: Check for CLI updates
+
+```bash
+iblai --version    # upgrade if outdated: pip install --upgrade iblai-app-cli OR npm i -g @iblai/cli@latest
+```
+
+## Step 1: Install shadcn primitives
+
+```bash
+npx shadcn@latest add dialog input form popover command badge button
+```
+
+`dialog` powers the tag manager and the delete-confirmation modal.
+`popover` + `command` together make a searchable tag combobox for the
+attach control. `badge` is the visual base for the tag chip. `input`
++ `form` cover the create/edit form. `button` covers actions.
+
+## Step 2: Typed API client wrapper
+
+Reuse the auth token wired in `/iblai-auth`. Create
+`lib/iblai/crm-tags.ts` with one wrapper per route. Base URL is
+`${NEXT_PUBLIC_API_BASE_URL}/api/crm`.
+
+```typescript
+// lib/iblai/crm-tags.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+const HEX = /^#[0-9A-Fa-f]{6}$/;
+
+export type Tag = {
+  id: number;
+  platform: number;
+  name: string;
+  color: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TagChip = Pick<Tag, "id" | "name" | "color">;
+
+export type Assignment = { assignment_id: number; tag: TagChip };
+
+function authHeaders(token: string) {
+  return {
+    Authorization: `Token ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+// Tag CRUD
+export async function listTags(token: string, params: { name?: string; page?: number } = {}) {
+  const qs = new URLSearchParams();
+  if (params.name) qs.set("name", params.name);
+  if (params.page) qs.set("page", String(params.page));
+  const r = await fetch(`${BASE}/tags/?${qs}`, { headers: authHeaders(token) });
+  if (!r.ok) throw new Error(`listTags ${r.status}`);
+  return r.json() as Promise<{ count: number; results: Tag[]; next_page: number | null; previous_page: number | null }>;
+}
+
+export async function createTag(token: string, body: { name: string; color?: string; metadata?: Record<string, unknown> }) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/`, { method: "POST", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function patchTag(token: string, id: number, body: Partial<Pick<Tag, "name" | "color" | "metadata">>) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "PATCH", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function deleteTag(token: string, id: number) {
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "DELETE", headers: authHeaders(token) });
+  if (!r.ok && r.status !== 204) throw new Error(`deleteTag ${r.status}`);
+}
+
+// Uniform host attach / detach. `host` is "persons" | "organizations" | "deals".
+export type Host = "persons" | "organizations" | "deals";
+
+export async function attachTag(token: string, host: Host, hostId: string | number, tagId: number): Promise<Assignment> {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ tag_id: tagId }),
+  });
+  // 201 = created; 409 = already attached, body still carries assignment_id + tag.
+  if (r.status === 201 || r.status === 409) return r.json();
+  throw await r.json();
+}
+
+export async function detachTag(token: string, host: Host, hostId: string | number, tagId: number) {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/${tagId}/`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+  // 204 = removed; 404 = not attached (treat as no-op success).
+  if (r.status !== 204 && r.status !== 404) throw new Error(`detachTag ${r.status}`);
+}
+```
+
+See `references/tags-api.md` for full endpoint table, error shapes, and
+filter semantics.
+
+## Step 3: Tag manager dialog
+
+Create `components/crm/tag-manager-dialog.tsx`. It is a single dialog
+that lists all tags from `GET /tags/`, lets the user create a new tag,
+edit an existing tag, or delete one.
+
+Requirements:
+
+- **Create form**: `name` (required, ≤ 64 chars, unique-per-Platform —
+  server-enforced) and `color` (`<input type="color">` is fine; on
+  submit, validate the value against `^#[0-9A-Fa-f]{6}$` before
+  calling `createTag`). Surface the server's 400 errors verbatim —
+  duplicate name, blank name, > 64 chars, bad hex.
+- **Edit**: inline rename + recolor calls `patchTag`. Renames take
+  effect immediately on every host chip — the chip renders from the
+  Tag row, not from the assignment.
+- **Delete**: opens a confirmation modal — see the destructive cascade
+  callout below. Disable the delete button until the user types the
+  tag name to confirm, or at minimum require a second click.
+
+The dialog reads the token from the auth store wired by `/iblai-auth`.
+
+## Step 4: Tag chip component
+
+Create `components/crm/tag-chip.tsx`. Renders `{id, name, color}` as a
+shadcn `Badge` with `style={{ backgroundColor: tag.color, color: '#fff' }}`.
+Accept an optional `onDetach: () => void` prop — when supplied, render
+a small `x` icon button inside the chip; otherwise render the chip as
+read-only.
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import type { TagChip as TTagChip } from "@/lib/iblai/crm-tags";
+
+export function TagChip({ tag, onDetach }: { tag: TTagChip; onDetach?: () => void }) {
+  return (
+    <Badge style={{ backgroundColor: tag.color, color: "#fff" }} className="gap-1">
+      {tag.name}
+      {onDetach ? (
+        <button onClick={onDetach} aria-label={`Detach ${tag.name}`} className="ml-1">
+          <X className="h-3 w-3" />
+        </button>
+      ) : null}
+    </Badge>
+  );
+}
+```
+
+The `tags` array is **always present** on every Person, Organization,
+and Deal list/detail response — empty array, never `null`. So your
+renderer can iterate unconditionally.
+
+## Step 5: Attach control on host detail pages
+
+On Person, Organization, and Deal detail pages, add an "Add tag"
+button that opens a shadcn `Popover` containing a `Command` combobox.
+Populate the combobox with `listTags(token)` (search-as-you-type by
+filtering client-side, or pass `name=` to the API for large libraries).
+
+On select:
+
+```typescript
+const { assignment_id, tag } = await attachTag(token, host, hostId, selectedTagId);
+// Optimistically add `tag` to the local host.tags array; assignment_id is for
+// future detach reconciliation, not required for the chip itself.
+```
+
+Edge cases:
+
+- **409 Conflict** — the tag is already attached. The response body
+  still carries the existing `assignment_id` + `tag`, so you can
+  reconcile local state without a re-fetch and **must not** show a red
+  error toast. Treat 409 as a no-op success.
+- **404 Not Found** — the tag id is not in this Platform. Show
+  "Tag not found." The API never leaks existence across Platforms.
+
+## Step 6: Detach control
+
+Render the host's `tags` array as `TagChip` components with `onDetach`
+wired to `detachTag(token, host, hostId, tag.id)`.
+
+Edge case:
+
+- **404 Not Found** on detach means the tag was not attached. Detach
+  is **not** idempotent server-side — a retried DELETE returns 404,
+  not 204. Client code should treat both as the same success state.
+  The wrapper above already does this.
+
+## Step 7: Tag filter on list views
+
+Wire a multi-select tag picker into the Person, Organization, and Deal
+list pages.
+
+The list endpoints accept repeated or comma-separated `tags`:
+
+```
+GET /api/crm/persons/?tags=7&tags=12
+GET /api/crm/persons/?tags=7,12
+```
+
+Both forms have **OR** semantics — a record matching any selected tag
+appears once (the backend de-duplicates). The filter composes with
+every other filter on the same endpoint, e.g.:
+
+```
+GET /api/crm/persons/?tags=7&lifecycle_stage=customer&owner=4
+```
+
+Implementation: bind the selected tag-ids to `URLSearchParams.append`
+so a `tags` array becomes repeated params, then refetch the list.
+
+## Destructive cascade callout
+
+> **Deleting a tag silently removes it from every Person, Organization,
+> and Deal it is attached to.** `DELETE /tags/{id}/` cascades — there
+> is no preview, no soft-delete, and no undo.
+
+Best practice [confirm before deleting a tag](../../../docs/developer/applications/crm.md#167-confirm-before-deleting-a-tag): gate the delete button behind a confirmation modal
+that **names the tag explicitly** ("Delete tag *Enterprise*?"), states
+the consequence ("This will remove the tag from N records across people,
+organizations, and deals."), and requires an affirmative second action
+(typing the tag name or clicking a destructive button), not a single
+"OK". Optionally pre-fetch impact counts:
+
+```
+GET /api/crm/persons/?tags={id}&page_size=1   → response.count
+GET /api/crm/organizations/?tags={id}&page_size=1
+GET /api/crm/deals/?tags={id}&page_size=1
+```
+
+See `references/tags-api.md` for the full endpoint contract, error
+shapes, and host attach/detach matrix.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and visit the surface in the browser:
+   - Open the tag manager. Try to create a tag with color `#FFF`
+     (three digits) — the client should reject it before the request
+     leaves; if you bypass the client check, the server returns
+     `400 {"color": ["Color must be a hex string like \`#3F6BFF\`."]}`.
+   - Create a valid tag (`name`: `Enterprise`, `color`: `#3F6BFF`).
+   - On a Person detail page, attach the tag. Confirm the chip
+     renders. Click attach a second time — UI must not flash an
+     error (409 path).
+   - On an Organization detail page, attach the same tag.
+   - On a Deal detail page, attach the same tag.
+   - Detach the tag from the Person — chip disappears.
+   - On the Person list view, filter by the tag (`?tags=<id>`) and
+     confirm only tagged people remain.
+   - Trigger the delete-tag confirmation modal — confirm copy names
+     the tag and warns about cascade.
+3. Screenshot:
+   ```bash
+   npx playwright screenshot http://localhost:3000/crm/tags /tmp/tags.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC
+- `/iblai-crm-lead-flow` — attach tags to persons and organizations
+- `/iblai-crm-deal-flow` — attach tags to deals; filter board by tag
+- `/iblai-rbac` — CRM User role required for tag writes
+- `/iblai-auth` — token wiring

--- a/skills/iblai-crm-activity/SKILL.md
+++ b/skills/iblai-crm-activity/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: iblai-crm-activity
+description: Build the CRM activity timeline panel that mounts inside a Person or a Deal detail surface — list calls, meetings, emails, notes, tasks, lunches, and deadlines, schedule them, set reminders, mark them done idempotently, and render server-emitted stage-change audit rows distinctly. Use when the user mentions CRM activity, activities, timeline, log a call, schedule a meeting, sales notes, tasks, deadlines, reminders, or mark done. See /iblai-crm-overview for shared setup and RBAC, /iblai-crm-lead-flow for the person host, /iblai-crm-deal-flow for the deal host and stage-change audit rows, /iblai-notification for the bell that surfaces reminders, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-activity
+
+Build the activity timeline panel that lives inside a Person or Deal detail
+surface: list activities, create them (call, meeting, email, note, task,
+lunch, deadline), schedule + remind, mark done, and render server-emitted
+audit rows distinctly.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — this skill reuses the
+  token that `/iblai-auth` wired into `.env.local`. Do not introduce
+  a new auth layer.
+- MCP and skills must be set up: `iblai add mcp`
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- Caller must hold the **CRM User** role for activity CRUD and the
+  `done/` action. See `/iblai-rbac` for the full matrix.
+- A host surface must already exist. The timeline is a **panel**, not a
+  standalone page. Either:
+  - `/iblai-crm-lead-flow` — for the Person detail timeline, OR
+  - `/iblai-crm-deal-flow` — for the Deal detail timeline (which is
+    also the source of the server-emitted `Stage changed` audit rows
+    you will render).
+
+## What you'll build
+
+- A **timeline panel** that mounts inside the existing Person detail
+  page (filtered by `person=<uuid>`) and inside the existing Deal
+  detail page (filtered by `deal=<id>`), backed by
+  `GET /api/crm/activities/` and the standard
+  `{count, next_page, previous_page, results}` envelope.
+- A **create-activity form** with a type selector covering all seven
+  types — `call`, `meeting`, `email`, `note`, `task`, `lunch`,
+  `deadline` — plus `title`, `comment`, optional `location`,
+  `schedule_from`, `schedule_to`, `reminder_at`, and free-form
+  `metadata`.
+- A **done checkbox** on each open user row that calls
+  `POST /api/crm/activities/{id}/done/` — idempotent, safe to retry.
+- A **system-row renderer** that visually de-emphasizes
+  server-emitted stage-change audit rows
+  (`type === "note" && title === "Stage changed"`) and suppresses
+  their edit / delete / done controls per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently).
+
+Reference tables for every endpoint and field live in:
+
+- `references/activities-api.md`
+- `references/timeline-rendering.md`
+
+## Step 0: Check for CLI Updates
+
+Before running any `iblai` command, ensure the CLI is up to date. Run
+`iblai --version` to check the current version, then upgrade directly:
+
+- pip: `pip install --upgrade iblai-app-cli`
+- npm: `npm install -g @iblai/cli@latest`
+
+This is safe to run even if already at the latest version.
+
+## Step 1: Install shadcn primitives
+
+There is no dedicated `iblai add` generator for the timeline panel — it is
+plain shadcn/ui glued to the CRM REST API. Install the primitives you need:
+
+```bash
+npx shadcn@latest add card select input textarea checkbox button dialog calendar popover badge
+```
+
+You will use `card` for each row, `select` for the type picker, `input`
+and `textarea` for title/comment, `calendar` + `popover` for date
+pickers, `checkbox` for the done toggle, `dialog` for the create form,
+and `badge` for the type chip.
+
+## Step 2: Wrap the activities REST API
+
+Create `lib/iblai/crm-activities.ts`. Read the token and base URL the way
+`/iblai-auth` already wired them — do not introduce a parallel auth layer.
+
+Endpoints (every activity row is scoped to your Platform; cross-Platform
+rows return 404):
+
+| Verb | Path | Use |
+|---|---|---|
+| `GET` | `/api/crm/activities/?person={uuid}` | List a person's timeline |
+| `GET` | `/api/crm/activities/?deal={id}` | List a deal's timeline |
+| `POST` | `/api/crm/activities/` | Create — body MUST set EXACTLY one of `person`/`deal` (or both, where the person equals the deal's person). Neither = 400. |
+| `PATCH` | `/api/crm/activities/{id}/` | Edit user-authored rows. Do NOT call on system rows. |
+| `DELETE` | `/api/crm/activities/{id}/` | Delete user-authored rows. Do NOT call on system rows. |
+| `POST` | `/api/crm/activities/{id}/done/` | Mark done — idempotent, no body |
+
+Every list call uses the standard pagination envelope
+`{count, next_page, previous_page, results[]}`. Default ordering is
+newest-first by `created_at`.
+
+Server-managed fields you MUST NOT write from the client:
+
+- `done_at` — stamped server-side the first time `is_done` flips true
+- `reminder_sent` — flipped server-side after reminder dispatch
+
+See `references/activities-api.md` for the full field list, every
+filter, the attachment-rule errors, and curl examples.
+
+## Step 3: Activity-type selector
+
+Render a shadcn `select` whose values map 1:1 to the `type` field on the
+POST body. All seven types are first-class — none are aliases.
+
+| Value | Suggested chip color | Suggested icon |
+|---|---|---|
+| `call` | sky | Phone |
+| `meeting` | indigo | CalendarClock |
+| `email` | violet | Mail |
+| `note` | slate | StickyNote |
+| `task` | amber | CheckSquare |
+| `lunch` | rose | Utensils |
+| `deadline` | red | AlarmClock |
+
+The chip color is cosmetic — drive it from a small lookup table next to
+your renderer. The `type` you POST must be one of the seven strings
+above verbatim.
+
+## Step 4: Scheduling and reminders
+
+Collect three ISO-8601 datetime fields in the create form. Match the
+shape to the intent — do not invent dates to fill empty slots:
+
+| `schedule_from` | `schedule_to` | Read as |
+|---|---|---|
+| null | null | A past log entry recorded after the fact (a logged call, a written note) |
+| set | null | A scheduled task or deadline with a start time but no fixed end |
+| set | set | A meeting or other time-bounded event |
+
+Add an optional `reminder_at` — typically a fixed offset before
+`schedule_from` (15 minutes before is a common meeting default). The
+server stamps `reminder_sent` after dispatch — DO NOT set it from the
+client. The server also stamps `done_at` on completion — DO NOT set it
+from the client.
+
+> Reminder delivery is not yet dispatched server-side (see [Reminders](../../../docs/developer/applications/crm.md#105-reminders)).
+> `reminder_at` round-trips and you can surface a local in-app prompt
+> from it today; `reminder_sent` will stay `false` until the dispatcher
+> ships.
+
+## Step 5: Mark-done checkbox
+
+Render a shadcn `checkbox` on every open user row. When checked, POST
+to `/api/crm/activities/{id}/done/` with no body. The response is the
+full updated activity object — splice it into your local list so the
+row re-renders with `is_done=true` and `done_at` populated without a
+follow-up GET.
+
+This action is **idempotent**: repeat calls on an already-done activity
+return the SAME `done_at` the server stamped on the first call. That
+makes the checkbox safe to retry from a flaky network without drifting
+completion timestamps that downstream reports depend on.
+
+Do not render the checkbox on system rows — see Step 7.
+
+## Step 6: Render the timeline
+
+Order rows newest-first. Default to `created_at` desc (which is what
+the API returns); when you want a calendar-style view (e.g. an
+upcoming-meetings panel), sort by `schedule_from` instead and filter
+`?is_done=false` to hide completed entries.
+
+Each row should show, at minimum: the type chip (with the color +
+icon from Step 3), `title`, `comment`, the relative time, the owner,
+and — for scheduled rows — `schedule_from` (and `schedule_to` when
+present). Combine list filters to drive panel variants — for example
+`?deal=314&type=call&is_done=false` powers an "upcoming calls" panel
+on a deal.
+
+## Step 7: Render system audit rows distinctly
+
+Per [best practice: render system audit Activities differently](../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently), the CRM writes a system Activity every time a deal moves
+stage, wins, or is lost. Detect them client-side with one predicate:
+
+```ts
+const isStageChangeAudit = (a: Activity): boolean =>
+  a.type === "note" && a.title === "Stage changed";
+```
+
+For rows where that returns true:
+
+- Use a distinct system icon (a small arrow / system glyph)
+- Render at smaller size with muted text
+- Suppress edit, delete, and done controls — the row is server-authored
+  and arrives already complete (`is_done: true`, `done_at` set to the
+  transition timestamp)
+- Use the `comment` body (e.g. `"Discovery → Proposal"`) as the line
+  of record
+
+See `references/timeline-rendering.md` for the full rationale and the
+schedule / reminder / attachment semantics.
+
+## Filters
+
+The list endpoint accepts a focused set of query parameters useful for
+the panel variants you will build. The most commonly used here:
+
+| Param | Type | Use |
+|---|---|---|
+| `person` | UUID | Person timeline (mount on person detail) |
+| `deal` | integer | Deal timeline (mount on deal detail) |
+| `type` | string | One of the seven types — narrow to a single kind |
+| `is_done` | boolean | Hide completed / show only open |
+| `owner` | integer | Filter by owning user id |
+| `schedule_from__gte` | datetime | Calendar window start |
+| `schedule_from__lte` | datetime | Calendar window end |
+| `metadata__has_key` | string | Activities whose `metadata` JSON contains this top-level key |
+| `page`, `page_size` | integer | Standard pagination |
+
+The full list — including `metadata__has_key` semantics and combining
+rules — lives in `references/activities-api.md`.
+
+## Verify
+
+Run `/iblai-ops-test` before telling the user the work is ready:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and open the relevant detail pages:
+   - Open a Person detail page from `/iblai-crm-lead-flow`. Create an
+     activity with `type=call`, no schedule, a short comment. Confirm
+     it appears at the top of the timeline. Mark it done with the
+     checkbox; confirm `is_done` flips and `done_at` populates.
+   - Open a Deal detail page from `/iblai-crm-deal-flow`. Create a
+     `meeting` with `schedule_from` and `schedule_to` set 30 minutes
+     apart, and `reminder_at` 15 minutes before `schedule_from`.
+     Confirm the row renders with the type chip, scheduled time, and
+     reminder.
+   - From the deal kanban, move the deal to a new stage. Reload the
+     deal timeline and confirm a server-emitted row appears with
+     `type="note"`, `title="Stage changed"`, `is_done=true`, and is
+     rendered distinctly (smaller, muted, system icon, no edit /
+     delete / done controls).
+3. Screenshot the timeline so the user can see it:
+   ```bash
+   pnpm dev &
+   npx playwright screenshot http://localhost:3000/crm/deals/<id> /tmp/deal-timeline.png
+   npx playwright screenshot http://localhost:3000/crm/contacts/<uuid> /tmp/person-timeline.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — person timeline host
+- `/iblai-crm-deal-flow` — deal timeline host + audit row source (stage moves emit notes)
+- `/iblai-notification` — bell UI for activity reminders + CRM events
+- `/iblai-rbac` — CRM User role
+- `/iblai-auth` — token wiring

--- a/skills/iblai-crm-activity/references/activities-api.md
+++ b/skills/iblai-crm-activity/references/activities-api.md
@@ -1,0 +1,197 @@
+# Activities API — `/api/crm/activities/`
+
+Condensed from the [Activities API](../../../../docs/developer/applications/crm.md#76-activities) section of the CRM developer documentation. An Activity is a
+timeline entry attached to a Deal **or** a Person (or both, when they
+agree). It carries a type, optional schedule, optional reminder, an
+owner, and a free-form metadata bag. Activities are also the audit row
+the server writes when a Deal transitions stages — those rows arrive
+already complete and are surfaced through the same endpoint.
+
+> **Base URL:** `https://<your-platform-host>/api/crm/`
+> **Auth:** `Authorization: Token <token>`
+> **Pagination envelope:** `{count, next_page, previous_page, results[]}`
+> **Default ordering:** newest-first by `created_at`
+
+## Endpoint summary
+
+| Method | Path | Purpose | Required permission |
+|---|---|---|---|
+| `GET` | `/activities/` | List activities (paginated) | `Ibl.CRM/Activities/list` |
+| `POST` | `/activities/` | Create an activity | `Ibl.CRM/Activities/action` |
+| `GET` | `/activities/{id}/` | Retrieve one activity | `Ibl.CRM/Activities/read` |
+| `PUT` | `/activities/{id}/` | Replace all editable fields | `Ibl.CRM/Activities/write` |
+| `PATCH` | `/activities/{id}/` | Patch supplied fields | `Ibl.CRM/Activities/write` |
+| `DELETE` | `/activities/{id}/` | Delete the activity | `Ibl.CRM/Activities/delete` |
+| `POST` | `/activities/{id}/done/` | Mark done (idempotent) | `Ibl.CRM/Activities/write` |
+
+## Activity object
+
+| Field | Type | Writable | Notes |
+|---|---|---|---|
+| `id` | integer | no | Server-assigned |
+| `platform` | integer | no | Owning Platform id |
+| `title` | string | yes | Short summary. Required on create. |
+| `type` | string | yes | One of `call`, `meeting`, `email`, `note`, `task`, `lunch`, `deadline`. Required on create. |
+| `location` | string | yes | Meeting location, dial-in URL, venue. Defaults to `""`. |
+| `comment` | string | yes | Free-text body. Defaults to `""`. |
+| `schedule_from` | datetime \| null | yes | Scheduled start (ISO-8601). |
+| `schedule_to` | datetime \| null | yes | Scheduled end (ISO-8601). |
+| `is_done` | boolean | yes | Defaults to `false`. Prefer `POST /activities/{id}/done/` to flip this — it stamps `done_at` for you and is idempotent. |
+| `done_at` | datetime \| null | **no — read-only** | Stamped the first time `is_done` flips true. Preserved on repeat `done/` calls. |
+| `deal` | integer \| null | yes | Attached Deal id. EXACTLY one of `deal`/`person` must be set on create (both is allowed only if they agree — see attachment rule). |
+| `person` | UUID \| null | yes | Attached Person id. See attachment rule. |
+| `owner` | integer \| null | yes | Owning user id. Defaults to the calling user. Must be an active member of your Platform. |
+| `reminder_at` | datetime \| null | yes | When to remind the owner. Typically a fixed offset before `schedule_from` (15 min before is common). |
+| `reminder_sent` | boolean | **no — read-only** | Flipped server-side after the reminder dispatch runs. Do not write from the client. |
+| `metadata` | object | yes | Free-form JSON, defaults to `{}`. |
+| `created_at` | datetime | no | Creation timestamp. |
+| `updated_at` | datetime | no | Last-modified timestamp. |
+
+## Attachment rule
+
+Every activity must attach to a `deal` **or** a `person`:
+
+- **Neither set** → `400 Bad Request`: `{"detail": "Activity must attach to a `deal` or a `person`."}`. The serializer raises before any database write, so a failed create has no side effects.
+- **Only `deal` set** → attached to that deal only.
+- **Only `person` set** → attached to that person only.
+- **Both set** → the person must equal the deal's `person`. A mismatch returns `400` with a field-level error: `{"person": "Person does not match the Deal's Person."}`.
+
+The rule is re-checked on every write. A `PATCH` that clears the only
+remaining attachment field returns `400`.
+
+## `GET /activities/`
+
+Paginated list. Query parameters:
+
+| Param | Type | Description |
+|---|---|---|
+| `type` | string | One of `call`, `meeting`, `email`, `note`, `task`, `lunch`, `deadline` |
+| `is_done` | boolean | Filter completed vs open |
+| `owner` | integer | Owning user id |
+| `deal` | integer | Deal id |
+| `person` | UUID | Person id |
+| `schedule_from__gte` | ISO-8601 datetime | Scheduled start on or after |
+| `schedule_from__lte` | ISO-8601 datetime | Scheduled start on or before |
+| `metadata__has_key` | string | Only activities whose top-level `metadata` object contains this key |
+| `page` | integer | Page number, defaults to 1 |
+| `page_size` | integer | Items per page |
+
+Combine filters freely — `?deal=314&type=call&is_done=false` powers an
+"upcoming calls" panel for a deal; `?person=<uuid>&schedule_from__gte=<now>`
+powers a "what is on this person's calendar" panel.
+
+```bash
+curl -X GET "https://api.iblai.app/dm/api/crm/activities/?deal=184&is_done=false" \
+  -H "Authorization: Token YOUR_ACCESS_TOKEN"
+```
+
+Response is the standard envelope; each result is the full Activity
+object documented above.
+
+## `POST /activities/`
+
+Create an activity. Required: `title`, `type`, and EXACTLY one of
+`deal` / `person` (both allowed only if they agree).
+
+```json
+{
+  "title": "Discovery call",
+  "type": "call",
+  "location": "Zoom",
+  "comment": "Walk through requirements with VP Eng.",
+  "schedule_from": "2026-06-02T15:00:00Z",
+  "schedule_to": "2026-06-02T15:45:00Z",
+  "deal": 184,
+  "person": "c4d2b1a8-7c3e-4f9a-9d6b-9a2c4f1e7b80",
+  "reminder_at": "2026-06-02T14:45:00Z",
+  "metadata": {"meeting_link": "https://zoom.us/j/123"}
+}
+```
+
+Response `201 Created` — full activity object.
+
+### Error responses
+
+`400 Bad Request` — attachment / validation failures:
+
+```json
+{"detail": "Activity must attach to a `deal` or a `person`."}
+```
+
+```json
+{"person": "Person does not match the Deal's Person."}
+```
+
+```json
+{"deal": "Deal belongs to a different platform."}
+```
+
+```json
+{"owner": "User is not an active member of this Platform."}
+```
+
+`403 Forbidden` — caller missing `Ibl.CRM/Activities/action`.
+
+## `GET /activities/{id}/`
+
+Retrieve one activity by integer id. Returns the full Activity object.
+`404 Not Found` if the id does not exist, or exists on another Platform
+(the API does not leak cross-Platform existence — see [cross-platform isolation](../../../../docs/developer/applications/crm.md#153-cross-platform-isolation)).
+
+## `PUT` / `PATCH /activities/{id}/`
+
+Replace (PUT) or patch (PATCH) editable fields. `done_at` and
+`reminder_sent` are read-only — attempting to set them is silently
+ignored. The attachment rule is re-checked on every write — a PATCH that
+clears the only attachment field returns `400`.
+
+```json
+{
+  "title": "Discovery call — rescheduled",
+  "schedule_from": "2026-06-03T15:00:00Z",
+  "schedule_to": "2026-06-03T15:45:00Z"
+}
+```
+
+Response `200 OK` — full updated activity.
+`403 Forbidden` — missing `Ibl.CRM/Activities/write`.
+`400 Bad Request` — attachment failures (see above).
+
+## `DELETE /activities/{id}/`
+
+Delete an activity. Response `204 No Content`. `404` if not found.
+
+> **Be deliberate when deleting server-emitted stage-change rows**
+> (`type === "note" && title === "Stage changed"`). They are the audit
+> trail for the deal's `move-stage/`, `won/`, `lost/` transitions —
+> once deleted there is no way to reconstruct that history. The
+> recommended UI suppresses the delete control on these rows entirely.
+
+## `POST /activities/{id}/done/`
+
+Mark an activity as done. **Idempotent**: the first call flips
+`is_done` to `true` and stamps `done_at` with the current server time;
+subsequent calls return the same activity with the ORIGINAL `done_at`
+preserved. Safe to retry from a flaky network without drifting
+completion timestamps that downstream reports depend on.
+
+- Request body: none. Any payload is ignored.
+- Response `200 OK` — the full updated Activity object. Splice it into
+  your local list to re-render without a follow-up `GET`.
+- `403 Forbidden` — missing `Ibl.CRM/Activities/write`.
+- `404 Not Found`.
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/activities/4408/done/" \
+  -H "Authorization: Token YOUR_ACCESS_TOKEN"
+```
+
+## Cross-references
+
+- [Activities API](../../../../docs/developer/applications/crm.md#76-activities) — full Activities API reference (this file is its condensed form)
+- [Activity Timeline & Auto-Records](../../../../docs/developer/applications/crm.md#10-activity-timeline--auto-records) — see `references/timeline-rendering.md`
+- [Render system audit Activities differently](../../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently) — rendering system audit Activities
+- [Deal audit trail](../../../../docs/developer/applications/crm.md#93-deal-audit-trail) — the source of stage-change Activities
+- [Filtering and pagination](../../../../docs/developer/applications/crm.md#13-filtering-and-pagination)
+- [RBAC roles and permissions](../../../../docs/developer/applications/crm.md#14-rbac-roles-and-permissions)
+- [Error reference](../../../../docs/developer/applications/crm.md#15-error-reference)

--- a/skills/iblai-crm-activity/references/timeline-rendering.md
+++ b/skills/iblai-crm-activity/references/timeline-rendering.md
@@ -1,0 +1,153 @@
+# Timeline Rendering — [Activity Timeline & Auto-Records](../../../../docs/developer/applications/crm.md#10-activity-timeline--auto-records) + [Render system audit Activities differently](../../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently)
+
+Condensed from [Activity Timeline & Auto-Records](../../../../docs/developer/applications/crm.md#10-activity-timeline--auto-records) and
+[Render system audit Activities differently](../../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently). Use this alongside
+`references/activities-api.md` when wiring the timeline panel.
+
+## 10.1 Reading a timeline
+
+The list endpoint is filterable by either parent. The panel is mounted
+inside an existing Person or Deal detail surface, and filters by
+exactly one host:
+
+- Deal-centric panel: `GET /api/crm/activities/?deal={id}`
+- Person-centric panel: `GET /api/crm/activities/?person={uuid}`
+
+Both calls return the standard paginated envelope. Default ordering is
+newest-first by `created_at`.
+
+Combine filters to drive panel variants — for example
+`?deal=314&type=call&is_done=false` renders an "upcoming calls" panel
+on a deal page.
+
+## 10.2 Distinguishing system rows from user rows
+
+The CRM writes its own Activities when a Deal transitions stages, wins,
+or is lost (see [Deal audit trail](../../../../docs/developer/applications/crm.md#93-deal-audit-trail)). These appear in the same `/activities/` feed as
+user-authored entries. There is no dedicated `source` field — use a
+client-side predicate:
+
+```ts
+const isStageChangeAudit = (a: Activity): boolean =>
+  a.type === "note" && a.title === "Stage changed";
+```
+
+System rows arrive already complete: `is_done: true` and `done_at` set
+to the transition timestamp. The `comment` body carries the transition
+line, e.g. `"Discovery → Proposal"`.
+
+**Do not** offer edit, delete, or mark-done controls for these rows —
+the user did not author them and there is nothing left to mark done.
+
+See also [Render system audit Activities differently](../../../../docs/developer/applications/crm.md#165-render-system-audit-activities-differently) below.
+
+## 10.3 Marking an activity done
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/activities/8821/done/" \
+  -H "Authorization: Token $TOKEN"
+```
+
+- No request body.
+- **Idempotent**: the first call flips `is_done=true` and stamps
+  `done_at` with the current server time. Subsequent calls return the
+  same activity with the ORIGINAL `done_at` preserved — the server does
+  not re-stamp on repeat invocations.
+- This matters for offline-capable clients that may retry the same
+  request after a network blip; you will not see the completion time
+  drift forward each time the queue flushes.
+- The response is the full updated Activity object, so the client can
+  replace the row in its local store without a follow-up `GET`.
+
+## 10.4 Schedule semantics
+
+`schedule_from` and `schedule_to` combine to express three intents.
+Pick the shape that matches what you are recording — do not invent
+dates to satisfy both fields:
+
+| `schedule_from` | `schedule_to` | Read as |
+|---|---|---|
+| null | null | A past log entry — what happened, recorded after the fact (e.g. "logged call") |
+| set | null | A scheduled task or deadline with a start time but no fixed end |
+| set | set | A meeting or other time-bounded event |
+
+A call note written ten minutes after the call ended is the first
+shape. A "follow up next Tuesday" task is the second. A 30-minute demo
+on the calendar is the third.
+
+The server does not enforce a relationship between the two fields
+beyond storage. A malformed combination (e.g. `schedule_to` earlier
+than `schedule_from`) is the client's responsibility to prevent — wire
+a simple ordering check into the create form.
+
+## 10.5 Reminders
+
+- `reminder_at` is set by the caller — typically a fixed offset before
+  `schedule_from` (15 minutes before is a common default for meetings).
+- `reminder_sent` is server-managed. **Do not write to it from the
+  client.**
+
+> **Reminder delivery is not currently dispatched server-side.** Set
+> `reminder_at` to track intent and surface a local in-app prompt; the
+> field round-trips correctly. `reminder_sent` will remain `false`
+> until a server-side dispatcher is wired.
+
+In the meantime, you can drive an in-app prompt from `reminder_at` for
+the current user's own owned activities, and feed CRM event
+notifications (see [Notifications](../../../../docs/developer/applications/crm.md#12-notifications) and `/iblai-notification`) into the bell UI.
+
+## 10.6 Attaching an activity
+
+Every activity must attach to a Deal **or** a Person — or both, where
+they agree:
+
+- Posting with neither set returns `400`:
+  ```json
+  { "detail": ["Activity must attach to a `deal` or a `person`."] }
+  ```
+  The serializer raises before any database write — a failed create
+  has no side effects.
+- If both `deal` and `person` are set, the person must equal the
+  person already attached to the deal. A mismatch returns `400` with a
+  field-level error rather than letting orphaned rows appear in the
+  timeline.
+
+A typical create call for a meeting attached to both:
+
+```bash
+curl -X POST "https://api.iblai.app/dm/api/crm/activities/" \
+  -H "Authorization: Token $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "meeting",
+    "title": "Pricing review",
+    "deal": 314,
+    "person": "9c6f4a2e-1b88-4a0e-9b71-2c2f7a1d6e44",
+    "schedule_from": "2026-06-10T16:00:00Z",
+    "schedule_to": "2026-06-10T16:45:00Z",
+    "reminder_at": "2026-06-10T15:45:00Z"
+  }'
+```
+
+The response is the created Activity — ready to splice into the
+timeline view without a re-fetch.
+
+## 16.5 Render system audit Activities differently
+
+When a deal transitions stages (via `move-stage/`, `won/`, or
+`lost/`), the server writes a system Activity with `type === "note"`
+and `title === "Stage changed"`. These appear in the same
+`/api/crm/activities/` list as user-authored notes, calls, and tasks.
+
+In the timeline UI:
+
+- Render them with a distinct icon — a system / arrow glyph works well.
+- **Suppress edit, delete, and mark-done controls.** They are already
+  complete (`is_done: true`, `done_at` set) and immutable in intent.
+- Keep them visually quieter than user-authored entries — smaller text,
+  muted color — so the timeline still reads as a human history with
+  system audit beats woven in.
+- The `comment` body (e.g. `"Discovery → Proposal"`) is the line of
+  record. Use it as the row body.
+
+See [Activities API](../../../../docs/developer/applications/crm.md#76-activities) and [Activity Timeline & Auto-Records](../../../../docs/developer/applications/crm.md#10-activity-timeline--auto-records) for the canonical references this guidance is built on.

--- a/skills/iblai-crm-notification/SKILL.md
+++ b/skills/iblai-crm-notification/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: iblai-crm-notification
+description: Reference for the three CRM notification event types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`) the ibl.ai CRM dispatches after a write commits — payload shapes, recipient routing modes (default / per-Platform configured), and how to surface them in your app. Use when the user mentions CRM notifications, lead/deal alerts, "who gets notified when a deal moves stages", recipient mode configuration, or wiring a CRM-only inbox; see /iblai-crm-overview for setup, /iblai-crm-lead-flow and /iblai-crm-deal-flow for the events' source skills, and /iblai-notification for the bell UI that actually renders these events. This is a REFERENCE skill — it documents the contract; it does NOT build the bell UI.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-notification
+
+Reference skill for the three CRM notification event types. Documents
+when each one fires, the context keys included in the payload, the
+recipient-routing modes available per Platform, and where the developer
+goes next to surface these events in the UI. This skill does NOT build
+the notification bell — that is `/iblai-notification`.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth set up (`/iblai-auth`)
+- MCP and skills set up (`iblai add mcp`)
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user holds a CRM role (`CRM Viewer` is enough to read
+  inbox entries that target them; see `/iblai-rbac`)
+
+## The three CRM notification types
+
+Every CRM write that produces a notification routes through exactly one
+of these three event types. Full payload tables (every `context` key)
+live in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+| `event_type` | Fires when | Source skill | Default recipients |
+|---|---|---|---|
+| `CRM_PERSON_CREATED` | A person row is created via any path — REST `POST /persons/`, the Django admin, or bulk import | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+| `CRM_DEAL_STAGE_CHANGED` | A deal moves between stages via `POST /deals/{id}/move-stage/`, `POST /deals/{id}/won/`, or `POST /deals/{id}/lost/`. No-op transitions (destination stage equals current stage) are SUPPRESSED — no notification | `/iblai-crm-deal-flow` | Platform admins + `deal.owner` |
+| `CRM_PERSON_LINKED_TO_USER` | A person is bound to a Platform user — either by explicit `POST /persons/{id}/link-user/` or implicitly by the auto-link signal when a new user registers with a matching email | `/iblai-crm-lead-flow` | Platform admins + `person.owner` |
+
+"Object owner" is `person.owner` for the two person-scoped events and
+`deal.owner` for the stage-change event. If the owner field is unset on
+the triggering object, the configured recipient mode decides whether to
+fall back to admins or drop the notification — see `## Recipient routing`
+below.
+
+## After-commit dispatch
+
+All three event types dispatch **asynchronously after the writing
+transaction commits**. The CRM signal is observed inside the request, but
+the actual notification send fires from a post-commit hook on the
+database transaction. The practical consequences:
+
+- A write that rolls back — failed validation, database constraint, a
+  `move-stage` call that raises mid-transition — produces no
+  notification. The signal is observed, the dispatch is not.
+- By the time a recipient sees the email, push entry, or inbox row, the
+  underlying record is durably on disk. There are no ghost notifications
+  for state that never persisted.
+- Context keys are snapshotted at signal time from the live object. A
+  template that references `{{ deal_lead_value }}` reads the value as it
+  stood the moment the stage transition committed; later edits to the
+  deal do not re-render or re-send.
+
+Cross-reference: this is the same after-commit rule the [System Overview](../../../docs/developer/applications/crm.md#2-system-overview) "Side
+Effects" block describes, and it is shared with the audit `Activity` row
+that `move-stage`/`won`/`lost` writes alongside the notification (see
+`/iblai-crm-activity`).
+
+## Recipient routing
+
+Every CRM notification template — and any notification type that opts
+into the shared recipients pipeline — can be configured per Platform
+with one of five recipient modes:
+
+| Mode | Effect |
+|---|---|
+| `platform_admins_only` | Deliver to active Platform admins only. The object's owner is ignored. |
+| `object_owner_only` | Deliver to the object's owner. If the owner field is unset, fall back to Platform admins so nothing is silently dropped. |
+| `object_owner_only_strict` | Deliver to the object's owner only. If the owner is unset, no one is notified. Use when the notification is meaningless without an owner. |
+| `platform_admins_and_object_owner` | **Default.** Both audiences receive the notification, deduplicated so an admin who is also the owner does not get two copies. |
+| `custom` | Deliver to a hand-picked list of users, user groups, or RBAC role-policy holders. Admins and the owner are NOT implicitly included. |
+
+When the mode is `custom`, the template's `recipients_custom_recipients`
+field holds a list of dicts. Each entry takes one of three shapes:
+
+```json
+{ "type": "user",        "id": 123 }
+{ "type": "user_group",  "id": 7 }
+{ "type": "rbac_policy", "policy_name": "CRM Manager" }
+```
+
+Entries compose freely — a single list can mix individual users, groups,
+and policy holders. The resolver expands each entry, unions the results,
+deduplicates, and runs the active-Platform-membership filter as a final
+gate. Stale entries (departed users, reassigned policies, drained
+groups) simply contribute zero recipients on that dispatch.
+
+Recipient configuration lives on the **notification template, not the
+CRM models**. Changing it for `CRM_DEAL_STAGE_CHANGED` on a given
+Platform is a `PATCH` against that Platform's template for that type,
+setting `recipients_recipient_mode` and (if `custom`) populating
+`recipients_custom_recipients`. The CRM does not add a separate API
+surface for this — the same template-management endpoints documented in
+`/iblai-notification` handle these three types alongside every other
+notification type on the platform. This skill does NOT modify those
+endpoints; it just documents which event types route through them.
+
+Full mode table, custom-shape examples, the change-recipients workflow,
+and the active-membership filter rules are in
+[`references/notification-types.md`](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/skills/iblai-crm-notification/references/notification-types.md).
+
+## Channels
+
+Email delivery is wired by default for all three CRM event types.
+Per-user notification preferences are honored by the underlying delivery
+machinery — the CRM does not bypass them. Additional channels (in-app
+inbox feed, push notification) follow the template's channel
+configuration, inspected and changed via the same templates API.
+
+The **in-app bell + notification center** that surfaces inbox entries is
+NOT in scope for this skill. Send the developer to `/iblai-notification`
+for the drop-in `<NotificationDropdown>` and `<NotificationDisplay>`
+components.
+
+## Consuming the events in your UI
+
+This is a reference skill. To actually show a user the three CRM event
+types in the browser:
+
+1. Install the bell + center via `/iblai-notification`. That skill ships
+   `components/iblai/notification-bell.tsx` and the
+   `<NotificationDisplay>` page surface (Inbox + Alerts tabs).
+2. The bell's inbox list is a standard notification feed — every
+   delivered notification carries an `event_type` matching one of the
+   three values from the table above. Filter the inbox query to those
+   three values (or any subset) when you want a CRM-only inbox view.
+3. For deeper drill-down (clicking an inbox entry that says "Deal moved
+   to Negotiation" and jumping to the kanban card), wire the
+   `onViewNotifications` callback on `<NotificationDropdown>` to route
+   to the deal detail page built by `/iblai-crm-deal-flow`.
+
+## Verify
+
+End-to-end smoke once the bell is wired:
+
+1. From the kanban built in `/iblai-crm-deal-flow`, move a deal from one
+   stage to another via `POST /deals/{id}/move-stage/`. Make sure the
+   destination stage actually differs from the current one (same-stage
+   moves are suppressed and produce nothing).
+2. Within a few seconds, confirm a `CRM_DEAL_STAGE_CHANGED` row appears
+   in the inbox bell installed by `/iblai-notification` for the deal's
+   owner.
+3. Open the deal's activity timeline (`/iblai-crm-activity`) and confirm
+   the corresponding audit `Activity` row exists with `type=note`,
+   `done=true`, `title="Stage changed"`. The notification and the audit
+   row are written together — if one is missing while the other is
+   present, the transaction split unexpectedly and is worth filing.
+4. Re-run the same `move-stage` call with `stage_code` set to the
+   destination it just reached. The API should return the deal
+   unchanged, no new audit row, and no new notification.
+
+Run `/iblai-ops-test` before reporting done.
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC, seeded defaults
+- `/iblai-crm-lead-flow` — source of `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER`
+- `/iblai-crm-deal-flow` — source of `CRM_DEAL_STAGE_CHANGED`
+- `/iblai-notification` — bell UI + notification center that consumes these events
+- `/iblai-rbac` — required CRM roles
+- `/iblai-auth` — token wiring

--- a/skills/iblai-crm-notification/references/notification-types.md
+++ b/skills/iblai-crm-notification/references/notification-types.md
@@ -1,0 +1,219 @@
+# CRM notification types — reference
+
+Condensed from the ibl.ai CRM developer documentation, [Notifications](../../../../docs/developer/applications/crm.md#12-notifications).
+Use this file as the lookup table when wiring inbox filters, configuring
+recipient routing on a Platform, or building a custom CRM-only inbox surface.
+
+The CRM fires three notification types. Each is configurable per Platform —
+you can change recipients, edit the email/push template content, or toggle
+the type off entirely through the notification templates API. The mechanics
+(template storage, channel routing, preference resolution) are the same
+machinery every other notification type in the system uses; cross-reference
+the notification system documentation (`/iblai-notification`) for the full
+template payload and lifecycle. This file covers only what is CRM-specific:
+when each type fires, the context keys the template can interpolate, and how
+recipient routing works.
+
+---
+
+## 1. The three types
+
+| Type | Fires when | Default recipients |
+|---|---|---|
+| `CRM_PERSON_CREATED` | A person is created (API, admin, or import) | Platform admins + person owner |
+| `CRM_DEAL_STAGE_CHANGED` | A deal moves between stages (`move-stage` / `won` / `lost`). No-op transitions (same stage to same stage) are suppressed. | Platform admins + deal owner |
+| `CRM_PERSON_LINKED_TO_USER` | A person is bound to a Platform user — either by the auto-link signal that matches on email when a new user registers, or by an explicit call to `/link-user/` | Platform admins + person owner |
+
+### Context keys per type
+
+Every notification carries a `context` object the template interpolates
+into the rendered title/body/email. The keys provided for each type:
+
+**`CRM_PERSON_CREATED`**
+
+| Key | Source |
+|---|---|
+| `person_id` | `person.id` |
+| `person_name` | `person.name` |
+| `person_email` | `person.email` |
+| `person_lifecycle_stage` | `person.lifecycle_stage` |
+| `person_job_title` | `person.job_title` |
+| `owner_username` | `person.owner.username` |
+
+**`CRM_DEAL_STAGE_CHANGED`**
+
+| Key | Source |
+|---|---|
+| `deal_id` | `deal.id` |
+| `deal_title` | `deal.title` |
+| `deal_status` | `deal.status` (`open` / `won` / `lost`) |
+| `deal_lead_value` | `deal.lead_value` |
+| `deal_currency` | `deal.currency` |
+| `from_stage_code` | Source stage's `code` |
+| `from_stage_name` | Source stage's display name |
+| `to_stage_code` | Destination stage's `code` |
+| `to_stage_name` | Destination stage's display name |
+| `person_name` | `deal.person.name` |
+| `actor_username` | Username of the user that called `move-stage`/`won`/`lost` |
+
+**`CRM_PERSON_LINKED_TO_USER`**
+
+| Key | Source |
+|---|---|
+| `person_id` | `person.id` |
+| `person_name` | `person.name` |
+| `person_email` | `person.email` |
+| `linked_user_id` | The Platform user's id |
+| `linked_user_username` | The Platform user's username |
+| `linked_user_email` | The Platform user's email |
+
+### After-commit dispatch rule
+
+All three are dispatched asynchronously **after the writing transaction
+commits**. If the write that triggered the signal is rolled back — a
+validation failure further down the request, a `move-stage` call that
+raises mid-transition — no notification is produced. The signal is
+observed, but the dispatch only fires on the post-commit hook, so
+consumers never see ghost notifications for state that never persisted.
+
+Context keys are populated at signal time from the live object. A
+template that references `{{ deal_lead_value }}` reads the value as it
+stood the moment the stage transition committed; later edits to the deal
+do not re-render or re-send the notification.
+
+---
+
+## 2. Recipient modes
+
+Every CRM notification template — and in fact any notification type that
+opts into the shared recipients pipeline — can be configured per Platform
+with one of five recipient modes:
+
+| Mode | Effect |
+|---|---|
+| `platform_admins_only` | Deliver only to active Platform admins. The object's owner is ignored. |
+| `object_owner_only` | Deliver to the object's owner. If the owner field is unset, fall back to Platform admins so the notification is not silently dropped. |
+| `object_owner_only_strict` | Deliver to the object's owner only. If the owner is unset, no one is notified. Use when the notification is meaningless without an owner. |
+| `platform_admins_and_object_owner` | Default. Both audiences receive the notification, deduplicated so an admin who is also the owner does not get two copies. |
+| `custom` | Deliver to a hand-picked list of users, user groups, or RBAC role-policy holders. Admins and the owner are not implicitly included. |
+
+"Object owner" refers to the `owner` field on the triggering object:
+
+- For `CRM_PERSON_CREATED` and `CRM_PERSON_LINKED_TO_USER`, that is `person.owner`.
+- For `CRM_DEAL_STAGE_CHANGED`, that is `deal.owner`.
+
+If an object is created without an owner — for instance, an imported
+person row that has no assigned account manager yet — the fallback
+behavior described in the table applies. There is no separate concept of
+an organization-level owner being used for routing.
+
+---
+
+## 3. Custom recipient shape
+
+When the mode is `custom`, the template's `recipients_custom_recipients`
+field holds a list. Each entry takes one of three shapes:
+
+```json
+{"type": "user", "id": 123}
+```
+
+```json
+{"type": "user_group", "id": 7}
+```
+
+```json
+{"type": "rbac_policy", "policy_name": "CRM Manager"}
+```
+
+The three types compose freely — a single custom list can mix individual
+users, groups, and policy holders. The resolver expands each entry,
+unions the results, deduplicates, and then runs the active-Platform-
+membership filter described below.
+
+Custom recipients are re-filtered against active Platform membership at
+delivery time. A stale entry — a user who has left the Platform, a group
+whose roster has changed, a policy that has been reassigned — simply
+contributes no one to that send. You do not need to prune the list
+manually when membership changes; the resolver does it on every dispatch.
+This means a single custom recipient list can be maintained centrally
+even if individual users come and go.
+
+If every entry in a custom list resolves to zero active members, the
+notification produces no deliveries for that Platform on that event. It
+is not auto-promoted back to the default mode; "no recipients" is
+treated as a valid configured outcome.
+
+---
+
+## 4. Changing recipients
+
+Recipient configuration lives on the notification template, **not** on
+the CRM models. To change who hears about, say, deal stage transitions
+on a given Platform, `PATCH` the template for `CRM_DEAL_STAGE_CHANGED`
+on that Platform via the notification templates API and set:
+
+- `recipients_recipient_mode` — one of the five modes from section 2.
+- `recipients_custom_recipients` — required when the mode is `custom`; a
+  list of target dicts as shown in section 3. Ignored for the other modes.
+
+The exact endpoint path, full payload schema, and authentication
+requirements are documented under the notification system
+(`/iblai-notification`). The CRM does not add a separate API surface for
+this — the same template management endpoints that handle every other
+notification type handle these three.
+
+Toggling a type off entirely is also done at the template level via the
+standard enable/disable flag on the notification template. The CRM
+signal still fires; the callback short-circuits before resolving
+recipients or dispatching. There is no CRM-side setting to suppress
+notifications.
+
+---
+
+## 5. Channels
+
+Email delivery is wired by default for all three CRM notifications.
+Whether a given recipient actually receives mail depends on their
+individual notification preferences, which are honored by the underlying
+delivery machinery — the CRM does not bypass user preferences.
+
+Additional channels (in-app feed, push notification) follow the
+template's channel configuration if added there; the CRM callbacks
+themselves dispatch email. Consult the templates API
+(`/iblai-notification`) to inspect or change the active channel set per
+type, the same way you change recipients.
+
+---
+
+## 6. Diagram — notification routing
+
+```mermaid
+flowchart LR
+    E[CRM event - person created, deal stage change, person linked] --> S[Notification service - post-commit dispatch]
+    S --> R{Recipient mode}
+    R -->|platform_admins_only| A[Active Platform admins]
+    R -->|object_owner_only / strict| O[Object owner - person.owner or deal.owner]
+    R -->|platform_admins_and_object_owner default| AO[Admins + owner deduped]
+    R -->|custom| C[Custom users / user groups / RBAC policy holders]
+    A --> F[Active Platform membership filter]
+    O --> F
+    AO --> F
+    C --> F
+    F --> M[Email + push delivery, honoring per-user preferences]
+```
+
+The membership filter is the last gate before delivery. Every resolved
+recipient — regardless of mode — is checked against the Platform's
+active membership at dispatch time. A user who has been removed from the
+Platform between the event and the dispatch does not receive the
+notification, even if they appear in a custom list, were the recorded
+`owner`, or were an admin at the time the event fired.
+
+---
+
+## Related references
+
+- Source documentation: [IBL CRM Developer Documentation — Notifications](../../../../docs/developer/applications/crm.md#12-notifications)
+- Bell UI + template management API: `/iblai-notification`
+- Event sources: `/iblai-crm-lead-flow` (person events), `/iblai-crm-deal-flow` (stage events)

--- a/skills/iblai-crm-tag/SKILL.md
+++ b/skills/iblai-crm-tag/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: iblai-crm-tag
+description: Build the CRM tag manager — CRUD on /api/crm/tags/ with hex color picker, a reusable tag chip, attach/detach controls on Person/Organization/Deal detail pages, and tag filters on list views with OR semantics. Use when the user mentions CRM tags, labels, tagging, color chips, tag manager, attach tag, detach tag, filter by tag, or wants to add segmentation labels to people/orgs/deals. See /iblai-crm-overview for setup and RBAC, /iblai-crm-lead-flow for the person/org host pages, /iblai-crm-deal-flow for the deal host pages, /iblai-rbac for the CRM User role, and /iblai-auth for token wiring.
+globs:
+alwaysApply: false
+---
+
+# /iblai-crm-tag
+
+Build the CRM tag surface — tag CRUD dialog, color chip, attach/detach
+controls on Person, Organization, and Deal pages, plus a `?tags=` filter
+on every CRM list view.
+
+Do NOT add custom styles, colors, or CSS overrides to ibl.ai SDK components.
+They ship with their own styling. Keep the components as-is.
+Do NOT implement dark mode unless the user explicitly asks for it.
+
+When building custom UI around SDK components, use the ibl.ai brand:
+- **Primary**: `#0058cc`, **Gradient**: `linear-gradient(135deg, #00b0ef, #0058cc)`
+- **Button**: `bg-gradient-to-r from-[#2563EB] to-[#93C5FD] text-white`
+- **Font**: System sans-serif stack, **Style**: shadcn/ui new-york variant
+- Follow the component hierarchy: use ibl.ai SDK components
+  (`@iblai/iblai-js`) first, then shadcn/ui for everything else
+  (`npx shadcn@latest add <component>`). Do NOT write custom components
+  when an ibl.ai or shadcn equivalent exists. Both share the same
+  Tailwind theme and render in ibl.ai brand colors automatically.
+- Follow [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) for
+  colors, typography, spacing, and component styles.
+
+You MUST run `/iblai-ops-test` before telling the user the work is ready.
+
+After all work is complete, start a dev server (`pnpm dev`) so the user
+can see the result at http://localhost:3000.
+
+`iblai.env` is NOT a `.env.local` replacement — it only holds the 3
+shorthand variables (`DOMAIN`, `PLATFORM`, `TOKEN`). Next.js still reads
+its runtime env vars from `.env.local`.
+
+Use `pnpm` as the default package manager. Fall back to `npm` if pnpm
+is not installed. The generated app should live in the current directory,
+not in a subdirectory.
+
+> **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
+
+## Prerequisites
+
+- Auth must be set up first (`/iblai-auth`) — provides the platform
+  `Authorization: Token <token>` header used by every call below.
+- MCP and skills must be set up: `iblai add mcp`.
+- `iblai.env` populated with `PLATFORM`, `DOMAIN`, `TOKEN`. If missing,
+  tell the user to download the template:
+  `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`
+- The signed-in user must hold the **CRM User** role (or higher) on the
+  Platform. CRM User unlocks `Ibl.CRM/Tags/list`, `read`, `action`,
+  `write`, and `delete`. CRM Viewer can only see tags, not write or
+  attach them. See `/iblai-rbac` for the role matrix and how to assign
+  CRM roles to a user.
+- At least one host surface should already exist so there is something
+  to tag. Run `/iblai-crm-lead-flow` (people + organizations) or
+  `/iblai-crm-deal-flow` (deals) first if you have not yet.
+
+## What you'll build
+
+1. A **tag manager dialog** — list, create, edit, and delete tags. Color
+   input is validated client-side against `^#[0-9A-Fa-f]{6}$` before
+   submit so the user sees errors immediately (the server applies the
+   same regex).
+2. A **tag chip** component — renders `{id, name, color}` with the hex
+   color as background. Optional `x` button for detach.
+3. **Attach / detach controls** on Person, Organization, and Deal detail
+   pages. The contract is uniform: `POST /{host}/{id}/tags/` with
+   `{tag_id}`, `DELETE /{host}/{id}/tags/{tag_id}/`.
+4. A **tag filter** on Person, Organization, and Deal list views —
+   `?tags=<id>&tags=<id2>` with **OR** semantics. Results are
+   de-duplicated by the backend.
+
+## Step 0: Check for CLI updates
+
+```bash
+iblai --version    # upgrade if outdated: pip install --upgrade iblai-app-cli OR npm i -g @iblai/cli@latest
+```
+
+## Step 1: Install shadcn primitives
+
+```bash
+npx shadcn@latest add dialog input form popover command badge button
+```
+
+`dialog` powers the tag manager and the delete-confirmation modal.
+`popover` + `command` together make a searchable tag combobox for the
+attach control. `badge` is the visual base for the tag chip. `input`
++ `form` cover the create/edit form. `button` covers actions.
+
+## Step 2: Typed API client wrapper
+
+Reuse the auth token wired in `/iblai-auth`. Create
+`lib/iblai/crm-tags.ts` with one wrapper per route. Base URL is
+`${NEXT_PUBLIC_API_BASE_URL}/api/crm`.
+
+```typescript
+// lib/iblai/crm-tags.ts
+const BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/crm`;
+const HEX = /^#[0-9A-Fa-f]{6}$/;
+
+export type Tag = {
+  id: number;
+  platform: number;
+  name: string;
+  color: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TagChip = Pick<Tag, "id" | "name" | "color">;
+
+export type Assignment = { assignment_id: number; tag: TagChip };
+
+function authHeaders(token: string) {
+  return {
+    Authorization: `Token ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+// Tag CRUD
+export async function listTags(token: string, params: { name?: string; page?: number } = {}) {
+  const qs = new URLSearchParams();
+  if (params.name) qs.set("name", params.name);
+  if (params.page) qs.set("page", String(params.page));
+  const r = await fetch(`${BASE}/tags/?${qs}`, { headers: authHeaders(token) });
+  if (!r.ok) throw new Error(`listTags ${r.status}`);
+  return r.json() as Promise<{ count: number; results: Tag[]; next_page: number | null; previous_page: number | null }>;
+}
+
+export async function createTag(token: string, body: { name: string; color?: string; metadata?: Record<string, unknown> }) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/`, { method: "POST", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function patchTag(token: string, id: number, body: Partial<Pick<Tag, "name" | "color" | "metadata">>) {
+  if (body.color && !HEX.test(body.color)) {
+    throw new Error("Color must match ^#[0-9A-Fa-f]{6}$");
+  }
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "PATCH", headers: authHeaders(token), body: JSON.stringify(body) });
+  if (!r.ok) throw await r.json();
+  return r.json() as Promise<Tag>;
+}
+
+export async function deleteTag(token: string, id: number) {
+  const r = await fetch(`${BASE}/tags/${id}/`, { method: "DELETE", headers: authHeaders(token) });
+  if (!r.ok && r.status !== 204) throw new Error(`deleteTag ${r.status}`);
+}
+
+// Uniform host attach / detach. `host` is "persons" | "organizations" | "deals".
+export type Host = "persons" | "organizations" | "deals";
+
+export async function attachTag(token: string, host: Host, hostId: string | number, tagId: number): Promise<Assignment> {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/`, {
+    method: "POST",
+    headers: authHeaders(token),
+    body: JSON.stringify({ tag_id: tagId }),
+  });
+  // 201 = created; 409 = already attached, body still carries assignment_id + tag.
+  if (r.status === 201 || r.status === 409) return r.json();
+  throw await r.json();
+}
+
+export async function detachTag(token: string, host: Host, hostId: string | number, tagId: number) {
+  const r = await fetch(`${BASE}/${host}/${hostId}/tags/${tagId}/`, {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+  // 204 = removed; 404 = not attached (treat as no-op success).
+  if (r.status !== 204 && r.status !== 404) throw new Error(`detachTag ${r.status}`);
+}
+```
+
+See `references/tags-api.md` for full endpoint table, error shapes, and
+filter semantics.
+
+## Step 3: Tag manager dialog
+
+Create `components/crm/tag-manager-dialog.tsx`. It is a single dialog
+that lists all tags from `GET /tags/`, lets the user create a new tag,
+edit an existing tag, or delete one.
+
+Requirements:
+
+- **Create form**: `name` (required, ≤ 64 chars, unique-per-Platform —
+  server-enforced) and `color` (`<input type="color">` is fine; on
+  submit, validate the value against `^#[0-9A-Fa-f]{6}$` before
+  calling `createTag`). Surface the server's 400 errors verbatim —
+  duplicate name, blank name, > 64 chars, bad hex.
+- **Edit**: inline rename + recolor calls `patchTag`. Renames take
+  effect immediately on every host chip — the chip renders from the
+  Tag row, not from the assignment.
+- **Delete**: opens a confirmation modal — see the destructive cascade
+  callout below. Disable the delete button until the user types the
+  tag name to confirm, or at minimum require a second click.
+
+The dialog reads the token from the auth store wired by `/iblai-auth`.
+
+## Step 4: Tag chip component
+
+Create `components/crm/tag-chip.tsx`. Renders `{id, name, color}` as a
+shadcn `Badge` with `style={{ backgroundColor: tag.color, color: '#fff' }}`.
+Accept an optional `onDetach: () => void` prop — when supplied, render
+a small `x` icon button inside the chip; otherwise render the chip as
+read-only.
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import type { TagChip as TTagChip } from "@/lib/iblai/crm-tags";
+
+export function TagChip({ tag, onDetach }: { tag: TTagChip; onDetach?: () => void }) {
+  return (
+    <Badge style={{ backgroundColor: tag.color, color: "#fff" }} className="gap-1">
+      {tag.name}
+      {onDetach ? (
+        <button onClick={onDetach} aria-label={`Detach ${tag.name}`} className="ml-1">
+          <X className="h-3 w-3" />
+        </button>
+      ) : null}
+    </Badge>
+  );
+}
+```
+
+The `tags` array is **always present** on every Person, Organization,
+and Deal list/detail response — empty array, never `null`. So your
+renderer can iterate unconditionally.
+
+## Step 5: Attach control on host detail pages
+
+On Person, Organization, and Deal detail pages, add an "Add tag"
+button that opens a shadcn `Popover` containing a `Command` combobox.
+Populate the combobox with `listTags(token)` (search-as-you-type by
+filtering client-side, or pass `name=` to the API for large libraries).
+
+On select:
+
+```typescript
+const { assignment_id, tag } = await attachTag(token, host, hostId, selectedTagId);
+// Optimistically add `tag` to the local host.tags array; assignment_id is for
+// future detach reconciliation, not required for the chip itself.
+```
+
+Edge cases:
+
+- **409 Conflict** — the tag is already attached. The response body
+  still carries the existing `assignment_id` + `tag`, so you can
+  reconcile local state without a re-fetch and **must not** show a red
+  error toast. Treat 409 as a no-op success.
+- **404 Not Found** — the tag id is not in this Platform. Show
+  "Tag not found." The API never leaks existence across Platforms.
+
+## Step 6: Detach control
+
+Render the host's `tags` array as `TagChip` components with `onDetach`
+wired to `detachTag(token, host, hostId, tag.id)`.
+
+Edge case:
+
+- **404 Not Found** on detach means the tag was not attached. Detach
+  is **not** idempotent server-side — a retried DELETE returns 404,
+  not 204. Client code should treat both as the same success state.
+  The wrapper above already does this.
+
+## Step 7: Tag filter on list views
+
+Wire a multi-select tag picker into the Person, Organization, and Deal
+list pages.
+
+The list endpoints accept repeated or comma-separated `tags`:
+
+```
+GET /api/crm/persons/?tags=7&tags=12
+GET /api/crm/persons/?tags=7,12
+```
+
+Both forms have **OR** semantics — a record matching any selected tag
+appears once (the backend de-duplicates). The filter composes with
+every other filter on the same endpoint, e.g.:
+
+```
+GET /api/crm/persons/?tags=7&lifecycle_stage=customer&owner=4
+```
+
+Implementation: bind the selected tag-ids to `URLSearchParams.append`
+so a `tags` array becomes repeated params, then refetch the list.
+
+## Destructive cascade callout
+
+> **Deleting a tag silently removes it from every Person, Organization,
+> and Deal it is attached to.** `DELETE /tags/{id}/` cascades — there
+> is no preview, no soft-delete, and no undo.
+
+Best practice [confirm before deleting a tag](../../../docs/developer/applications/crm.md#167-confirm-before-deleting-a-tag): gate the delete button behind a confirmation modal
+that **names the tag explicitly** ("Delete tag *Enterprise*?"), states
+the consequence ("This will remove the tag from N records across people,
+organizations, and deals."), and requires an affirmative second action
+(typing the tag name or clicking a destructive button), not a single
+"OK". Optionally pre-fetch impact counts:
+
+```
+GET /api/crm/persons/?tags={id}&page_size=1   → response.count
+GET /api/crm/organizations/?tags={id}&page_size=1
+GET /api/crm/deals/?tags={id}&page_size=1
+```
+
+See `references/tags-api.md` for the full endpoint contract, error
+shapes, and host attach/detach matrix.
+
+## Verify
+
+Run `/iblai-ops-test` before reporting done:
+
+1. `pnpm build` — must pass with zero errors.
+2. `pnpm dev` and visit the surface in the browser:
+   - Open the tag manager. Try to create a tag with color `#FFF`
+     (three digits) — the client should reject it before the request
+     leaves; if you bypass the client check, the server returns
+     `400 {"color": ["Color must be a hex string like \`#3F6BFF\`."]}`.
+   - Create a valid tag (`name`: `Enterprise`, `color`: `#3F6BFF`).
+   - On a Person detail page, attach the tag. Confirm the chip
+     renders. Click attach a second time — UI must not flash an
+     error (409 path).
+   - On an Organization detail page, attach the same tag.
+   - On a Deal detail page, attach the same tag.
+   - Detach the tag from the Person — chip disappears.
+   - On the Person list view, filter by the tag (`?tags=<id>`) and
+     confirm only tagged people remain.
+   - Trigger the delete-tag confirmation modal — confirm copy names
+     the tag and warns about cascade.
+3. Screenshot:
+   ```bash
+   npx playwright screenshot http://localhost:3000/crm/tags /tmp/tags.png
+   ```
+
+## Related skills
+
+- `/iblai-crm-overview` — setup, RBAC
+- `/iblai-crm-lead-flow` — attach tags to persons and organizations
+- `/iblai-crm-deal-flow` — attach tags to deals; filter board by tag
+- `/iblai-rbac` — CRM User role required for tag writes
+- `/iblai-auth` — token wiring

--- a/skills/iblai-crm-tag/references/tags-api.md
+++ b/skills/iblai-crm-tag/references/tags-api.md
@@ -1,0 +1,240 @@
+# CRM Tags — API reference
+
+Condensed from the [Tags API](../../../../docs/developer/applications/crm.md#77-tags) (Tags resource) and [Tagging](../../../../docs/developer/applications/crm.md#11-tagging) (Tagging workflow).
+
+> **Base URL:** `${NEXT_PUBLIC_API_BASE_URL}/api/crm`
+> **Auth:** `Authorization: Token <token>` (same token wired by `/iblai-auth`)
+> **Scope:** Tags are scoped to your Platform. Existence across Platforms is
+> never leaked — a 404 means "not in your Platform" or "does not exist," and
+> the API does not distinguish.
+
+## Mental model
+
+- **Tag rows are the taxonomy; assignments are the chips you see on a record.**
+- A single Tag (`{name, color}`) lives once and may be attached to many host
+  records of different types.
+- Host serializers (Person, Organization, Deal) expose a read-only `tags`
+  array on every list and detail response. The array is always present —
+  empty array, never `null`. No second call is needed to render chips.
+
+## Tag CRUD
+
+| Method | Path | Purpose | Permission |
+|---|---|---|---|
+| GET | `/tags/` | List tags. Query: `name`, `created_at__gte`, `created_at__lte`, `page`, `page_size` | `Ibl.CRM/Tags/list` |
+| POST | `/tags/` | Create a tag | `Ibl.CRM/Tags/action` |
+| GET | `/tags/{id}/` | Retrieve one tag | `Ibl.CRM/Tags/read` |
+| PUT | `/tags/{id}/` | Replace editable fields | `Ibl.CRM/Tags/write` |
+| PATCH | `/tags/{id}/` | Patch supplied fields | `Ibl.CRM/Tags/write` |
+| DELETE | `/tags/{id}/` | Delete the tag — cascades to every host | `Ibl.CRM/Tags/delete` |
+
+### Tag shape
+
+```json
+{
+  "id": 7,
+  "platform": 1,
+  "name": "Enterprise",
+  "color": "#3F6BFF",
+  "metadata": {"order": 1},
+  "created_at": "2026-02-08T09:12:01Z",
+  "updated_at": "2026-02-08T09:12:01Z"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | integer | Server-assigned |
+| `platform` | integer | Owning Platform id |
+| `name` | string | Up to 64 chars, unique-per-Platform, **case-sensitive** after `.strip()` |
+| `color` | string | Hex `#RRGGBB`. Defaults to `#888888`. Six hex digits required — `#FFF` shorthand is rejected |
+| `metadata` | object | Free-form JSON, defaults to `{}` |
+| `created_at` / `updated_at` | datetime | Server-managed |
+
+### Hex color regex
+
+The server validates `color` against:
+
+```
+^#[0-9A-Fa-f]{6}$
+```
+
+Validate the same regex client-side **before** submit so the user sees the
+error immediately rather than on round-trip. Three-digit shorthand and
+named CSS colors are rejected.
+
+### POST `/tags/` body
+
+```json
+{"name": "Enterprise", "color": "#3F6BFF", "metadata": {"order": 1}}
+```
+
+### 400 errors
+
+```json
+{"name": ["A Tag with this name already exists in this Platform."]}
+{"name": ["Name must not be blank."]}
+{"name": ["Name must be at most 64 characters."]}
+{"color": ["Color must be a hex string like `#3F6BFF`."]}
+```
+
+### Rename behavior
+
+PATCH on `name` or `color` takes effect **immediately on every host** that
+carries the tag chip. Chips render `{id, name, color}` live from the Tag
+row, so a rename updates everywhere the tag appears without touching the
+assignment tables.
+
+### DELETE — destructive cascade
+
+> **DESTRUCTIVE.** Deleting a Tag silently cascades: every assignment to
+> every Person, Organization, and Deal is removed atomically. No preview,
+> no confirmation step from the API, no undo. A tag deleted by mistake
+> must be recreated by hand and re-attached to every record.
+
+Response: `204 No Content`. UI **must** carry the warning — see best
+practice [confirm before deleting a tag](../../../../docs/developer/applications/crm.md#167-confirm-before-deleting-a-tag). Pre-fetch impact counts with `?tags={id}&page_size=1`
+against each host list endpoint and surface them in the confirmation
+modal.
+
+## Host attach / detach (uniform contract)
+
+The contract is identical across host types — only the path prefix changes.
+`{host}` is one of `persons`, `organizations`, `deals`. Person and
+Organization ids are UUIDs; Deal ids are integers.
+
+| Method | Path | Purpose | Permission |
+|---|---|---|---|
+| POST | `/persons/{person_id}/tags/` | Attach tag to a person | `Ibl.CRM/Tags/write` |
+| DELETE | `/persons/{person_id}/tags/{tag_id}/` | Detach tag from a person | `Ibl.CRM/Tags/write` |
+| POST | `/organizations/{organization_id}/tags/` | Attach tag to an organization | `Ibl.CRM/Tags/write` |
+| DELETE | `/organizations/{organization_id}/tags/{tag_id}/` | Detach tag from an organization | `Ibl.CRM/Tags/write` |
+| POST | `/deals/{deal_id}/tags/` | Attach tag to a deal | `Ibl.CRM/Tags/write` |
+| DELETE | `/deals/{deal_id}/tags/{tag_id}/` | Detach tag from a deal | `Ibl.CRM/Tags/write` |
+
+**Critical permission rule.** All six attach/detach routes are gated by
+`Ibl.CRM/Tags/write`. Holding `Ibl.CRM/Persons/write`,
+`Ibl.CRM/Organizations/write`, or `Ibl.CRM/Deals/write` does **not**
+allow the caller to tag the record. A sales rep with full deal-edit rights
+but no tag-write rights still gets `403 Forbidden` from
+`POST /deals/{id}/tags/`. Check tag-write **separately** from host-write
+when deciding whether to render the "Add tag" affordance — see [permission-aware affordances](../../../../docs/developer/applications/crm.md#1611-permission-aware-affordances).
+
+### Attach request
+
+```json
+{"tag_id": 7}
+```
+
+`tag_id` is required, integer, must be ≥ 1, must belong to your Platform.
+
+### Attach `201 Created`
+
+```json
+{
+  "assignment_id": 532,
+  "tag": {"id": 7, "name": "Enterprise", "color": "#3F6BFF"}
+}
+```
+
+The embedded `tag` lets the client render the chip with no second
+round-trip.
+
+### Attach `409 Conflict` — already attached
+
+Same shape as 201, but `assignment_id` is the **existing** row:
+
+```json
+{
+  "detail": "Tag already attached.",
+  "assignment_id": 488,
+  "tag": {"id": 7, "name": "Enterprise", "color": "#3F6BFF"}
+}
+```
+
+Treat 409 as a **no-op success**. The user clicked twice or two tabs raced;
+the desired state is already in place. Use the returned `assignment_id`
+to reconcile local state without a re-fetch. Do **not** show a red
+error toast.
+
+### Attach errors
+
+| Status | Meaning |
+|---|---|
+| 400 | `{"tag_id": ["This field is required."]}` or `["Ensure this value is greater than or equal to 1."]` |
+| 403 | Missing `Ibl.CRM/Tags/write` |
+| 404 | Host id unknown, host on another Platform, or `{"detail": "Tag not found in this platform."}` |
+
+### Detach `204 No Content`
+
+Removes the assignment row only. The Tag itself is untouched.
+
+### Detach `404 Not Found` — treat as no-op
+
+```json
+{"detail": "Tag not attached to this record."}
+```
+
+Detach is **not idempotent** server-side — a second DELETE for the same
+pair returns 404, not 204. From the user's point of view both responses
+mean the tag is gone, so client code should treat 204 and 404 identically
+when reconciling local state.
+
+## Filtering by tag
+
+All three host list endpoints (`/persons/`, `/organizations/`, `/deals/`)
+accept a `tags` filter with **OR** semantics. Two equivalent forms:
+
+```
+GET /api/crm/persons/?tags=7&tags=12
+GET /api/crm/persons/?tags=7,12
+```
+
+Both queries return every person tagged with `7` *or* `12`. A record
+carrying both tags appears **once** — the backend de-duplicates, no
+client-side `DISTINCT` step needed.
+
+`tags` composes with every other filter on the list endpoint:
+
+```
+GET /api/crm/persons/?tags=7&lifecycle_stage=customer&owner=4
+```
+
+Response uses the standard pagination envelope:
+
+```json
+{"count": 14, "next_page": null, "previous_page": null, "results": [...]}
+```
+
+`next_page` and `previous_page` are integer page numbers or `null` at the
+boundaries — not URLs. Walk pages with `?page=N`. `page_size` is
+Platform-configurable; default may be smaller than your data set. See
+[pagination best practices](../../../../docs/developer/applications/crm.md#169-pagination).
+
+## Reading tags off a host
+
+Person, Organization, and Deal serializers expose a read-only `tags`
+array on every list and detail response:
+
+```json
+"tags": [
+  {"id": 7, "name": "VIP", "color": "#3F6BFF"},
+  {"id": 12, "name": "trial", "color": "#22AA66"}
+]
+```
+
+The array is **always present** — empty array, never `null` or missing.
+Renderers can iterate unconditionally.
+
+## RBAC summary
+
+| Verb | Permission | Default CRM role with it |
+|---|---|---|
+| List tags | `Ibl.CRM/Tags/list` | CRM Viewer + above |
+| Read tag | `Ibl.CRM/Tags/read` | CRM Viewer + above |
+| Create tag | `Ibl.CRM/Tags/action` | CRM User + above |
+| Update tag | `Ibl.CRM/Tags/write` | CRM User + above |
+| Delete tag | `Ibl.CRM/Tags/delete` | CRM User + above |
+| Attach / detach on any host | `Ibl.CRM/Tags/write` | CRM User + above |
+
+See `/iblai-rbac` for the full CRM role matrix.


### PR DESCRIPTION
## What

Three auxiliary skills that mount inside the lead-flow / deal-flow surfaces:

- **`/iblai-crm-activity`** — timeline panel that mounts inside a Person or Deal detail surface. Lists calls, meetings, emails, notes, tasks, lunches, and deadlines; schedules them via `schedule_from` / `schedule_to`; sets reminders via `reminder_at`; marks done idempotently via `POST /activities/{id}/done/`. Renders server-emitted stage-change audit rows distinctly so users can't edit them.
- **`/iblai-crm-tag`** — tag manager (`/api/crm/tags/` CRUD with hex color picker validated against `^#[0-9A-Fa-f]{6}$`), reusable tag chip, uniform attach/detach controls on Person / Organization / Deal detail pages, OR-semantics filter on list views. Calls out the destructive cascade on `DELETE /tags/{id}/`.
- **`/iblai-crm-notification`** — reference for the three CRM event types (`CRM_PERSON_CREATED`, `CRM_DEAL_STAGE_CHANGED`, `CRM_PERSON_LINKED_TO_USER`), after-commit dispatch rule, default recipient routing + per-Platform custom recipient shape, and how to filter the `/iblai-notification` bell to a CRM-only inbox.

Each includes condensed `references/`, Cursor + Codex adapters, and a `CLAUDE.md` skill-table row.

## Why

These three skills bolt onto the funnel rather than replace it — a developer can ship lead-flow + deal-flow (PR 2) and add timeline / tags / notification wiring later, or merge all three together. Keeping them in their own PR isolates the timeline rendering rules, the tag attach/detach contract, and the notification routing reference from the larger funnel review.

## Depends on

PR 2 (`crm-2-funnel`) — `iblai-crm-activity` mounts inside lead-flow / deal-flow surfaces; tag attach/detach references the same hosts; notification documents the events those skills fire.