### PR TITLE
fix(vibe-starter): persist the token pair TenantProvider returns from re-auth

### DIFF
--- a/skills/iblai-vibe-auth/assets/iblai-providers.tsx.j2
+++ b/skills/iblai-vibe-auth/assets/iblai-providers.tsx.j2
@@ -19,7 +19,10 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { Provider as ReduxProvider } from "react-redux";
 import { usePathname } from "next/navigation";
-import { initializeDataLayer } from "@iblai/iblai-js/data-layer";
+import {
+  initializeDataLayer,
+  type TokenResponse,
+} from "@iblai/iblai-js/data-layer";
 import { AuthProvider, TenantProvider } from "@iblai/iblai-js/web-utils";
 
 import { iblaiStore } from "@/store/iblai-store";
@@ -116,6 +119,27 @@ export function IblaiProviders({ children }: { children: ReactNode }) {
           }}
           saveUserTenants={(t: unknown) =>
             localStorage.setItem("tenants", JSON.stringify(t))
+          }
+          // TenantProvider re-authenticates against the requested tenant and
+          // hands back a fresh, tenant-scoped token pair. Without persisting it
+          // the next membership check still runs on the pre-switch tokens, so
+          // the provider loops on
+          //   "User still does not belong to tenant after re-auth"
+          // and the app never leaves its loading state. iblai/os wires these up
+          // (providers/index.tsx -> saveUserTokens).
+          saveUserTokens={(tokens: TokenResponse) => {
+            if (tokens?.axd_token) {
+              localStorage.setItem("axd_token", tokens.axd_token.token);
+              localStorage.setItem("axd_token_expires", tokens.axd_token.expires);
+            }
+            if (tokens?.dm_token) {
+              localStorage.setItem("dm_token", tokens.dm_token.token);
+              localStorage.setItem("dm_token_expires", tokens.dm_token.expires);
+            }
+          }}
+          saveTenant={(t: string) => localStorage.setItem("tenant", t)}
+          onAuthFailure={(reason: string) =>
+            console.error("[TenantProvider] Auth failure:", reason)
           }
           handleTenantSwitch={async () => {
             const tenant = resolveAppTenant();

--- a/skills/iblai-vibe-ops-init/assets/vibe-starter/providers/iblai-providers.tsx
+++ b/skills/iblai-vibe-ops-init/assets/vibe-starter/providers/iblai-providers.tsx
@@ -19,7 +19,10 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { Provider as ReduxProvider } from "react-redux";
 import { usePathname } from "next/navigation";
-import { initializeDataLayer } from "@iblai/iblai-js/data-layer";
+import {
+  initializeDataLayer,
+  type TokenResponse,
+} from "@iblai/iblai-js/data-layer";
 import { AuthProvider, TenantProvider } from "@iblai/iblai-js/web-utils";
 
 import { iblaiStore } from "@/store/iblai-store";
@@ -114,6 +117,27 @@ export function IblaiProviders({ children }: { children: ReactNode }) {
           }}
           saveUserTenants={(t: unknown) =>
             localStorage.setItem("tenants", JSON.stringify(t))
+          }
+          // TenantProvider re-authenticates against the requested tenant and
+          // hands back a fresh, tenant-scoped token pair. Without persisting it
+          // the next membership check still runs on the pre-switch tokens, so
+          // the provider loops on
+          //   "User still does not belong to tenant after re-auth"
+          // and the app never leaves its loading state. iblai/os wires these up
+          // (providers/index.tsx -> saveUserTokens).
+          saveUserTokens={(tokens: TokenResponse) => {
+            if (tokens?.axd_token) {
+              localStorage.setItem("axd_token", tokens.axd_token.token);
+              localStorage.setItem("axd_token_expires", tokens.axd_token.expires);
+            }
+            if (tokens?.dm_token) {
+              localStorage.setItem("dm_token", tokens.dm_token.token);
+              localStorage.setItem("dm_token_expires", tokens.dm_token.expires);
+            }
+          }}
+          saveTenant={(t: string) => localStorage.setItem("tenant", t)}
+          onAuthFailure={(reason: string) =>
+            console.error("[TenantProvider] Auth failure:", reason)
           }
           handleTenantSwitch={async () => {
             const tenant = resolveAppTenant();


### PR DESCRIPTION
## Problem

`TenantProvider` re-authenticates against the requested tenant and hands the fresh, tenant-scoped token pair back through the optional `saveUserTokens` prop:

```ts
saveUserTokens?: (tokens: TokenResponse) => void;
```

vibe-starter never passed it, so those tokens were discarded and the next membership check reran against the pre-switch pair. The app loops on

> `[TenantProvider] User still does not belong to tenant after re-auth: <tenant>`

and stays parked on its loading state indefinitely.

This is easy to misread as a permissions problem — the user *is* a member of the tenant, and login itself succeeded.

## Fix

Persist the pair, and also wire two props `iblai/os` passes that vibe-starter omitted:

- `saveUserTokens` — write `axd_token` / `dm_token` and their expiries
- `saveTenant`
- `onAuthFailure` — log the reason instead of failing silently

Mirrors [`iblai/os` `providers/index.tsx`](https://github.com/iblai/os/blob/main/providers/index.tsx), which defines `saveUserTokens(tokenResponse)` for exactly this.

## Note on scope

This is a real gap against the `os` reference wiring and worth fixing on its own. In the case that surfaced it, the *root* cause of the loop turned out to be a different misconfiguration (unsetting `NEXT_PUBLIC_API_BASE_URL`), documented separately — so I can't claim this alone fixes that loop. It removes a genuine way to hit it and closes the divergence from `os`.

## Files

- `skills/iblai-vibe-ops-init/assets/vibe-starter/providers/iblai-providers.tsx`
- `skills/iblai-vibe-auth/assets/iblai-providers.tsx.j2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)