### PR TITLE
feat(ops-build): signed + notarized macOS/Windows desktop release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,30 @@ pnpm exec tauri build           # Desktop build for current platform
 pnpm exec tauri ios init        # iOS project setup
 ```
 
+#### Signed desktop releases (macOS DMG + Windows NSIS)
+
+`/iblai-vibe-ops-build` also ships **signed, distributable** desktop builds —
+a **notarized** universal macOS `.dmg` (Intel + Apple Silicon) and **signed**
+NSIS installers for Windows **x64 + arm64**. Run them two ways:
+
+- **CI** — copy the `tauri-release-macos-dmg.yml` / `tauri-release-windows.yml`
+  workflows into `.github/workflows/`, then push an `app-v*` tag. Each build is
+  signed (macOS also notarized + stapled) and attached to that tag's GitHub
+  Release. Great for producing macOS + Windows (+ arm64) from a single push.
+- **Local (no CI)** — copy `desktop-release.mk` to your project root and build
+  on your own machine:
+
+  ```bash
+  make -f desktop-release.mk macos-dmg      # signed + notarized universal DMG
+  make -f desktop-release.mk windows-nsis   # signed NSIS installer (on Windows)
+  ```
+
+Credentials (Apple Developer ID cert + notarization password; optional Windows
+cert) are the same for both paths — full setup in
+[`references/signed-release.md`](skills/iblai-vibe-ops-build/references/signed-release.md).
+For a Windows Store / sideload **MSIX** package instead, see
+[`/iblai-vibe-windows-msix`](skills/iblai-vibe-windows-msix/SKILL.md).
+
 ## Resources
 
 - [Vibe Starter](https://github.com/iblai/vibe-starter) -- pre-wired Next.js + ibl.ai SSO template

--- a/adapters/codex/iblai-vibe-ops-build.md
+++ b/adapters/codex/iblai-vibe-ops-build.md
@@ -76,6 +76,57 @@ This configures:
 Without this, mobile SSO will redirect to an HTTPS URL that stays inside
 the system browser session and never returns to the app.
 
+## Build-Time Flags (Tenant Lock & In-App Purchase)
+
+The Tauri shell exposes two build-time flags so a **single codebase can
+produce differently-configured builds** — e.g. one desktop/mobile build
+locked to tenant A and another locked to tenant B, both served from the same
+app URL. The values are baked in at `cargo build` time via Rust's
+`option_env!`, so they are set as **environment variables in the build shell**
+(not `iblai.env`, which is CLI config) before running the build:
+
+| Env var | Command exposed to JS | Default | Effect |
+|---|---|---|---|
+| `IBL_TENANT` | `get_locked_tenant` → `string` | `""` (unlocked) | Locks the build to one tenant: the frontend forces login to it and hides tenant switching. |
+| `IBL_ALLOW_IN_APP_PURCHASE` | `allow_in_app_purchase` → `bool` | `false` | Enables in-app purchase UI. Truthy values: `1`/`true`/`yes`/`on` (case-insensitive). |
+
+Set them before the build (they are read at compile time, so they must be in
+the environment when cargo compiles `src-tauri`):
+
+```bash
+# tenant-locked build with in-app purchase enabled
+IBL_TENANT=acme IBL_ALLOW_IN_APP_PURCHASE=true iblai builds build
+```
+
+In CI, set them as env on the build step:
+
+```yaml
+- name: Build
+  env:
+    IBL_TENANT: acme
+    IBL_ALLOW_IN_APP_PURCHASE: "true"
+  run: iblai builds build
+```
+
+`src-tauri/build.rs` declares `cargo:rerun-if-env-changed` for both, so cargo
+recompiles when a value changes between builds. Unset → the "off" default, so
+a normal build is unaffected.
+
+**Frontend consumption** (app code, outside this template) invokes the
+commands and reacts to them:
+
+```ts
+import { invoke } from '@tauri-apps/api/core';
+
+const lockedTenant = await invoke<string>('get_locked_tenant'); // '' = unlocked
+const iap = await invoke<boolean>('allow_in_app_purchase');
+```
+
+When `get_locked_tenant` returns a non-empty key, force the user onto that
+tenant (logging out of any other) and hide the tenant switcher. The commands
+are registered in `src-tauri/src/lib.rs` (`generate_handler!`); no extra ACL
+entry is needed since they are application commands.
+
 ## App Icons
 
 Generate platform-ready icons from your logo (works for all platforms):
@@ -331,11 +382,21 @@ Or:
 pnpm tauri:build
 ```
 
-#### macOS CI
+#### Signed + notarized release — CI or local
 
-```bash
-# create the workflow from assets/tauri/workflows/ (desktop, ios, windows-msix templates)
-```
+**CI:** copy `assets/tauri/workflows/tauri-release-macos-dmg.yml` into
+`.github/workflows/`. On an `app-v*` tag push it builds a **signed + notarized**
+universal `.dmg` (Intel + Apple Silicon) and attaches it to the tag's GitHub
+Release; a manual run produces a build-only artifact.
+
+**Local (no CI):** copy `assets/tauri/desktop-release.mk` +
+`desktop-signing.env.example` to your project root and run
+`make -f desktop-release.mk macos-dmg` — same sign + notarize, on your own Mac.
+
+Either way needs Apple Developer ID credentials — full setup in
+[`references/signed-release.md`](references/signed-release.md). For a quick
+**unsigned** build across macOS/Linux/Windows, use
+`assets/tauri/workflows/tauri-build-desktop.yml`.
 
 ---
 
@@ -371,11 +432,18 @@ pnpm exec tauri build
 The installer targets are configured in `src-tauri/tauri.conf.json` under
 `bundle.targets` (includes `nsis` and `msi` by default).
 
-#### Surface CI
+#### Surface / Windows CI (signed NSIS, x64 + arm64)
 
