### PR TITLE
fix(vibe-starter): hydration mismatch on every route

### DIFF
--- a/skills/iblai-vibe-auth/assets/iblai-providers.tsx.j2
+++ b/skills/iblai-vibe-auth/assets/iblai-providers.tsx.j2
@@ -16,7 +16,7 @@
  *   }
  */
 
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Provider as ReduxProvider } from "react-redux";
 import { usePathname } from "next/navigation";
 import { initializeDataLayer } from "@iblai/iblai-js/data-layer";
@@ -66,6 +66,15 @@ export function IblaiProviders({ children }: { children: ReactNode }) {
     return true;
   });
 
+  // `isInitialized` is false during SSR but true on the client's first render,
+  // so gating the tree on it alone makes server and client markup disagree and
+  // React throws a hydration mismatch on every route. Gate on a mount flag
+  // instead: server and first client render both produce LOADING, and the tree
+  // appears on the next commit. The data layer is still initialized
+  // synchronously above, before any child can fire a query.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   const username = useMemo(() => {
     if (typeof window === "undefined") return "";
     try {
@@ -86,7 +95,7 @@ export function IblaiProviders({ children }: { children: ReactNode }) {
     </div>
   );
 
-  if (!isInitialized) return LOADING;
+  if (!isInitialized || !mounted) return LOADING;
 
   return (
     <ReduxProvider store={iblaiStore}>

--- a/skills/iblai-vibe-ops-init/assets/vibe-starter/providers/iblai-providers.tsx
+++ b/skills/iblai-vibe-ops-init/assets/vibe-starter/providers/iblai-providers.tsx
@@ -16,7 +16,7 @@
  *   }
  */
 
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Provider as ReduxProvider } from "react-redux";
 import { usePathname } from "next/navigation";
 import { initializeDataLayer } from "@iblai/iblai-js/data-layer";
@@ -65,6 +65,15 @@ export function IblaiProviders({ children }: { children: ReactNode }) {
     return true;
   });
 
+  // `isInitialized` is false during SSR but true on the client's first render,
+  // so gating the tree on it alone makes server and client markup disagree and
+  // React throws a hydration mismatch on every route. Gate on a mount flag
+  // instead: server and first client render both produce LOADING, and the tree
+  // appears on the next commit. The data layer is still initialized
+  // synchronously above, before any child can fire a query.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   const username = useMemo(() => {
     if (typeof window === "undefined") return "";
     try {
@@ -85,7 +94,7 @@ export function IblaiProviders({ children }: { children: ReactNode }) {
     </div>
   );
 
-  if (!isInitialized) return LOADING;
+  if (!isInitialized || !mounted) return LOADING;
 
   return (
     <ReduxProvider store={iblaiStore}>


### PR DESCRIPTION
## Problem

`IblaiProviders` gates its subtree on `isInitialized`, which comes from a `useState` initializer that early-returns `false` when `typeof window === "undefined"`:

```tsx
const [isInitialized] = useState(() => {
  if (typeof window === "undefined") return false;
  initializeDataLayer(/* … */);
  return true;
});

if (!isInitialized) return LOADING;
```

So SSR renders `LOADING` and the client's first render produces the real tree. React throws on **every** page load:

> Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client.

## Fix

Gate on a mount flag so the server and the client's first render agree, and let the real tree appear on the next commit:

```tsx
const [mounted, setMounted] = useState(false);
useEffect(() => setMounted(true), []);

if (!isInitialized || !mounted) return LOADING;
```

`initializeDataLayer` still runs synchronously in the same `useState` initializer, so the documented ordering constraint — data layer configured before any child fires an RTK Query — is preserved.

## Verification

Built a real app on vibe-starter against a live `iblai.app` tenant. Before: the hydration exception fired on every route, including `/sso-login-complete`. After: gone from all routes, Next.js dev overlay reports zero issues.

## Files

Patched in both places the provider ships from, so scaffold and `/iblai-vibe-auth` stay in sync:

- `skills/iblai-vibe-ops-init/assets/vibe-starter/providers/iblai-providers.tsx`
- `skills/iblai-vibe-auth/assets/iblai-providers.tsx.j2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)