### PR TITLE
feat(builds): tenant-lock & in-app-purchase build-time flags for Tauri shell

### DIFF
--- a/skills/iblai-vibe-ops-build/SKILL.md
+++ b/skills/iblai-vibe-ops-build/SKILL.md
@@ -79,6 +79,57 @@ This configures:
 Without this, mobile SSO will redirect to an HTTPS URL that stays inside
 the system browser session and never returns to the app.
 
+## Build-Time Flags (Tenant Lock & In-App Purchase)
+
+The Tauri shell exposes two build-time flags so a **single codebase can
+produce differently-configured builds** — e.g. one desktop/mobile build
+locked to tenant A and another locked to tenant B, both served from the same
+app URL. The values are baked in at `cargo build` time via Rust's
+`option_env!`, so they are set as **environment variables in the build shell**
+(not `iblai.env`, which is CLI config) before running the build:
+
+| Env var | Command exposed to JS | Default | Effect |
+|---|---|---|---|
+| `IBL_TENANT` | `get_locked_tenant` → `string` | `""` (unlocked) | Locks the build to one tenant: the frontend forces login to it and hides tenant switching. |
+| `IBL_ALLOW_IN_APP_PURCHASE` | `allow_in_app_purchase` → `bool` | `false` | Enables in-app purchase UI. Truthy values: `1`/`true`/`yes`/`on` (case-insensitive). |
+
+Set them before the build (they are read at compile time, so they must be in
+the environment when cargo compiles `src-tauri`):
+
+```bash
+# tenant-locked build with in-app purchase enabled
+IBL_TENANT=acme IBL_ALLOW_IN_APP_PURCHASE=true iblai builds build
+```
+
+In CI, set them as env on the build step:
+
+```yaml
+- name: Build
+  env:
+    IBL_TENANT: acme
+    IBL_ALLOW_IN_APP_PURCHASE: "true"
+  run: iblai builds build
+```
+
+`src-tauri/build.rs` declares `cargo:rerun-if-env-changed` for both, so cargo
+recompiles when a value changes between builds. Unset → the "off" default, so
+a normal build is unaffected.
+
+**Frontend consumption** (app code, outside this template) invokes the
+commands and reacts to them:
+
+```ts
+import { invoke } from '@tauri-apps/api/core';
+
+const lockedTenant = await invoke<string>('get_locked_tenant'); // '' = unlocked
+const iap = await invoke<boolean>('allow_in_app_purchase');
+```
+
+When `get_locked_tenant` returns a non-empty key, force the user onto that
+tenant (logging out of any other) and hide the tenant switcher. The commands
+are registered in `src-tauri/src/lib.rs` (`generate_handler!`); no extra ACL
+entry is needed since they are application commands.
+
 ## App Icons
 
 Generate platform-ready icons from your logo (works for all platforms):

--- a/skills/iblai-vibe-ops-build/assets/tauri/src-tauri/build.rs
+++ b/skills/iblai-vibe-ops-build/assets/tauri/src-tauri/build.rs
@@ -1,3 +1,8 @@
 fn main() {
+    // `option_env!` bakes these in at compile time, so cargo must rebuild when
+    // they change between builds. See the `allow_in_app_purchase` /
+    // `get_locked_tenant` commands in src/lib.rs.
+    println!("cargo:rerun-if-env-changed=IBL_ALLOW_IN_APP_PURCHASE");
+    println!("cargo:rerun-if-env-changed=IBL_TENANT");
     tauri_build::build()
 }

--- a/skills/iblai-vibe-ops-build/assets/tauri/src-tauri/src/lib.rs.j2
+++ b/skills/iblai-vibe-ops-build/assets/tauri/src-tauri/src/lib.rs.j2
@@ -508,6 +508,38 @@ async fn open_external_url(app: tauri::AppHandle, url: String) -> Result<(), Str
 }
 
 // ---------------------------------------------------------------------------
+// Build-time configuration commands
+//
+// Both values are baked in at `cargo build` time via `option_env!`, so a single
+// codebase can produce differently-configured builds by setting the env vars in
+// the build shell (see build.rs `rerun-if-env-changed`). They default to the
+// "off" value when the env var is unset, so a normal build is unaffected.
+// ---------------------------------------------------------------------------
+
+/// Whether this build may offer in-app purchases. Controlled by the
+/// `IBL_ALLOW_IN_APP_PURCHASE` build-time env (accepts `1`/`true`/`yes`/`on`,
+/// case-insensitive); returns `false` when unset.
+#[tauri::command]
+fn allow_in_app_purchase() -> bool {
+    match option_env!("IBL_ALLOW_IN_APP_PURCHASE") {
+        Some(value) => matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        None => false,
+    }
+}
+
+/// The tenant key this build is locked to, injected at build time via the
+/// `IBL_TENANT` env var. Returns an empty string when unset (normal
+/// multi-tenant behaviour); a non-empty value tells the frontend to force the
+/// user onto that tenant and hide tenant switching.
+#[tauri::command]
+fn get_locked_tenant() -> String {
+    option_env!("IBL_TENANT").unwrap_or("").trim().to_string()
+}
+
+// ---------------------------------------------------------------------------
 // Mobile initialization script: safe area CSS + OAuth interception
 // ---------------------------------------------------------------------------
 
@@ -744,7 +776,11 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![open_external_url])
+        .invoke_handler(tauri::generate_handler![
+            open_external_url,
+            allow_in_app_purchase,
+            get_locked_tenant
+        ])
         .setup(|app| {
             // ---- Mobile: deep-link listeners ----
             #[cfg(any(target_os = "ios", target_os = "android"))]


### PR DESCRIPTION
## What

Adds two compile-time flags to the generated Tauri shell in the `iblai-vibe-ops-build` skill so a **single codebase can produce differently-configured desktop/mobile builds from the same app URL** (e.g. one build locked to tenant A, another to tenant B).

| Env var | JS command | Default | Effect |
|---|---|---|---|
| `IBL_TENANT` | `get_locked_tenant()` → `string` | `""` (unlocked) | Locks the build to one tenant — frontend forces login to it and hides tenant switching |
| `IBL_ALLOW_IN_APP_PURCHASE` | `allow_in_app_purchase()` → `bool` | `false` | Enables in-app purchase UI (`1`/`true`/`yes`/`on`) |

## Changes

- **`assets/tauri/src-tauri/src/lib.rs.j2`** — two `#[tauri::command]` fns reading `option_env!`, registered in `generate_handler!`.
- **`assets/tauri/src-tauri/build.rs`** — `cargo:rerun-if-env-changed` for both flags so cargo recompiles when a value changes between builds.
- **`SKILL.md`** — new "Build-Time Flags" section: what they do, how to set them (build shell / CI env, since they're read at compile time), and frontend consumption via `invoke`.

## Notes

- Values are baked in at `cargo build` time (`option_env!`), so they must be set as environment variables in the build shell before `iblai builds build` — not in `iblai.env`.
- No ACL changes needed: these are application commands, permitted by default like the existing `open_external_url`.
- Web-side wiring (forcing the locked tenant, hiding the switcher) is app code and lives outside this template; the docs point to it.

Mirrors the implementation shipped in the `os` app (in-app-purchase via PR #299, tenant lock via PR #320).

🤖 Generated with [Claude Code](https://claude.com/claude-code)