-```bash
-# create the workflow from assets/tauri/workflows/ (desktop, ios, windows-msix templates)
-```
+Copy `assets/tauri/workflows/tauri-release-windows.yml` into
+`.github/workflows/`. On an `app-v*` tag push it builds **signed** NSIS
+installers for x64 and arm64 and attaches them to the Release. It signs with a
+stored `.pfx` if you provide one, otherwise generates a self-signed cert in the
+runner (zero setup) — see [`references/signed-release.md`](references/signed-release.md).
+Requires `bundle.windows.certificateThumbprint: null` in `tauri.conf.json` (the
+template already has it). To build **locally** instead, run
+`make -f desktop-release.mk windows-nsis` on a Windows machine. For a Store /
+sideload **MSIX** package instead, see
+[`/iblai-vibe-windows-msix`](../iblai-vibe-windows-msix/SKILL.md).
 
 ---
 
@@ -438,6 +506,10 @@ Generate CI workflows for all platforms at once:
 | **Desktop** | |
 | Run desktop dev mode | `pnpm exec tauri dev` |
 | Build desktop release | `pnpm exec tauri build` |
+| macOS signed + notarized DMG (CI) | `tauri-release-macos-dmg.yml` — push an `app-v*` tag |
+| Windows signed NSIS x64 + arm64 (CI) | `tauri-release-windows.yml` — push an `app-v*` tag |
+| macOS signed DMG (local, no CI) | `make -f desktop-release.mk macos-dmg` |
+| Windows signed NSIS (local, no CI) | `make -f desktop-release.mk windows-nsis` |
 | macOS CI workflow | the templates in `assets/tauri/workflows/` |
 | Surface CI workflow | the templates in `assets/tauri/workflows/` |
 | Linux CI workflow | the templates in `assets/tauri/workflows/` |
@@ -449,5 +521,6 @@ Generate CI workflows for all platforms at once:
 ## Reference
 
 - [`/iblai-vibe-scaffold`](../iblai-vibe-scaffold/SKILL.md) -- the project templates + scaffold and command behavior
+- [`references/signed-release.md`](references/signed-release.md) -- signed + notarized macOS DMG and signed Windows NSIS release workflows (secrets, certs, tag triggering)
 - [`references/builds-command.md`](references/builds-command.md) -- full `iblai builds` subcommand behavior (for reference)
 - `references/builds-command.md` -- full list of build commands

--- a/adapters/cursor/iblai-vibe-ops-build.mdc
+++ b/adapters/cursor/iblai-vibe-ops-build.mdc
@@ -78,6 +78,57 @@ This configures:
 Without this, mobile SSO will redirect to an HTTPS URL that stays inside
 the system browser session and never returns to the app.
 
+## Build-Time Flags (Tenant Lock & In-App Purchase)
+
+The Tauri shell exposes two build-time flags so a **single codebase can
+produce differently-configured builds** — e.g. one desktop/mobile build
+locked to tenant A and another locked to tenant B, both served from the same
+app URL. The values are baked in at `cargo build` time via Rust's
+`option_env!`, so they are set as **environment variables in the build shell**
+(not `iblai.env`, which is CLI config) before running the build:
+
+| Env var | Command exposed to JS | Default | Effect |
+|---|---|---|---|
+| `IBL_TENANT` | `get_locked_tenant` → `string` | `""` (unlocked) | Locks the build to one tenant: the frontend forces login to it and hides tenant switching. |
+| `IBL_ALLOW_IN_APP_PURCHASE` | `allow_in_app_purchase` → `bool` | `false` | Enables in-app purchase UI. Truthy values: `1`/`true`/`yes`/`on` (case-insensitive). |
+
+Set them before the build (they are read at compile time, so they must be in
+the environment when cargo compiles `src-tauri`):
+
+```bash
+# tenant-locked build with in-app purchase enabled
+IBL_TENANT=acme IBL_ALLOW_IN_APP_PURCHASE=true iblai builds build
+```
+
+In CI, set them as env on the build step:
+
+```yaml
+- name: Build
+  env:
+    IBL_TENANT: acme
+    IBL_ALLOW_IN_APP_PURCHASE: "true"
+  run: iblai builds build
+```
+
+`src-tauri/build.rs` declares `cargo:rerun-if-env-changed` for both, so cargo
+recompiles when a value changes between builds. Unset → the "off" default, so
+a normal build is unaffected.
+
+**Frontend consumption** (app code, outside this template) invokes the
+commands and reacts to them:
+
+```ts
+import { invoke } from '@tauri-apps/api/core';
+
+const lockedTenant = await invoke<string>('get_locked_tenant'); // '' = unlocked
+const iap = await invoke<boolean>('allow_in_app_purchase');
+```
+
+When `get_locked_tenant` returns a non-empty key, force the user onto that
+tenant (logging out of any other) and hide the tenant switcher. The commands
+are registered in `src-tauri/src/lib.rs` (`generate_handler!`); no extra ACL
+entry is needed since they are application commands.
+
 ## App Icons
 
 Generate platform-ready icons from your logo (works for all platforms):
@@ -333,11 +384,21 @@ Or:
 pnpm tauri:build
 ```
 
-#### macOS CI
+#### Signed + notarized release — CI or local
 
-```bash
-# create the workflow from assets/tauri/workflows/ (desktop, ios, windows-msix templates)
-```
+**CI:** copy `assets/tauri/workflows/tauri-release-macos-dmg.yml` into
+`.github/workflows/`. On an `app-v*` tag push it builds a **signed + notarized**
+universal `.dmg` (Intel + Apple Silicon) and attaches it to the tag's GitHub
+Release; a manual run produces a build-only artifact.
+
+**Local (no CI):** copy `assets/tauri/desktop-release.mk` +
+`desktop-signing.env.example` to your project root and run
+`make -f desktop-release.mk macos-dmg` — same sign + notarize, on your own Mac.
+
+Either way needs Apple Developer ID credentials — full setup in
+[`references/signed-release.md`](references/signed-release.md). For a quick
+**unsigned** build across macOS/Linux/Windows, use
+`assets/tauri/workflows/tauri-build-desktop.yml`.
 
 ---
 
@@ -373,11 +434,18 @@ pnpm exec tauri build
 The installer targets are configured in `src-tauri/tauri.conf.json` under
 `bundle.targets` (includes `nsis` and `msi` by default).
 
-#### Surface CI
+#### Surface / Windows CI (signed NSIS, x64 + arm64)
 
-```bash
-# create the workflow from assets/tauri/workflows/ (desktop, ios, windows-msix templates)
-```
+Copy `assets/tauri/workflows/tauri-release-windows.yml` into
+`.github/workflows/`. On an `app-v*` tag push it builds **signed** NSIS
+installers for x64 and arm64 and attaches them to the Release. It signs with a
+stored `.pfx` if you provide one, otherwise generates a self-signed cert in the
+runner (zero setup) — see [`references/signed-release.md`](references/signed-release.md).
+Requires `bundle.windows.certificateThumbprint: null` in `tauri.conf.json` (the
+template already has it). To build **locally** instead, run
+`make -f desktop-release.mk windows-nsis` on a Windows machine. For a Store /
+sideload **MSIX** package instead, see
+[`/iblai-vibe-windows-msix`](../iblai-vibe-windows-msix/SKILL.md).
 
 ---
 
@@ -440,6 +508,10 @@ Generate CI workflows for all platforms at once:
 | **Desktop** | |
 | Run desktop dev mode | `pnpm exec tauri dev` |
 | Build desktop release | `pnpm exec tauri build` |
+| macOS signed + notarized DMG (CI) | `tauri-release-macos-dmg.yml` — push an `app-v*` tag |
+| Windows signed NSIS x64 + arm64 (CI) | `tauri-release-windows.yml` — push an `app-v*` tag |
+| macOS signed DMG (local, no CI) | `make -f desktop-release.mk macos-dmg` |
+| Windows signed NSIS (local, no CI) | `make -f desktop-release.mk windows-nsis` |
 | macOS CI workflow | the templates in `assets/tauri/workflows/` |
 | Surface CI workflow | the templates in `assets/tauri/workflows/` |
 | Linux CI workflow | the templates in `assets/tauri/workflows/` |
@@ -451,5 +523,6 @@ Generate CI workflows for all platforms at once:
 ## Reference
 
 - [`/iblai-vibe-scaffold`](../iblai-vibe-scaffold/SKILL.md) -- the project templates + scaffold and command behavior
+- [`references/signed-release.md`](references/signed-release.md) -- signed + notarized macOS DMG and signed Windows NSIS release workflows (secrets, certs, tag triggering)
 - [`references/builds-command.md`](references/builds-command.md) -- full `iblai builds` subcommand behavior (for reference)
 - `references/builds-command.md` -- full list of build commands

--- a/skills/iblai-vibe-ops-build/SKILL.md
+++ b/skills/iblai-vibe-ops-build/SKILL.md
@@ -385,11 +385,21 @@ Or:
 pnpm tauri:build
 ```
 
-#### macOS CI
+#### Signed + notarized release — CI or local
 
-```bash
-# create the workflow from assets/tauri/workflows/ (desktop, ios, windows-msix templates)
-```
+**CI:** copy `assets/tauri/workflows/tauri-release-macos-dmg.yml` into
+`.github/workflows/`. On an `app-v*` tag push it builds a **signed + notarized**
+universal `.dmg` (Intel + Apple Silicon) and attaches it to the tag's GitHub
+Release; a manual run produces a build-only artifact.
+
+**Local (no CI):** copy `assets/tauri/desktop-release.mk` +
+`desktop-signing.env.example` to your project root and run
+`make -f desktop-release.mk macos-dmg` — same sign + notarize, on your own Mac.
+
+Either way needs Apple Developer ID credentials — full setup in
+[`references/signed-release.md`](references/signed-release.md). For a quick
+**unsigned** build across macOS/Linux/Windows, use
+`assets/tauri/workflows/tauri-build-desktop.yml`.
 
 ---
 
@@ -425,11 +435,18 @@ pnpm exec tauri build
 The installer targets are configured in `src-tauri/tauri.conf.json` under
 `bundle.targets` (includes `nsis` and `msi` by default).
 
-#### Surface CI
+#### Surface / Windows CI (signed NSIS, x64 + arm64)
 
-```bash
-# create the workflow from assets/tauri/workflows/ (desktop, ios, windows-msix templates)
-```
+Copy `assets/tauri/workflows/tauri-release-windows.yml` into
+`.github/workflows/`. On an `app-v*` tag push it builds **signed** NSIS
+installers for x64 and arm64 and attaches them to the Release. It signs with a
+stored `.pfx` if you provide one, otherwise generates a self-signed cert in the
+runner (zero setup) — see [`references/signed-release.md`](references/signed-release.md).
+Requires `bundle.windows.certificateThumbprint: null` in `tauri.conf.json` (the
+template already has it). To build **locally** instead, run
+`make -f desktop-release.mk windows-nsis` on a Windows machine. For a Store /
+sideload **MSIX** package instead, see
+[`/iblai-vibe-windows-msix`](../iblai-vibe-windows-msix/SKILL.md).
 
 ---
 
@@ -492,6 +509,10 @@ Generate CI workflows for all platforms at once:
 | **Desktop** | |
 | Run desktop dev mode | `pnpm exec tauri dev` |
 | Build desktop release | `pnpm exec tauri build` |
+| macOS signed + notarized DMG (CI) | `tauri-release-macos-dmg.yml` — push an `app-v*` tag |
+| Windows signed NSIS x64 + arm64 (CI) | `tauri-release-windows.yml` — push an `app-v*` tag |
+| macOS signed DMG (local, no CI) | `make -f desktop-release.mk macos-dmg` |
+| Windows signed NSIS (local, no CI) | `make -f desktop-release.mk windows-nsis` |
 | macOS CI workflow | the templates in `assets/tauri/workflows/` |
 | Surface CI workflow | the templates in `assets/tauri/workflows/` |
 | Linux CI workflow | the templates in `assets/tauri/workflows/` |
@@ -503,5 +524,6 @@ Generate CI workflows for all platforms at once:
 ## Reference
 
 - [`/iblai-vibe-scaffold`](../iblai-vibe-scaffold/SKILL.md) -- the project templates + scaffold and command behavior
+- [`references/signed-release.md`](references/signed-release.md) -- signed + notarized macOS DMG and signed Windows NSIS release workflows (secrets, certs, tag triggering)
 - [`references/builds-command.md`](references/builds-command.md) -- full `iblai builds` subcommand behavior (for reference)
 - `references/builds-command.md` -- full list of build commands

--- a/skills/iblai-vibe-ops-build/assets/tauri/desktop-release.mk
+++ b/skills/iblai-vibe-ops-build/assets/tauri/desktop-release.mk
@@ -1,0 +1,61 @@
+# Local signed desktop release builds — no CI required.
+#
+# Companion to /iblai-vibe-ops-build's GitHub workflows: same sign + notarize
+# steps, run on your own Mac / Windows machine instead of a runner. Copy this
+# file + desktop-signing.env.example to your project root.
+#
+#   make -f desktop-release.mk doctor
+#   make -f desktop-release.mk macos-dmg          # signed + notarized universal DMG
+#   make -f desktop-release.mk macos-dmg-unsigned # quick unsigned universal DMG
+#   make -f desktop-release.mk windows-nsis       # signed NSIS installer
+#
+# Or `include desktop-release.mk` from an existing Makefile (e.g. the one from
+# /iblai-vibe-ops-release) to get these targets alongside it.
+#
+# Credentials load from desktop-signing.env (copy desktop-signing.env.example
+# and fill it in; gitignore it). Full setup: references/signed-release.md.
+
+ENV_FILE ?= desktop-signing.env
+-include $(ENV_FILE)
+export
+
+MACOS_DMG := src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+WIN_NSIS  := src-tauri/target/*/release/bundle/nsis/*-setup.exe
+
+.DEFAULT_GOAL := help
+.PHONY: help doctor macos-dmg macos-dmg-unsigned windows-nsis
+
+help: ## List available targets
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+doctor: ## Check tooling + signing config
+	@command -v pnpm  >/dev/null 2>&1 && echo "  ok  pnpm"  || echo "  MISSING pnpm"
+	@command -v cargo >/dev/null 2>&1 && echo "  ok  cargo" || echo "  MISSING rust toolchain (rustup.rs)"
+	@test -f $(ENV_FILE) && echo "  ok  $(ENV_FILE)" || echo "  MISSING $(ENV_FILE) (cp desktop-signing.env.example desktop-signing.env)"
+	@test -n "$(APPLE_SIGNING_IDENTITY)" && echo "  ok  APPLE_SIGNING_IDENTITY set" || echo "  note (macOS) set APPLE_SIGNING_IDENTITY to sign + notarize"
+	@rustup target list --installed 2>/dev/null | grep -q aarch64-apple-darwin \
+		&& echo "  ok  macOS universal targets" \
+		|| echo "  note (macOS) rustup target add aarch64-apple-darwin x86_64-apple-darwin"
+
+# Tauri reads APPLE_* from the environment: signs the universal .app with the
+# Developer ID identity, then notarizes + staples the DMG when APPLE_ID +
+# APPLE_PASSWORD + APPLE_TEAM_ID are present. Leaving APPLE_CERTIFICATE empty
+# uses a Developer ID identity already in your login keychain.
+macos-dmg: ## Signed + notarized universal DMG (needs APPLE_* in the env file)
+	@test -n "$(APPLE_SIGNING_IDENTITY)" || { echo "APPLE_SIGNING_IDENTITY not set — see references/signed-release.md"; exit 1; }
+	pnpm exec tauri build --target universal-apple-darwin --bundles app,dmg
+	@echo "Built (signed): $(MACOS_DMG)"
+
+macos-dmg-unsigned: ## Universal DMG without signing (quick local build)
+	pnpm exec tauri build --target universal-apple-darwin --bundles app,dmg
+	@echo "Built (unsigned): $(MACOS_DMG)"
+
+# Signs via signtool when bundle.windows.certificateThumbprint is set in
+# tauri.conf.json. There is no env var Tauri reads for the thumbprint — set it
+# in the config to the thumbprint of a cert in your CurrentUser store first
+# (see references/signed-release.md). Run under a shell that has `make`
+# (Git Bash / MSYS2 / WSL).
+windows-nsis: ## Signed NSIS installer (needs certificateThumbprint set in tauri.conf.json)
+	pnpm exec tauri build --bundles nsis
+	@echo "Built: $(WIN_NSIS)"

--- a/skills/iblai-vibe-ops-build/assets/tauri/desktop-signing.env.example
+++ b/skills/iblai-vibe-ops-build/assets/tauri/desktop-signing.env.example
@@ -1,0 +1,21 @@
+# Copy to desktop-signing.env and fill in. NEVER commit desktop-signing.env.
+# Used by desktop-release.mk for LOCAL signed builds. Setup: references/signed-release.md
+
+# ---- macOS (Developer ID signing + notarization) ----
+APPLE_SIGNING_IDENTITY=Developer ID Application: Acme, LLC (TEAMID)
+APPLE_TEAM_ID=TEAMID
+
+# Notarization — Apple ID + app-specific password (from account.apple.com):
+APPLE_ID=you@example.com
+APPLE_PASSWORD=abcd-efgh-ijkl-mnop
+
+# Cert source (optional): base64 of a Developer ID .p12 + its password. Leave
+# BOTH empty to use a Developer ID identity already in your login keychain.
+#   APPLE_CERTIFICATE=$(base64 -i DeveloperID.p12)
+APPLE_CERTIFICATE=
+APPLE_CERTIFICATE_PASSWORD=
+
+# ---- Windows (Authenticode) ----
+# Local Windows signing has no env var — set the thumbprint of a cert in your
+# CurrentUser store into bundle.windows.certificateThumbprint in tauri.conf.json,
+# then run `make -f desktop-release.mk windows-nsis`.

--- a/skills/iblai-vibe-ops-build/assets/tauri/src-tauri/tauri.conf.json.j2
+++ b/skills/iblai-vibe-ops-build/assets/tauri/src-tauri/tauri.conf.json.j2
@@ -22,6 +22,9 @@
       "minimumSystemVersion": "10.15"
     },
     "windows": {
+      "certificateThumbprint": null,
+      "digestAlgorithm": "sha256",
+      "timestampUrl": "http://timestamp.digicert.com",
       "webviewInstallMode": {
         "type": "downloadBootstrapper"
       },

--- a/skills/iblai-vibe-ops-build/assets/tauri/workflows/tauri-release-macos-dmg.yml.j2
+++ b/skills/iblai-vibe-ops-build/assets/tauri/workflows/tauri-release-macos-dmg.yml.j2
@@ -1,0 +1,119 @@
+{% raw %}
+name: Release macOS DMG (Tauri)
+
+# Builds a SIGNED + NOTARIZED Developer ID DMG (universal — Intel + Apple
+# Silicon) and attaches it to a GitHub Release. Push an `app-v*` tag to build +
+# publish; "Run workflow" (workflow_dispatch) produces a build-only artifact
+# with no Release. Setup + secrets: references/signed-release.md.
+#
+# Required repo/org Actions secrets:
+#   APPLE_CERTIFICATE           base64 of the Developer ID Application .p12
+#   APPLE_CERTIFICATE_PASSWORD  password for that .p12
+#   APPLE_ID                    Apple ID email (used for notarization)
+#   APPLE_PASSWORD              app-specific password for that Apple ID
+# Required repo/org Actions variables (Settings > Secrets and variables > Actions > Variables):
+#   APPLE_SIGNING_IDENTITY      e.g. "Developer ID Application: Acme, LLC (TEAMID)"
+#   APPLE_TEAM_ID               e.g. "TEAMID"
+# Optional variables (this app shell's compile-time flags; empty = defaults):
+#   IBL_ALLOW_IN_APP_PURCHASE   "true" to enable in-app purchase UI
+#   IBL_TENANT                  tenant key to lock the build to
+
+on:
+  push:
+    tags:
+      - 'app-v*'
+  workflow_dispatch:
+
+concurrency:
+  group: release-macos-dmg-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # attach the DMG to the Release
+
+jobs:
+  build-dmg:
+    runs-on: macos-latest # Apple Silicon runner; cross-compiles the x86_64 slice too
+    env:
+      # Not secret — tauri-action needs them in the environment to pick the right
+      # identity in its temporary signing keychain and to notarize.
+      APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_SIGNING_IDENTITY }}
+      APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node/pnpm let tauri-action resolve the package manager; the frontend is a
+      # static export produced by beforeBuildCommand.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Cache Rust build
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # Build + sign + notarize. No tagName/releaseName is passed, so tauri-action
+      # does NOT create a Release; we attach the DMG ourselves (below) so it lands
+      # on the app-v<X> Release rather than a parallel one.
+      - name: Build, sign & notarize DMG
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # --- Code signing (Developer ID Application cert, exported as .p12) ---
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          # --- Notarization (Apple ID + app-specific password) ---
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          # APPLE_SIGNING_IDENTITY / APPLE_TEAM_ID are inherited from job env.
+          # This app shell's compile-time flags (read via option_env! in Rust).
+          IBL_ALLOW_IN_APP_PURCHASE: ${{ vars.IBL_ALLOW_IN_APP_PURCHASE }}
+          IBL_TENANT: ${{ vars.IBL_TENANT }}
+        with:
+          args: --target universal-apple-darwin --bundles app,dmg
+
+      # Always keep the DMG as a CI artifact (SHA-named for dev builds).
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-macos-dmg-${{ github.sha }}
+          path: src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+
+      # Release builds only (tag push): attach the DMG to the tag's Release.
+      - name: Attach DMG to release
+        if: ${{ github.ref_type == 'tag' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass via env (not interpolated into the script) to avoid injection.
+          DMG_PATH: src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=($DMG_PATH) # intentional glob expansion of the path pattern
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No DMG found at $DMG_PATH"; exit 1
+          fi
+          # Create the Release as a fallback if the tag flow didn't already.
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TAG" \
+              --notes "Automated, notarized macOS build."
+          fi
+          gh release upload "$RELEASE_TAG" "${files[@]}" --clobber
+          echo "Attached ${#files[@]} DMG(s) to $RELEASE_TAG"
+{% endraw %}

--- a/skills/iblai-vibe-ops-build/assets/tauri/workflows/tauri-release-windows.yml.j2
+++ b/skills/iblai-vibe-ops-build/assets/tauri/workflows/tauri-release-windows.yml.j2
@@ -1,0 +1,186 @@
+{% raw %}
+name: Release Windows (Tauri)
+
+# Builds SIGNED NSIS installers for x64 + arm64 and attaches them to a GitHub
+# Release. Push an `app-v*` tag to build + publish; "Run workflow"
+# (workflow_dispatch) produces build-only artifacts with no Release.
+# Setup + secrets: references/signed-release.md.
+#
+# Signing: if secrets.WINDOWS_CERTIFICATE (base64 .pfx) +
+# WINDOWS_CERTIFICATE_PASSWORD are set, signs with that stored cert (stable
+# publisher). Otherwise generates a fresh self-signed code-signing cert in the
+# runner (zero setup; publisher/thumbprint varies per build). Either way the
+# thumbprint is injected into bundle.windows.certificateThumbprint in
+# tauri.conf.json at build time — that field MUST exist as `null` in the file.
+#
+# Optional repo/org Actions variables:
+#   WINDOWS_CERT_SUBJECT        subject for the generated cert (default below)
+#   IBL_ALLOW_IN_APP_PURCHASE   "true" to enable in-app purchase UI
+#   IBL_TENANT                  tenant key to lock the build to
+
+on:
+  push:
+    tags:
+      - 'app-v*'
+  workflow_dispatch:
+
+concurrency:
+  group: release-windows-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # attach the installers to the Release
+
+jobs:
+  build-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            rust_target: x86_64-pc-windows-msvc
+          - arch: arm64
+            rust_target: aarch64-pc-windows-msvc
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # arm64 is cross-compiled from the x64 runner: the GitHub-hosted
+      # windows-latest image ships the MSVC ARM64 build tools + Windows 11 SDK,
+      # so no extra Visual Studio component install is needed.
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust build
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.arch }}
+
+      # Resolve a code-signing cert into the CurrentUser store and expose only its
+      # thumbprint. Prefer a stored .pfx (stable publisher); else generate one.
+      - name: Prepare signing certificate
+        id: cert
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_CERT_SUBJECT: ${{ vars.WINDOWS_CERT_SUBJECT }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:WINDOWS_CERTIFICATE) {
+            Write-Host 'Using stored WINDOWS_CERTIFICATE (self-signed .pfx from secrets)'
+            $pfxPath = Join-Path $env:RUNNER_TEMP 'signing.pfx'
+            [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE))
+            $pw = ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText
+            $cert = Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\CurrentUser\My -Password $pw
+            Remove-Item $pfxPath -Force
+          } else {
+            $subject = if ($env:WINDOWS_CERT_SUBJECT) { $env:WINDOWS_CERT_SUBJECT } else { 'CN=Example App, O=Example' }
+            Write-Host "No stored certificate — generating a fresh self-signed cert ($subject)"
+            $cert = New-SelfSignedCertificate `
+              -Type CodeSigningCert `
+              -Subject $subject `
+              -CertStoreLocation Cert:\CurrentUser\My `
+              -KeyExportPolicy Exportable `
+              -KeyAlgorithm RSA -KeyLength 2048 `
+              -HashAlgorithm SHA256 `
+              -NotAfter (Get-Date).AddYears(5)
+          }
+          $thumb = $cert.Thumbprint
+          Write-Host "Signing thumbprint: $thumb"
+          "thumbprint=$thumb" >> $env:GITHUB_OUTPUT
+
+      # Tauri signs the app .exe + NSIS installer via signtool when
+      # bundle.windows.certificateThumbprint is set. Inject the resolved
+      # thumbprint into that one field, leaving sibling windows settings intact.
+      - name: Inject signing thumbprint into tauri.conf.json
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $conf = 'src-tauri/tauri.conf.json'
+          $thumb = '${{ steps.cert.outputs.thumbprint }}'
+          if ([string]::IsNullOrWhiteSpace($thumb)) { throw 'empty signing thumbprint' }
+          $text = Get-Content $conf -Raw
+          if ($text -notmatch '"certificateThumbprint"\s*:\s*null') {
+            throw 'certificateThumbprint: null not found in tauri.conf.json (add it under bundle.windows)'
+          }
+          $text = $text -replace '"certificateThumbprint"\s*:\s*null', ('"certificateThumbprint": "' + $thumb + '"')
+          Set-Content -Path $conf -Value $text -NoNewline -Encoding utf8
+          Write-Host "Injected certificateThumbprint $thumb"
+
+      # Build + sign the NSIS installer. MSI/WiX doesn't support arm64, so NSIS is
+      # the only bundle type that builds for both x64 and arm64.
+      - name: Build & sign NSIS installer
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This app shell's compile-time flags (read via option_env! in Rust).
+          IBL_ALLOW_IN_APP_PURCHASE: ${{ vars.IBL_ALLOW_IN_APP_PURCHASE }}
+          IBL_TENANT: ${{ vars.IBL_TENANT }}
+        with:
+          args: --target ${{ matrix.rust_target }} --bundles nsis
+
+      # A self-signed signature is untrusted (won't be "Valid" without the cert in
+      # a trusted root), so only assert that a signer cert is embedded — i.e.
+      # signtool ran — not that it chains to a trusted root.
+      - name: Verify installer is signed
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $exe = Get-ChildItem "src-tauri/target/${{ matrix.rust_target }}/release/bundle/nsis/*-setup.exe" | Select-Object -First 1
+          if (-not $exe) { throw 'No NSIS installer produced' }
+          $sig = Get-AuthenticodeSignature $exe.FullName
+          Write-Host "Installer: $($exe.Name)"
+          Write-Host "Signature status: $($sig.Status)"
+          if ($null -eq $sig.SignerCertificate) {
+            throw "Installer is NOT signed (no signer certificate embedded)"
+          }
+          Write-Host 'OK: installer carries an Authenticode signature.'
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-windows-${{ matrix.arch }}-${{ github.sha }}
+          path: src-tauri/target/${{ matrix.rust_target }}/release/bundle/nsis/*-setup.exe
+          if-no-files-found: error
+
+      # Release builds only (tag push): attach the installer to the tag's Release.
+      - name: Attach installer to release
+        if: ${{ github.ref_type == 'tag' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXE_GLOB: src-tauri/target/${{ matrix.rust_target }}/release/bundle/nsis/*-setup.exe
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=($EXE_GLOB) # intentional glob expansion of the path pattern
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No installer found at $EXE_GLOB"; exit 1
+          fi
+          # The x64 and arm64 legs run concurrently; tolerate a lost create race.
+          # They upload distinctly-named files, so --clobber never pits them
+          # against each other.
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TAG" \
+              --notes "Automated, self-signed Windows build." || true
+          fi
+          gh release upload "$RELEASE_TAG" "${files[@]}" --clobber
+          echo "Attached ${#files[@]} installer(s) to $RELEASE_TAG"
+{% endraw %}

--- a/skills/iblai-vibe-ops-build/references/signed-release.md
+++ b/skills/iblai-vibe-ops-build/references/signed-release.md
@@ -1,0 +1,193 @@
+# Signed desktop release builds (macOS DMG + Windows NSIS)
+
+The two release workflows in
+[`assets/tauri/workflows/`](../assets/tauri/workflows/) build **distributable,
+signed** desktop installers and attach them to a GitHub Release — separate from
+the unsigned, build-only `tauri-build-desktop.yml` (which is fine for quick CI
+checks and also covers Linux).
+
+| Workflow | Output | Signing |
+|---|---|---|
+| `tauri-release-macos-dmg.yml` | Universal `.dmg` (Intel + Apple Silicon) | Developer ID + **notarized + stapled** — opens with no Gatekeeper warning |
+| `tauri-release-windows.yml` | NSIS `-setup.exe` for **x64 + arm64** | Authenticode (stored `.pfx` or a runner-generated self-signed cert) |
+
+Copy them into `.github/workflows/` alongside your project.
+
+> **Don't want CI?** The signing steps aren't GitHub-specific — you can run the
+> exact same `tauri build` + signing locally on your own Mac / Windows machine.
+> See [Local builds (no CI)](#local-builds-no-ci) below. The credential setup in
+> the rest of this doc applies to both paths — CI reads it from Actions
+> secrets/variables, local reads it from `desktop-signing.env`.
+
+## How they trigger
+
+Both run on:
+
+- **`app-v*` tag push** → build, sign, and **attach the installer to that tag's
+  Release** (created as a fallback if it doesn't exist).
+- **Manual "Run workflow"** (`workflow_dispatch`) → build-only, uploads a CI
+  artifact, no Release.
+
+Create a release by tagging:
+
+```bash
+git tag app-v1.2.3
+git push origin app-v1.2.3
+```
+
+> The mentorai app automates this with a `tauri-autoversion` workflow that bumps
+> `src-tauri/tauri.conf.json` and pushes the `app-v<X>` tag whenever `src-tauri/`
+> changes on `main`. That's optional — tagging by hand or using
+> `workflow_dispatch` works without it.
+
+---
+
+## Local builds (no CI)
+
+For building on your own machine without GitHub, copy `assets/tauri/desktop-release.mk`
+and `assets/tauri/desktop-signing.env.example` into your project root:
+
+```bash
+cp desktop-signing.env.example desktop-signing.env   # then fill in + gitignore it
+make -f desktop-release.mk doctor          # check tooling + config
+make -f desktop-release.mk macos-dmg       # signed + notarized universal DMG
+make -f desktop-release.mk windows-nsis    # signed NSIS installer (run on Windows)
+```
+
+`desktop-release.mk` loads your credentials from `desktop-signing.env` and runs
+the same `tauri build` the workflow does — Tauri reads the `APPLE_*` env vars and
+signs + notarizes automatically. The credential values are identical to the CI
+ones below; you just put them in `desktop-signing.env` instead of Actions
+secrets. Caveats vs CI:
+
+- **You build on the target OS you own.** A universal macOS DMG needs a Mac;
+  the Windows installer needs Windows. CI gives you both (plus arm64) from any
+  push — that's its main advantage over local.
+- **macOS**: `rustup target add aarch64-apple-darwin x86_64-apple-darwin` first
+  (for the universal binary).
+- **Windows**: set `bundle.windows.certificateThumbprint` in `tauri.conf.json`
+  to a cert in your CurrentUser store (there's no env var for it), and run `make`
+  under Git Bash / MSYS2 / WSL.
+
+---
+
+## macOS — Developer ID signing + notarization
+
+Requires a paid **Apple Developer Program** membership.
+
+### 1. Export the Developer ID Application certificate
+
+In Xcode (Settings → Accounts → Manage Certificates) or the
+[Developer portal](https://developer.apple.com/account/resources/certificates),
+create a **Developer ID Application** certificate. Then export it from
+**Keychain Access** as a `.p12` (right-click the cert → Export, set a password),
+and base64-encode it:
+
+```bash
+base64 -i DeveloperID_Application.p12 | pbcopy
+```
+
+### 2. Create an app-specific password for notarization
+
+At [account.apple.com](https://account.apple.com) → Sign-In and Security →
+App-Specific Passwords, generate one for notarization.
+
+### 3. Set the secrets and variables
+
+**Secrets** (Settings → Secrets and variables → Actions → *Secrets*):
+
+| Secret | Value |
+|---|---|
+| `APPLE_CERTIFICATE` | base64 of the `.p12` (step 1) |
+| `APPLE_CERTIFICATE_PASSWORD` | the `.p12` export password |
+| `APPLE_ID` | your Apple ID email |
+| `APPLE_PASSWORD` | the app-specific password (step 2) |
+
+**Variables** (same page → *Variables* — these are not secret):
+
+| Variable | Value |
+|---|---|
+| `APPLE_SIGNING_IDENTITY` | e.g. `Developer ID Application: Acme, LLC (TEAMID)` |
+| `APPLE_TEAM_ID` | your 10-char team id, e.g. `TEAMID` |
+
+`tauri-action` imports the cert into a temporary keychain, signs the universal
+`.app`, builds the `.dmg`, then submits it to Apple's notary service and staples
+the ticket — all from the `APPLE_*` env it reads. No extra config file is
+needed. (If you want a hardened-runtime entitlements overlay, pass
+`--config src-tauri/tauri.<name>.conf.json` in the workflow's `args`.)
+
+---
+
+## Windows — Authenticode signing (x64 + arm64)
+
+The workflow signs with a stored certificate if you provide one, otherwise it
+**generates a self-signed cert in the runner** so you get a signed installer
+with zero setup. Self-signed installers still trip SmartScen­e/"unknown
+publisher" until enough installs build reputation — for a trusted publisher, buy
+an OV/EV code-signing cert and store it as the secrets below.
+
+### Prerequisite: `certificateThumbprint: null` in `tauri.conf.json`
+
+The signing step injects the resolved thumbprint into
+`bundle.windows.certificateThumbprint`, so that field must exist as `null`:
+
+```jsonc
+"bundle": {
+  "windows": {
+    "certificateThumbprint": null,
+    "digestAlgorithm": "sha256",
+    "timestampUrl": "http://timestamp.digicert.com"
+  }
+}
+```
+
+The vibe's `tauri.conf.json` template already includes this. (`null` = unsigned
+for local `pnpm exec tauri build`; only CI injects a real thumbprint.)
+
+### Optional: a stored self-signed cert (stable publisher)
+
+Generate a self-signed `.pfx` once and base64 it, so every build shares one
+publisher/thumbprint instead of a fresh one per run:
+
+```powershell
+$cert = New-SelfSignedCertificate -Type CodeSigningCert `
+  -Subject 'CN=Acme App, O=Acme' -CertStoreLocation Cert:\CurrentUser\My `
+  -KeyExportPolicy Exportable -KeyAlgorithm RSA -KeyLength 2048 `
+  -HashAlgorithm SHA256 -NotAfter (Get-Date).AddYears(5)
+$pw = ConvertTo-SecureString 'a-strong-password' -Force -AsPlainText
+Export-PfxCertificate -Cert $cert -FilePath signing.pfx -Password $pw
+[Convert]::ToBase64String([IO.File]::ReadAllBytes('signing.pfx')) | Set-Clipboard
+```
+
+Then set:
+
+| Setting | Type | Value |
+|---|---|---|
+| `WINDOWS_CERTIFICATE` | secret | base64 of the `.pfx` |
+| `WINDOWS_CERTIFICATE_PASSWORD` | secret | the `.pfx` password |
+| `WINDOWS_CERT_SUBJECT` | variable | subject for the *generated* cert if no `.pfx` is stored (optional) |
+
+Leave `WINDOWS_CERTIFICATE` unset to use the auto-generated cert path.
+
+### arm64 note
+
+arm64 is cross-compiled on the x64 `windows-latest` runner — the GitHub-hosted
+image already ships the MSVC ARM64 tools + Windows 11 SDK. Only **NSIS** builds
+for both architectures (MSI/WiX has no arm64 target), so the workflow restricts
+bundling to `--bundles nsis`.
+
+---
+
+## Compile-time app flags
+
+Both workflows forward this shell's build-time flags to `tauri-action` from repo
+variables (empty = the "off" default), so a signed release can also be
+tenant-locked or IAP-enabled without editing the workflow:
+
+| Variable | Effect |
+|---|---|
+| `IBL_ALLOW_IN_APP_PURCHASE` | `true` enables the in-app-purchase UI |
+| `IBL_TENANT` | locks the build to one tenant key |
+
+See the **Build-Time Flags** section of [`../SKILL.md`](../SKILL.md) for what
+these do at runtime.


### PR DESCRIPTION
## What

Brings production-grade **signed desktop release** builds into `/iblai-vibe-ops-build`, modeled on the mentorai app's CI. Before this, the vibe only shipped an *unsigned*, build-only desktop workflow. Now it produces **distributable** installers:

- **macOS** — signed + **notarized + stapled** universal `.dmg` (Intel + Apple Silicon), opens with no Gatekeeper warning
- **Windows** — signed NSIS installers for **x64 + arm64** (stored `.pfx` or a runner-generated self-signed cert)

Both are runnable **two ways**: GitHub CI, or locally on your own machine with no CI at all.

## Usage

**CI** — copy the workflows into `.github/workflows/`, then:

```bash
git tag app-v1.2.3 && git push origin app-v1.2.3
```

Each build is signed (macOS also notarized) and attached to that tag's GitHub Release. Manual "Run workflow" = build-only artifact.

**Local (no CI)** — copy `desktop-release.mk` to the project root:

```bash
make -f desktop-release.mk macos-dmg      # signed + notarized universal DMG
make -f desktop-release.mk windows-nsis   # signed NSIS installer (on Windows)
```

Same `tauri build`, same credentials — just from `desktop-signing.env` instead of Actions secrets.

## Contents

- `assets/tauri/workflows/tauri-release-macos-dmg.yml.j2` — sign + notarize + staple + attach
- `assets/tauri/workflows/tauri-release-windows.yml.j2` — x64 + arm64 matrix, sign + attach
- `assets/tauri/desktop-release.mk` + `desktop-signing.env.example` — local (no-CI) path
- `assets/tauri/src-tauri/tauri.conf.json.j2` — add `bundle.windows.certificateThumbprint: null` (+ `digestAlgorithm`, `timestampUrl`) so the Windows signing step has a field to inject into; stays unsigned for local `tauri build`
- `references/signed-release.md` — one doc covering cert export, notarization, secrets/vars, tag triggering, and the local path
- SKILL.md + README.md docs; regenerated Cursor/Codex adapters

## Notes

- Base is `docs/tauri-tenant-lock-iap-build-flags` so the diff shows only this feature. Separate from #149 (the `/iblai-vibe-ops-release` app-store skill) — different skill.
- Both workflows forward this shell's compile-time `IBL_ALLOW_IN_APP_PURCHASE` / `IBL_TENANT` flags from repo variables, so a signed release can also be tenant-locked / IAP-enabled.
- Generalized the mentorai-specific hardcoded signing identity/team/cert-subject to repo secrets & variables; dropped the IBL-specific "hide .app extension" DMG re-master step.
- Verified: both workflows parse as valid GHA YAML; `desktop-release.mk` parses under `make` (targets + guards expand correctly).