### PR TITLE
fix: IBLAI_USERNAME identity chain (no users/platforms auto-detect), …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ import { SsoLogin, UserProfileDropdown } from "@iblai/iblai-js/web-containers/ne
 DOMAIN=iblai.app
 PLATFORM=your-platform
 TOKEN=your-api-token
-USERNAME=your-username           # Optional — filled in by /iblai-vibe-ops-deploy on first deploy
+IBLAI_USERNAME=your-username     # Optional — env var wins; /iblai-vibe-ops-deploy asks once and persists it
 ```
 
 Map `DOMAIN`, `PLATFORM`, and `TOKEN` from `iblai.env` into the

--- a/README.md
+++ b/README.md
@@ -348,8 +348,8 @@ Skills are in `skills/` (symlinked to `.claude/skills/`). Read them, extend them
 Deploy through the ibl.ai platform's hosting API (Vercel-backed) -- see
 [`/iblai-vibe-ops-deploy`](skills/iblai-vibe-ops-deploy/SKILL.md). No Vercel
 account or token: the skill zips your app, uploads it with your platform
-API key, polls until the build is READY, and returns a live
-`https://<project>.vercel.app` URL.
+API key, polls until the build is READY, and returns the live `*.vercel.app` URL
+Vercel reports.
 
 
 ### Tauri (Desktop & Mobile)

--- a/adapters/codex/iblai-vibe-monetization-app-paywall.md
+++ b/adapters/codex/iblai-vibe-monetization-app-paywall.md
@@ -36,9 +36,10 @@ Selling items *inside* the app instead? Use the Connect family — start at
 
 ## Prerequisites
 
-- `iblai.env` with `PLATFORM` + `TOKEN` (platform API key). `USERNAME` is
-  auto-detected and persisted on first use (same Step 1 as
-  `/iblai-vibe-ops-deploy`).
+- `iblai.env` with `PLATFORM` + `TOKEN` (platform API key). `IBLAI_USERNAME`
+  comes from the environment (the ibl.ai desktop app exports it) or from
+  `iblai.env`; if neither has it, ask the user once and persist it (same
+  Step 1 as `/iblai-vibe-ops-deploy`).
 - A scaffolded vibe-starter app with working SSO auth.
 - The admin has a Stripe account and can mint a **restricted** key
   (`rk_…`) — never store a full live secret key.
@@ -53,9 +54,9 @@ Selling items *inside* the app instead? Use the Connect family — start at
 
 Full curls, error table, and verify list: [`references/setup-api.md`](references/setup-api.md).
 Condensed sequence — read `iblai.env` with the `val()` reader (do not
-`source` it), auto-detect `USERNAME` if absent (both exactly as in
-`/iblai-vibe-ops-deploy` Step 1), then with
-`PAY="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$USERNAME/providers/stripe/payments"`
+`source` it), resolve `IBLAI_USERNAME` (env → `iblai.env` → ask once; both
+exactly as in `/iblai-vibe-ops-deploy` Step 1), then with
+`PAY="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$IBLAI_USERNAME/providers/stripe/payments"`
 and `AUTH="Authorization: Api-Token $TOKEN"`:
 
 1. **Store the Stripe key** (skip if `GET $PAY/products/` already returns
@@ -63,8 +64,8 @@ and `AUTH="Authorization: Api-Token $TOKEN"`:
    with `{"name":"stripe","value":{"key":"rk_…"},"platform":"$PLATFORM"}`.
    Never echo the key.
 2. **Verify**: `GET $PAY/products/` → 200. (400 = credential missing,
-   502 = Stripe rejected the key, 404 = old backend or `$USERNAME` not a
-   member.)
+   502 = Stripe rejected the key, 404 = old backend or `$IBLAI_USERNAME`
+   not a member.)
 3. **Create the product**, tagged for this app:
    `POST $PAY/products/` `{"name":"<App> access","metadata":{"app":"<slug>"}}`.
    The `metadata.app` tag is what the DM enforces at checkout — it must
@@ -139,7 +140,7 @@ deploy first, or attach the domain.
       `sessionStorage` → access lapses within ~75s (DM cache) + up to 60s of
       client grant cache
 - [ ] Deployed: `.env.production` in the zip carries both `PAYWALL_*` lines;
-      SSO lands on `<project>.vercel.app/sso-login-complete` and `axd_token`
+      SSO lands on the deployed app's `/sso-login-complete` and `axd_token`
       appears in localStorage
 
 ## Deliberately not built
@@ -163,7 +164,7 @@ deploy first, or attach the domain.
 - Calling the DM paywall endpoints from the browser — the Api-Token is
   org-wide authority; only the app's server routes hold it.
 - Mixing auth schemes: DM paywall/proxy calls take
-  `Api-Token <platform key>`; `core/users/platforms/` identity resolution
+  `Api-Token <platform key>`; `core/token/verify/` identity resolution
   takes the end user's `Token <dm_token>`.
 - Forgetting `PAYWALL_*` in `.env.production` — works locally, then every
   deployed user gets 500s from the paywall routes.

--- a/adapters/codex/iblai-vibe-ops-deploy.md
+++ b/adapters/codex/iblai-vibe-ops-deploy.md
@@ -12,35 +12,34 @@ no Vercel token, no `vercel` CLI.
 > **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
 
 **How it works:** zip the app, POST it to the platform's hosting endpoint,
-poll until the build is READY. The app lands on
-`https://<vercel_project_name>.vercel.app`, public by default (no Vercel
+poll until the build is READY. The app lands on the `*.vercel.app` URL the
+API reports (never derived from the project name), public by default (no Vercel
 SSO/password protection to disable). POST again with the same `project`
 slug to redeploy.
 
 ## Step 1: Config
 
-Read `iblai.env` (values may contain spaces — do not `source` it):
+Read `iblai.env` (values may contain spaces — do not `source` it). The
+platform username comes from the `IBLAI_USERNAME` environment variable when
+the host provides it (the ibl.ai desktop app exports it), else from
+`iblai.env`. (Never name the variable `USERNAME` — zsh binds that to the OS
+login name and silently discards assignments.)
 
 ```bash
 val() { grep -m1 "^$1=" iblai.env | cut -d= -f2-; }
-DOMAIN=$(val DOMAIN); PLATFORM=$(val PLATFORM); TOKEN=$(val TOKEN); USERNAME=$(val USERNAME)
+DOMAIN=$(val DOMAIN); PLATFORM=$(val PLATFORM); TOKEN=$(val TOKEN)
+IBLAI_USERNAME="${IBLAI_USERNAME:-$(val IBLAI_USERNAME)}"
+[ -n "$IBLAI_USERNAME" ] || IBLAI_USERNAME=$(val USERNAME)   # legacy iblai.env key
 AUTH="Authorization: Api-Token $TOKEN"
 ```
 
-If `USERNAME` is empty, auto-detect the key owner's platform username and
-persist it:
+If `IBLAI_USERNAME` is still empty, ask the user once for their platform
+username and persist it: append `IBLAI_USERNAME=…` to `iblai.env`. Do not
+try to auto-detect it and do not pre-verify the token — a wrong username or
+token fails loudly on the first deploy call below. Then:
 
 ```bash
-USERNAME=$(curl -s "https://api.$DOMAIN/dm/api/core/users/platforms/" -H "$AUTH" \
-  | jq -r --arg p "$PLATFORM" '(.results // .) | first(.[] | select(.key == $p) | .username) // empty')
-[ -n "$USERNAME" ] && echo "USERNAME=$USERNAME" >> iblai.env
-```
-
-If auto-detect comes back empty, ask the user once for their platform
-username and append `USERNAME=…` to `iblai.env` the same way. Then:
-
-```bash
-BASE="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$USERNAME"
+BASE="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$IBLAI_USERNAME"
 ```
 
 ## Step 2: Project slug + mode
@@ -81,7 +80,7 @@ the guards abort the deploy loudly instead of shipping a broken app:
 
 ```bash
 # 1. Regenerate runtime env from .env.local on every deploy (never stale)
-grep -E '^(NEXT_PUBLIC_[A-Za-z0-9_]+|IBLAI_API_KEY|PAYWALL_[A-Za-z0-9_]+)=' .env.local | grep -vE '=$|=your-' > .env.production
+grep -E '^(NEXT_PUBLIC_[A-Za-z0-9_]+|IBLAI_API_KEY|PAYWALL_[A-Za-z0-9_]+|CSP_MODE)=' .env.local | grep -vE '=$|=your-' > .env.production
 
 # 2. Guard: the server needs its platform key
 grep -q '^IBLAI_API_KEY=' .env.production || { echo "ABORT: IBLAI_API_KEY missing/placeholder — fill it in .env.local"; exit 1; }
@@ -105,26 +104,45 @@ key.)
 RESP=$(curl -s -X POST "$BASE/providers/vercel/hosting/deployment/" -H "$AUTH" \
   -F "file=@app.zip" -F "project=$PROJECT" -F "framework=$MODE")
 ID=$(echo "$RESP" | jq -r .id)
-APP_URL="https://$(echo "$RESP" | jq -r .vercel_project_name).vercel.app"
+# The live URL is Vercel's to mint — NEVER build it from the project name
+# (long names get right-truncated, collisions get a hash suffix). `.url` is
+# the confirmed host from a previous deploy; empty on the very first one —
+# the poll below fills it from the deployment's alias list.
+APP_URL=$(echo "$RESP" | jq -r '.url // empty')
 ```
 
 A `202` returns the project row (`{id, name, vercel_project_name, url,
-push_state, …}`). Anything else → see the error table.
+vercel_alias, push_state, …}`). Anything else → see the error table.
 
 Poll until the build finishes (static deploys take seconds, server builds a
 few minutes; give up after ~10 min):
 
 ```bash
 STATE=BUILDING; TRIES=0
-until [ "$STATE" = "READY" ] || [ "$STATE" = "ERROR" ] || [ $TRIES -ge 60 ]; do
+until [ "$STATE" = "READY" ] || [ "$STATE" = "ERROR" ] || [ "$STATE" = "PUSH_FAILED" ] || [ $TRIES -ge 60 ]; do
   sleep 10; TRIES=$((TRIES+1))
-  STATE=$(curl -s "$BASE/providers/vercel/hosting/deployment/$ID/" -H "$AUTH" \
-    | jq -r '.deployment.ready_state')
+  R=$(curl -s "$BASE/providers/vercel/hosting/deployment/$ID/" -H "$AUTH")
+  case "$(echo "$R" | jq -r .push_state)" in
+    failed) echo "push failed: $(echo "$R" | jq -r .push_error)"; STATE=PUSH_FAILED ;;
+    # .deployment is the PREVIOUS deployment until the new push lands — read
+    # it only after push_state reaches "pushed", or a stale READY masks failure
+    pushed)
+      STATE=$(echo "$R" | jq -r '.deployment.ready_state // "BUILDING"')
+      # The deployment's alias list is the authoritative live host.
+      ALIAS=$(echo "$R" | jq -r '.deployment.aliases[0] // empty')
+      [ -n "$ALIAS" ] && APP_URL="https://$ALIAS" ;;
+  esac
 done
-echo "$STATE $APP_URL"
+echo "$STATE ${APP_URL:-'(URL not reported yet)'}"
 ```
 
-On `ERROR`, print the build log tail and fix what it reports:
+If `APP_URL` is still empty on READY, re-poll the detail endpoint and read
+`.deployment.aliases[0]` — tell the user the URL is not confirmed yet rather
+than guessing one from the project name.
+
+On `PUSH_FAILED`, the printed `push_error` says why the upload never reached
+Vercel (fix it, rebuild the zip, POST again). On `ERROR`, print the build
+log tail and fix what it reports:
 
 ```bash
 curl -s "$BASE/providers/vercel/hosting/deployment/$ID/" -H "$AUTH" | jq -r '.build_log_tail'
@@ -134,8 +152,9 @@ Redeploy = rebuild the zip, POST again with the same `project`.
 
 ## Step 5: Update Tauri (if present)
 
-If `src-tauri/tauri.conf.json` exists, set `build.devUrl` to the deployed
-URL so mobile/desktop dev builds load the hosted frontend.
+If `src-tauri/tauri.conf.json` exists and `APP_URL` is known, set
+`build.devUrl` to it so mobile/desktop dev builds load the hosted frontend.
+(Skip while the URL is unconfirmed — never write a guessed one.)
 
 ## Errors
 

--- a/adapters/codex/iblai-vibe-ops-init.md
+++ b/adapters/codex/iblai-vibe-ops-init.md
@@ -241,8 +241,9 @@ All features require auth first (`/iblai-vibe-auth`).
 ## Environment
 
 Platform configuration lives in `iblai.env` (`DOMAIN`, `PLATFORM`, `TOKEN`,
-and optionally `USERNAME` — your platform username, filled in by the deploy
-skill on first deploy). Map these into `.env.local`:
+and optionally `IBLAI_USERNAME` — your platform username; the
+`IBLAI_USERNAME` environment variable wins when the host exports it, and the
+deploy skill asks once and persists it otherwise). Map these into `.env.local`:
 `NEXT_PUBLIC_MAIN_TENANT_KEY` ← `PLATFORM`; the `NEXT_PUBLIC_*`
 API URLs default to `iblai.app`.
 

--- a/adapters/codex/iblai-vibe-readme.md
+++ b/adapters/codex/iblai-vibe-readme.md
@@ -34,7 +34,7 @@ Before writing, gather these inputs:
 | Source | Reads |
 |--------|-------|
 | `package.json` | `name`, `version`, `description`, `scripts.{dev,build,start,release}` |
-| `iblai.env` | `DOMAIN`, `PLATFORM` (+ optional `USERNAME`) |
+| `iblai.env` | `DOMAIN`, `PLATFORM` (+ optional `IBLAI_USERNAME`) |
 | `Dockerfile` | Presence → include the **Docker** section |
 | `next.config.{ts,mjs,js}` | `output: 'export'` → static mode; otherwise server mode (for the Deploy section copy) |
 | `src-tauri/tauri.conf.json` | Presence → include the **Native builds** section AND keep the **Deploy** section (mobile dev builds use the hosted URL) |
@@ -172,7 +172,7 @@ Deploy through the ibl.ai platform's hosting API (Vercel-backed) with
 No Vercel account or token — auth is the platform API key (`TOKEN`) in
 `iblai.env`. The skill zips the app (the `out/` export in static mode, the
 project source in server mode), uploads it, polls until the build is
-READY, and prints the live `https://<project>.vercel.app` URL. Re-run it
+READY, and prints the live `*.vercel.app` URL Vercel reports. Re-run it
 to redeploy; attach custom domains via the hosting DNS endpoint (the skill
 returns the DNS records to add).
 

--- a/adapters/cursor/iblai-vibe-monetization-app-paywall.mdc
+++ b/adapters/cursor/iblai-vibe-monetization-app-paywall.mdc
@@ -38,9 +38,10 @@ Selling items *inside* the app instead? Use the Connect family — start at
 
 ## Prerequisites
 
-- `iblai.env` with `PLATFORM` + `TOKEN` (platform API key). `USERNAME` is
-  auto-detected and persisted on first use (same Step 1 as
-  `/iblai-vibe-ops-deploy`).
+- `iblai.env` with `PLATFORM` + `TOKEN` (platform API key). `IBLAI_USERNAME`
+  comes from the environment (the ibl.ai desktop app exports it) or from
+  `iblai.env`; if neither has it, ask the user once and persist it (same
+  Step 1 as `/iblai-vibe-ops-deploy`).
 - A scaffolded vibe-starter app with working SSO auth.
 - The admin has a Stripe account and can mint a **restricted** key
   (`rk_…`) — never store a full live secret key.
@@ -55,9 +56,9 @@ Selling items *inside* the app instead? Use the Connect family — start at
 
 Full curls, error table, and verify list: [`references/setup-api.md`](references/setup-api.md).
 Condensed sequence — read `iblai.env` with the `val()` reader (do not
-`source` it), auto-detect `USERNAME` if absent (both exactly as in
-`/iblai-vibe-ops-deploy` Step 1), then with
-`PAY="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$USERNAME/providers/stripe/payments"`
+`source` it), resolve `IBLAI_USERNAME` (env → `iblai.env` → ask once; both
+exactly as in `/iblai-vibe-ops-deploy` Step 1), then with
+`PAY="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$IBLAI_USERNAME/providers/stripe/payments"`
 and `AUTH="Authorization: Api-Token $TOKEN"`:
 
 1. **Store the Stripe key** (skip if `GET $PAY/products/` already returns
@@ -65,8 +66,8 @@ and `AUTH="Authorization: Api-Token $TOKEN"`:
    with `{"name":"stripe","value":{"key":"rk_…"},"platform":"$PLATFORM"}`.
    Never echo the key.
 2. **Verify**: `GET $PAY/products/` → 200. (400 = credential missing,
-   502 = Stripe rejected the key, 404 = old backend or `$USERNAME` not a
-   member.)
+   502 = Stripe rejected the key, 404 = old backend or `$IBLAI_USERNAME`
+   not a member.)
 3. **Create the product**, tagged for this app:
    `POST $PAY/products/` `{"name":"<App> access","metadata":{"app":"<slug>"}}`.
    The `metadata.app` tag is what the DM enforces at checkout — it must
@@ -141,7 +142,7 @@ deploy first, or attach the domain.
       `sessionStorage` → access lapses within ~75s (DM cache) + up to 60s of
       client grant cache
 - [ ] Deployed: `.env.production` in the zip carries both `PAYWALL_*` lines;
-      SSO lands on `<project>.vercel.app/sso-login-complete` and `axd_token`
+      SSO lands on the deployed app's `/sso-login-complete` and `axd_token`
       appears in localStorage
 
 ## Deliberately not built
@@ -165,7 +166,7 @@ deploy first, or attach the domain.
 - Calling the DM paywall endpoints from the browser — the Api-Token is
   org-wide authority; only the app's server routes hold it.
 - Mixing auth schemes: DM paywall/proxy calls take
-  `Api-Token <platform key>`; `core/users/platforms/` identity resolution
+  `Api-Token <platform key>`; `core/token/verify/` identity resolution
   takes the end user's `Token <dm_token>`.
 - Forgetting `PAYWALL_*` in `.env.production` — works locally, then every
   deployed user gets 500s from the paywall routes.

--- a/adapters/cursor/iblai-vibe-ops-deploy.mdc
+++ b/adapters/cursor/iblai-vibe-ops-deploy.mdc
@@ -14,35 +14,34 @@ no Vercel token, no `vercel` CLI.
 > **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
 
 **How it works:** zip the app, POST it to the platform's hosting endpoint,
-poll until the build is READY. The app lands on
-`https://<vercel_project_name>.vercel.app`, public by default (no Vercel
+poll until the build is READY. The app lands on the `*.vercel.app` URL the
+API reports (never derived from the project name), public by default (no Vercel
 SSO/password protection to disable). POST again with the same `project`
 slug to redeploy.
 
 ## Step 1: Config
 
-Read `iblai.env` (values may contain spaces — do not `source` it):
+Read `iblai.env` (values may contain spaces — do not `source` it). The
+platform username comes from the `IBLAI_USERNAME` environment variable when
+the host provides it (the ibl.ai desktop app exports it), else from
+`iblai.env`. (Never name the variable `USERNAME` — zsh binds that to the OS
+login name and silently discards assignments.)
 
 ```bash
 val() { grep -m1 "^$1=" iblai.env | cut -d= -f2-; }
-DOMAIN=$(val DOMAIN); PLATFORM=$(val PLATFORM); TOKEN=$(val TOKEN); USERNAME=$(val USERNAME)
+DOMAIN=$(val DOMAIN); PLATFORM=$(val PLATFORM); TOKEN=$(val TOKEN)
+IBLAI_USERNAME="${IBLAI_USERNAME:-$(val IBLAI_USERNAME)}"
+[ -n "$IBLAI_USERNAME" ] || IBLAI_USERNAME=$(val USERNAME)   # legacy iblai.env key
 AUTH="Authorization: Api-Token $TOKEN"
 ```
 
-If `USERNAME` is empty, auto-detect the key owner's platform username and
-persist it:
+If `IBLAI_USERNAME` is still empty, ask the user once for their platform
+username and persist it: append `IBLAI_USERNAME=…` to `iblai.env`. Do not
+try to auto-detect it and do not pre-verify the token — a wrong username or
+token fails loudly on the first deploy call below. Then:
 
 ```bash
-USERNAME=$(curl -s "https://api.$DOMAIN/dm/api/core/users/platforms/" -H "$AUTH" \
-  | jq -r --arg p "$PLATFORM" '(.results // .) | first(.[] | select(.key == $p) | .username) // empty')
-[ -n "$USERNAME" ] && echo "USERNAME=$USERNAME" >> iblai.env
-```
-
-If auto-detect comes back empty, ask the user once for their platform
-username and append `USERNAME=…` to `iblai.env` the same way. Then:
-
-```bash
-BASE="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$USERNAME"
+BASE="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$IBLAI_USERNAME"
 ```
 
 ## Step 2: Project slug + mode
@@ -83,7 +82,7 @@ the guards abort the deploy loudly instead of shipping a broken app:
 
 ```bash
 # 1. Regenerate runtime env from .env.local on every deploy (never stale)
-grep -E '^(NEXT_PUBLIC_[A-Za-z0-9_]+|IBLAI_API_KEY|PAYWALL_[A-Za-z0-9_]+)=' .env.local | grep -vE '=$|=your-' > .env.production
+grep -E '^(NEXT_PUBLIC_[A-Za-z0-9_]+|IBLAI_API_KEY|PAYWALL_[A-Za-z0-9_]+|CSP_MODE)=' .env.local | grep -vE '=$|=your-' > .env.production
 
 # 2. Guard: the server needs its platform key
 grep -q '^IBLAI_API_KEY=' .env.production || { echo "ABORT: IBLAI_API_KEY missing/placeholder — fill it in .env.local"; exit 1; }
@@ -107,26 +106,45 @@ key.)
 RESP=$(curl -s -X POST "$BASE/providers/vercel/hosting/deployment/" -H "$AUTH" \
   -F "file=@app.zip" -F "project=$PROJECT" -F "framework=$MODE")
 ID=$(echo "$RESP" | jq -r .id)
-APP_URL="https://$(echo "$RESP" | jq -r .vercel_project_name).vercel.app"
+# The live URL is Vercel's to mint — NEVER build it from the project name
+# (long names get right-truncated, collisions get a hash suffix). `.url` is
+# the confirmed host from a previous deploy; empty on the very first one —
+# the poll below fills it from the deployment's alias list.
+APP_URL=$(echo "$RESP" | jq -r '.url // empty')
 ```
 
 A `202` returns the project row (`{id, name, vercel_project_name, url,
-push_state, …}`). Anything else → see the error table.
+vercel_alias, push_state, …}`). Anything else → see the error table.
 
 Poll until the build finishes (static deploys take seconds, server builds a
 few minutes; give up after ~10 min):
 
 ```bash
 STATE=BUILDING; TRIES=0
-until [ "$STATE" = "READY" ] || [ "$STATE" = "ERROR" ] || [ $TRIES -ge 60 ]; do
+until [ "$STATE" = "READY" ] || [ "$STATE" = "ERROR" ] || [ "$STATE" = "PUSH_FAILED" ] || [ $TRIES -ge 60 ]; do
   sleep 10; TRIES=$((TRIES+1))
-  STATE=$(curl -s "$BASE/providers/vercel/hosting/deployment/$ID/" -H "$AUTH" \
-    | jq -r '.deployment.ready_state')
+  R=$(curl -s "$BASE/providers/vercel/hosting/deployment/$ID/" -H "$AUTH")
+  case "$(echo "$R" | jq -r .push_state)" in
+    failed) echo "push failed: $(echo "$R" | jq -r .push_error)"; STATE=PUSH_FAILED ;;
+    # .deployment is the PREVIOUS deployment until the new push lands — read
+    # it only after push_state reaches "pushed", or a stale READY masks failure
+    pushed)
+      STATE=$(echo "$R" | jq -r '.deployment.ready_state // "BUILDING"')
+      # The deployment's alias list is the authoritative live host.
+      ALIAS=$(echo "$R" | jq -r '.deployment.aliases[0] // empty')
+      [ -n "$ALIAS" ] && APP_URL="https://$ALIAS" ;;
+  esac
 done
-echo "$STATE $APP_URL"
+echo "$STATE ${APP_URL:-'(URL not reported yet)'}"
 ```
 
-On `ERROR`, print the build log tail and fix what it reports:
+If `APP_URL` is still empty on READY, re-poll the detail endpoint and read
+`.deployment.aliases[0]` — tell the user the URL is not confirmed yet rather
+than guessing one from the project name.
+
+On `PUSH_FAILED`, the printed `push_error` says why the upload never reached
+Vercel (fix it, rebuild the zip, POST again). On `ERROR`, print the build
+log tail and fix what it reports:
 
 ```bash
 curl -s "$BASE/providers/vercel/hosting/deployment/$ID/" -H "$AUTH" | jq -r '.build_log_tail'
@@ -136,8 +154,9 @@ Redeploy = rebuild the zip, POST again with the same `project`.
 
 ## Step 5: Update Tauri (if present)
 
-If `src-tauri/tauri.conf.json` exists, set `build.devUrl` to the deployed
-URL so mobile/desktop dev builds load the hosted frontend.
+If `src-tauri/tauri.conf.json` exists and `APP_URL` is known, set
+`build.devUrl` to it so mobile/desktop dev builds load the hosted frontend.
+(Skip while the URL is unconfirmed — never write a guessed one.)
 
 ## Errors
 

--- a/adapters/cursor/iblai-vibe-ops-init.mdc
+++ b/adapters/cursor/iblai-vibe-ops-init.mdc
@@ -243,8 +243,9 @@ All features require auth first (`/iblai-vibe-auth`).
 ## Environment
 
 Platform configuration lives in `iblai.env` (`DOMAIN`, `PLATFORM`, `TOKEN`,
-and optionally `USERNAME` — your platform username, filled in by the deploy
-skill on first deploy). Map these into `.env.local`:
+and optionally `IBLAI_USERNAME` — your platform username; the
+`IBLAI_USERNAME` environment variable wins when the host exports it, and the
+deploy skill asks once and persists it otherwise). Map these into `.env.local`:
 `NEXT_PUBLIC_MAIN_TENANT_KEY` ← `PLATFORM`; the `NEXT_PUBLIC_*`
 API URLs default to `iblai.app`.
 

--- a/adapters/cursor/iblai-vibe-readme.mdc
+++ b/adapters/cursor/iblai-vibe-readme.mdc
@@ -36,7 +36,7 @@ Before writing, gather these inputs:
 | Source | Reads |
 |--------|-------|
 | `package.json` | `name`, `version`, `description`, `scripts.{dev,build,start,release}` |
-| `iblai.env` | `DOMAIN`, `PLATFORM` (+ optional `USERNAME`) |
+| `iblai.env` | `DOMAIN`, `PLATFORM` (+ optional `IBLAI_USERNAME`) |
 | `Dockerfile` | Presence → include the **Docker** section |
 | `next.config.{ts,mjs,js}` | `output: 'export'` → static mode; otherwise server mode (for the Deploy section copy) |
 | `src-tauri/tauri.conf.json` | Presence → include the **Native builds** section AND keep the **Deploy** section (mobile dev builds use the hosted URL) |
@@ -174,7 +174,7 @@ Deploy through the ibl.ai platform's hosting API (Vercel-backed) with
 No Vercel account or token — auth is the platform API key (`TOKEN`) in
 `iblai.env`. The skill zips the app (the `out/` export in static mode, the
 project source in server mode), uploads it, polls until the build is
-READY, and prints the live `https://<project>.vercel.app` URL. Re-run it
+READY, and prints the live `*.vercel.app` URL Vercel reports. Re-run it
 to redeploy; attach custom domains via the hosting DNS endpoint (the skill
 returns the DNS records to add).
 

--- a/docs/skill-setup.md
+++ b/docs/skill-setup.md
@@ -41,9 +41,10 @@ Full brand guidelines:
 ## Environment files
 
 - `iblai.env` is **NOT** a `.env.local` replacement — it holds the platform
-  shorthand (`DOMAIN`, `PLATFORM`, `TOKEN`, optional `USERNAME` for deploys)
-  plus the `AUTH_*` branding values. Next.js still reads its runtime env
-  vars from `.env.local`.
+  shorthand (`DOMAIN`, `PLATFORM`, `TOKEN`, optional `IBLAI_USERNAME` for
+  deploys — the `IBLAI_USERNAME` environment variable wins when the host
+  exports it) plus the `AUTH_*` branding values. Next.js still reads its
+  runtime env vars from `.env.local`.
 - The skills read `iblai.env` and derive the `NEXT_PUBLIC_*` values into
   `.env.local`. vibe-starter apps need only the tenant key and
   `IBLAI_API_KEY` — URL defaults live in `lib/iblai/config.ts`.

--- a/skills/iblai-vibe-monetization-app-paywall/SKILL.md
+++ b/skills/iblai-vibe-monetization-app-paywall/SKILL.md
@@ -39,9 +39,10 @@ Selling items *inside* the app instead? Use the Connect family — start at
 
 ## Prerequisites
 
-- `iblai.env` with `PLATFORM` + `TOKEN` (platform API key). `USERNAME` is
-  auto-detected and persisted on first use (same Step 1 as
-  `/iblai-vibe-ops-deploy`).
+- `iblai.env` with `PLATFORM` + `TOKEN` (platform API key). `IBLAI_USERNAME`
+  comes from the environment (the ibl.ai desktop app exports it) or from
+  `iblai.env`; if neither has it, ask the user once and persist it (same
+  Step 1 as `/iblai-vibe-ops-deploy`).
 - A scaffolded vibe-starter app with working SSO auth.
 - The admin has a Stripe account and can mint a **restricted** key
   (`rk_…`) — never store a full live secret key.
@@ -56,9 +57,9 @@ Selling items *inside* the app instead? Use the Connect family — start at
 
 Full curls, error table, and verify list: [`references/setup-api.md`](references/setup-api.md).
 Condensed sequence — read `iblai.env` with the `val()` reader (do not
-`source` it), auto-detect `USERNAME` if absent (both exactly as in
-`/iblai-vibe-ops-deploy` Step 1), then with
-`PAY="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$USERNAME/providers/stripe/payments"`
+`source` it), resolve `IBLAI_USERNAME` (env → `iblai.env` → ask once; both
+exactly as in `/iblai-vibe-ops-deploy` Step 1), then with
+`PAY="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$IBLAI_USERNAME/providers/stripe/payments"`
 and `AUTH="Authorization: Api-Token $TOKEN"`:
 
 1. **Store the Stripe key** (skip if `GET $PAY/products/` already returns
@@ -66,8 +67,8 @@ and `AUTH="Authorization: Api-Token $TOKEN"`:
    with `{"name":"stripe","value":{"key":"rk_…"},"platform":"$PLATFORM"}`.
    Never echo the key.
 2. **Verify**: `GET $PAY/products/` → 200. (400 = credential missing,
-   502 = Stripe rejected the key, 404 = old backend or `$USERNAME` not a
-   member.)
+   502 = Stripe rejected the key, 404 = old backend or `$IBLAI_USERNAME`
+   not a member.)
 3. **Create the product**, tagged for this app:
    `POST $PAY/products/` `{"name":"<App> access","metadata":{"app":"<slug>"}}`.
    The `metadata.app` tag is what the DM enforces at checkout — it must
@@ -142,7 +143,7 @@ deploy first, or attach the domain.
       `sessionStorage` → access lapses within ~75s (DM cache) + up to 60s of
       client grant cache
 - [ ] Deployed: `.env.production` in the zip carries both `PAYWALL_*` lines;
-      SSO lands on `<project>.vercel.app/sso-login-complete` and `axd_token`
+      SSO lands on the deployed app's `/sso-login-complete` and `axd_token`
       appears in localStorage
 
 ## Deliberately not built
@@ -166,7 +167,7 @@ deploy first, or attach the domain.
 - Calling the DM paywall endpoints from the browser — the Api-Token is
   org-wide authority; only the app's server routes hold it.
 - Mixing auth schemes: DM paywall/proxy calls take
-  `Api-Token <platform key>`; `core/users/platforms/` identity resolution
+  `Api-Token <platform key>`; `core/token/verify/` identity resolution
   takes the end user's `Token <dm_token>`.
 - Forgetting `PAYWALL_*` in `.env.production` — works locally, then every
   deployed user gets 500s from the paywall routes.

--- a/skills/iblai-vibe-monetization-app-paywall/references/app-files.md
+++ b/skills/iblai-vibe-monetization-app-paywall/references/app-files.md
@@ -23,17 +23,17 @@ export async function resolveUser(dmToken: string): Promise<PaywallUser | null> 
   const hit = identityCache.get(dmToken);
   if (hit && Date.now() - hit.at < IDENTITY_TTL_MS) return hit.user;
 
-  const res = await fetch(`${config.dmUrl()}/api/core/users/platforms/`, {
+  const res = await fetch(`${config.dmUrl()}/api/core/token/verify/`, {
     headers: { Authorization: `Token ${dmToken}` },
     cache: "no-store",
   });
   if (!res.ok) return null; // don't cache failures — token may be mid-refresh
 
   const body = await res.json().catch(() => null);
-  // Tolerate both bare-array and {results: []} shapes.
-  const memberships: any[] = Array.isArray(body) ? body : (body?.results ?? []);
-  const m = memberships.find((x) => x?.key === config.mainTenantKey());
-  const user = m ? { username: m.username, email: m.email } : null;
+  // token/verify returns the token's own user: {username, email, …}. Platform
+  // membership is enforced server-side by the payments endpoints (404 for
+  // non-members), so there is no client-side membership check to get wrong.
+  const user = body?.username ? { username: body.username, email: body.email ?? "" } : null;
   identityCache.set(dmToken, { user, at: Date.now() });
   return user;
 }

--- a/skills/iblai-vibe-monetization-app-paywall/references/setup-api.md
+++ b/skills/iblai-vibe-monetization-app-paywall/references/setup-api.md
@@ -6,29 +6,26 @@ echo the Stripe key into logs and never commit it.
 
 ## 0. Shorthand
 
-Read `iblai.env` (values may contain spaces — do not `source` it):
+Read `iblai.env` (values may contain spaces — do not `source` it). The
+platform username comes from the `IBLAI_USERNAME` environment variable when
+the host provides it, else from `iblai.env` — same as
+`/iblai-vibe-ops-deploy` Step 1 (never name the variable `USERNAME`: zsh
+binds that to the OS login name and silently discards assignments):
 
 ```bash
 val() { grep -m1 "^$1=" iblai.env | cut -d= -f2-; }
-DOMAIN=$(val DOMAIN); PLATFORM=$(val PLATFORM); TOKEN=$(val TOKEN); USERNAME=$(val USERNAME)
+DOMAIN=$(val DOMAIN); PLATFORM=$(val PLATFORM); TOKEN=$(val TOKEN)
+IBLAI_USERNAME="${IBLAI_USERNAME:-$(val IBLAI_USERNAME)}"
+[ -n "$IBLAI_USERNAME" ] || IBLAI_USERNAME=$(val USERNAME)   # legacy iblai.env key
 AUTH="Authorization: Api-Token $TOKEN"
 DM="https://api.$DOMAIN/dm"
 ```
 
-If `USERNAME` is empty, auto-detect the key owner's platform username and
-persist it (same as `/iblai-vibe-ops-deploy` Step 1):
+If `IBLAI_USERNAME` is still empty, ask the user once for their platform
+username and append `IBLAI_USERNAME=…` to `iblai.env`. Then:
 
 ```bash
-USERNAME=$(curl -s "$DM/api/core/users/platforms/" -H "$AUTH" \
-  | jq -r --arg p "$PLATFORM" '(.results // .) | first(.[] | select(.key == $p) | .username) // empty')
-[ -n "$USERNAME" ] && echo "USERNAME=$USERNAME" >> iblai.env
-```
-
-(If auto-detect comes back empty, ask the user once and append the line the
-same way.) Then:
-
-```bash
-PAY="$DM/api/ai-mentor/orgs/$PLATFORM/users/$USERNAME/providers/stripe/payments"
+PAY="$DM/api/ai-mentor/orgs/$PLATFORM/users/$IBLAI_USERNAME/providers/stripe/payments"
 ```
 
 ## 1. Store the tenant's Stripe key
@@ -54,7 +51,7 @@ curl -s "$PAY/products/?limit=1" -H "$AUTH"
 - `400` with a self-describing message → credential missing; do step 1.
 - `502` → Stripe rejected the stored key (typo / wrong mode) — re-save it.
 - `404` → either the platform backend predates the Stripe proxy/paywall
-  (needs ibl-dm-pro ≥ PR #2977) or `$USERNAME` is not a member of
+  (needs ibl-dm-pro ≥ PR #2977) or `$IBLAI_USERNAME` is not a member of
   `$PLATFORM`. Fix before continuing.
 
 ## 3. Create the product, tagged for this app
@@ -114,7 +111,7 @@ refresh on every uncached access check.
 | Status | Meaning | Fix |
 |---|---|---|
 | 400 | Missing credential, or actionable input problem (wrong app tag, disallowed redirect host, bad body) | Read the body — it says exactly what to change |
-| 404 | Backend predates the paywall endpoints, or path user not a platform member | Upgrade ibl-dm-pro / fix `USERNAME` |
+| 404 | Backend predates the paywall endpoints, or path user not a platform member | Upgrade ibl-dm-pro / fix `IBLAI_USERNAME` |
 | 429 | Stripe rate limit (passed through) | Wait `Retry-After` seconds, retry |
 | 502 | Stripe rejected the stored key | Re-save a valid `rk_` key |
 

--- a/skills/iblai-vibe-ops-deploy/SKILL.md
+++ b/skills/iblai-vibe-ops-deploy/SKILL.md
@@ -15,35 +15,34 @@ no Vercel token, no `vercel` CLI.
 > **Common setup (brand, conventions, env files, verification):** see [docs/skill-setup.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/docs/skill-setup.md).
 
 **How it works:** zip the app, POST it to the platform's hosting endpoint,
-poll until the build is READY. The app lands on
-`https://<vercel_project_name>.vercel.app`, public by default (no Vercel
+poll until the build is READY. The app lands on the `*.vercel.app` URL the
+API reports (never derived from the project name), public by default (no Vercel
 SSO/password protection to disable). POST again with the same `project`
 slug to redeploy.
 
 ## Step 1: Config
 
-Read `iblai.env` (values may contain spaces — do not `source` it):
+Read `iblai.env` (values may contain spaces — do not `source` it). The
+platform username comes from the `IBLAI_USERNAME` environment variable when
+the host provides it (the ibl.ai desktop app exports it), else from
+`iblai.env`. (Never name the variable `USERNAME` — zsh binds that to the OS
+login name and silently discards assignments.)
 
 ```bash
 val() { grep -m1 "^$1=" iblai.env | cut -d= -f2-; }
-DOMAIN=$(val DOMAIN); PLATFORM=$(val PLATFORM); TOKEN=$(val TOKEN); USERNAME=$(val USERNAME)
+DOMAIN=$(val DOMAIN); PLATFORM=$(val PLATFORM); TOKEN=$(val TOKEN)
+IBLAI_USERNAME="${IBLAI_USERNAME:-$(val IBLAI_USERNAME)}"
+[ -n "$IBLAI_USERNAME" ] || IBLAI_USERNAME=$(val USERNAME)   # legacy iblai.env key
 AUTH="Authorization: Api-Token $TOKEN"
 ```
 
-If `USERNAME` is empty, auto-detect the key owner's platform username and
-persist it:
+If `IBLAI_USERNAME` is still empty, ask the user once for their platform
+username and persist it: append `IBLAI_USERNAME=…` to `iblai.env`. Do not
+try to auto-detect it and do not pre-verify the token — a wrong username or
+token fails loudly on the first deploy call below. Then:
 
 ```bash
-USERNAME=$(curl -s "https://api.$DOMAIN/dm/api/core/users/platforms/" -H "$AUTH" \
-  | jq -r --arg p "$PLATFORM" '(.results // .) | first(.[] | select(.key == $p) | .username) // empty')
-[ -n "$USERNAME" ] && echo "USERNAME=$USERNAME" >> iblai.env
-```
-
-If auto-detect comes back empty, ask the user once for their platform
-username and append `USERNAME=…` to `iblai.env` the same way. Then:
-
-```bash
-BASE="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$USERNAME"
+BASE="https://api.$DOMAIN/dm/api/ai-mentor/orgs/$PLATFORM/users/$IBLAI_USERNAME"
 ```
 
 ## Step 2: Project slug + mode
@@ -84,7 +83,7 @@ the guards abort the deploy loudly instead of shipping a broken app:
 
 ```bash
 # 1. Regenerate runtime env from .env.local on every deploy (never stale)
-grep -E '^(NEXT_PUBLIC_[A-Za-z0-9_]+|IBLAI_API_KEY|PAYWALL_[A-Za-z0-9_]+)=' .env.local | grep -vE '=$|=your-' > .env.production
+grep -E '^(NEXT_PUBLIC_[A-Za-z0-9_]+|IBLAI_API_KEY|PAYWALL_[A-Za-z0-9_]+|CSP_MODE)=' .env.local | grep -vE '=$|=your-' > .env.production
 
 # 2. Guard: the server needs its platform key
 grep -q '^IBLAI_API_KEY=' .env.production || { echo "ABORT: IBLAI_API_KEY missing/placeholder — fill it in .env.local"; exit 1; }
@@ -108,26 +107,45 @@ key.)
 RESP=$(curl -s -X POST "$BASE/providers/vercel/hosting/deployment/" -H "$AUTH" \
   -F "file=@app.zip" -F "project=$PROJECT" -F "framework=$MODE")
 ID=$(echo "$RESP" | jq -r .id)
-APP_URL="https://$(echo "$RESP" | jq -r .vercel_project_name).vercel.app"
+# The live URL is Vercel's to mint — NEVER build it from the project name
+# (long names get right-truncated, collisions get a hash suffix). `.url` is
+# the confirmed host from a previous deploy; empty on the very first one —
+# the poll below fills it from the deployment's alias list.
+APP_URL=$(echo "$RESP" | jq -r '.url // empty')
 ```
 
 A `202` returns the project row (`{id, name, vercel_project_name, url,
-push_state, …}`). Anything else → see the error table.
+vercel_alias, push_state, …}`). Anything else → see the error table.
 
 Poll until the build finishes (static deploys take seconds, server builds a
 few minutes; give up after ~10 min):
 
 ```bash
 STATE=BUILDING; TRIES=0
-until [ "$STATE" = "READY" ] || [ "$STATE" = "ERROR" ] || [ $TRIES -ge 60 ]; do
+until [ "$STATE" = "READY" ] || [ "$STATE" = "ERROR" ] || [ "$STATE" = "PUSH_FAILED" ] || [ $TRIES -ge 60 ]; do
   sleep 10; TRIES=$((TRIES+1))
-  STATE=$(curl -s "$BASE/providers/vercel/hosting/deployment/$ID/" -H "$AUTH" \
-    | jq -r '.deployment.ready_state')
+  R=$(curl -s "$BASE/providers/vercel/hosting/deployment/$ID/" -H "$AUTH")
+  case "$(echo "$R" | jq -r .push_state)" in
+    failed) echo "push failed: $(echo "$R" | jq -r .push_error)"; STATE=PUSH_FAILED ;;
+    # .deployment is the PREVIOUS deployment until the new push lands — read
+    # it only after push_state reaches "pushed", or a stale READY masks failure
+    pushed)
+      STATE=$(echo "$R" | jq -r '.deployment.ready_state // "BUILDING"')
+      # The deployment's alias list is the authoritative live host.
+      ALIAS=$(echo "$R" | jq -r '.deployment.aliases[0] // empty')
+      [ -n "$ALIAS" ] && APP_URL="https://$ALIAS" ;;
+  esac
 done
-echo "$STATE $APP_URL"
+echo "$STATE ${APP_URL:-'(URL not reported yet)'}"
 ```
 
-On `ERROR`, print the build log tail and fix what it reports:
+If `APP_URL` is still empty on READY, re-poll the detail endpoint and read
+`.deployment.aliases[0]` — tell the user the URL is not confirmed yet rather
+than guessing one from the project name.
+
+On `PUSH_FAILED`, the printed `push_error` says why the upload never reached
+Vercel (fix it, rebuild the zip, POST again). On `ERROR`, print the build
+log tail and fix what it reports:
 
 ```bash
 curl -s "$BASE/providers/vercel/hosting/deployment/$ID/" -H "$AUTH" | jq -r '.build_log_tail'
@@ -137,8 +155,9 @@ Redeploy = rebuild the zip, POST again with the same `project`.
 
 ## Step 5: Update Tauri (if present)
 
-If `src-tauri/tauri.conf.json` exists, set `build.devUrl` to the deployed
-URL so mobile/desktop dev builds load the hosted frontend.
+If `src-tauri/tauri.conf.json` exists and `APP_URL` is known, set
+`build.devUrl` to it so mobile/desktop dev builds load the hosted frontend.
+(Skip while the URL is unconfirmed — never write a guessed one.)
 
 ## Errors
 

--- a/skills/iblai-vibe-ops-init/SKILL.md
+++ b/skills/iblai-vibe-ops-init/SKILL.md
@@ -244,8 +244,9 @@ All features require auth first (`/iblai-vibe-auth`).
 ## Environment
 
 Platform configuration lives in `iblai.env` (`DOMAIN`, `PLATFORM`, `TOKEN`,
-and optionally `USERNAME` — your platform username, filled in by the deploy
-skill on first deploy). Map these into `.env.local`:
+and optionally `IBLAI_USERNAME` — your platform username; the
+`IBLAI_USERNAME` environment variable wins when the host exports it, and the
+deploy skill asks once and persists it otherwise). Map these into `.env.local`:
 `NEXT_PUBLIC_MAIN_TENANT_KEY` ← `PLATFORM`; the `NEXT_PUBLIC_*`
 API URLs default to `iblai.app`.
 

--- a/skills/iblai-vibe-ops-init/assets/vibe-starter/AGENTS.md
+++ b/skills/iblai-vibe-ops-init/assets/vibe-starter/AGENTS.md
@@ -84,7 +84,8 @@ All features require auth first (`/iblai-vibe-auth`).
 ## Environment
 
 Platform configuration lives in `iblai.env` (`DOMAIN`, `PLATFORM`, `TOKEN`,
-and optionally `USERNAME` for deploys; copy from
+and optionally `IBLAI_USERNAME` for deploys — the `IBLAI_USERNAME`
+environment variable wins when the host exports it; copy from
 `iblai.env.example`). Treat it as the source of truth: derive the runtime
 vars from it (via the skills) rather than hand-editing them. The one
 real Next env file is the gitignored `.env.local` (copy from `.env.example`):

--- a/skills/iblai-vibe-ops-init/assets/vibe-starter/README.md
+++ b/skills/iblai-vibe-ops-init/assets/vibe-starter/README.md
@@ -182,7 +182,7 @@ pnpm test:e2e        # Playwright E2E
 Run `/iblai-vibe-ops-deploy` — zips the app, uploads it to the ibl.ai
 platform's hosting API using your platform API key (no Vercel account or
 token), polls until the build is READY, and updates `devUrl` in
-`tauri.conf.json`. The app lands on `https://<project>.vercel.app`.
+`tauri.conf.json`. The app lands on the `*.vercel.app` URL the API reports.
 
 ### Tauri (Desktop & Mobile)
 

--- a/skills/iblai-vibe-ops-init/assets/vibe-starter/app/layout.tsx
+++ b/skills/iblai-vibe-ops-init/assets/vibe-starter/app/layout.tsx
@@ -13,6 +13,12 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// The middleware's nonce-based CSP requires per-request rendering: a statically
+// prerendered page ships nonce-less <script> tags that enforce mode blocks
+// (strict-dynamic disables 'self'/https: fallbacks), white-screening the
+// deployed app. Remove this only if the CSP middleware goes too.
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "vibe-starter",
   description: "Built on the ibl.ai platform",

--- a/skills/iblai-vibe-readme/SKILL.md
+++ b/skills/iblai-vibe-readme/SKILL.md
@@ -37,7 +37,7 @@ Before writing, gather these inputs:
 | Source | Reads |
 |--------|-------|
 | `package.json` | `name`, `version`, `description`, `scripts.{dev,build,start,release}` |
-| `iblai.env` | `DOMAIN`, `PLATFORM` (+ optional `USERNAME`) |
+| `iblai.env` | `DOMAIN`, `PLATFORM` (+ optional `IBLAI_USERNAME`) |
 | `Dockerfile` | Presence → include the **Docker** section |
 | `next.config.{ts,mjs,js}` | `output: 'export'` → static mode; otherwise server mode (for the Deploy section copy) |
 | `src-tauri/tauri.conf.json` | Presence → include the **Native builds** section AND keep the **Deploy** section (mobile dev builds use the hosted URL) |
@@ -175,7 +175,7 @@ Deploy through the ibl.ai platform's hosting API (Vercel-backed) with
 No Vercel account or token — auth is the platform API key (`TOKEN`) in
 `iblai.env`. The skill zips the app (the `out/` export in static mode, the
 project source in server mode), uploads it, polls until the build is
-READY, and prints the live `https://<project>.vercel.app` URL. Re-run it
+READY, and prints the live `*.vercel.app` URL Vercel reports. Re-run it
 to redeploy; attach custom domains via the hosting DNS endpoint (the skill
 returns the DNS records to add).
 


### PR DESCRIPTION
…API-reported deploy URLs only, force-dynamic starter CSP + CSP_MODE passthrough, push_state-aware deploy poll


## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
  Skill + starter fixes for the code-mode → Vercel deploy
  flow (pairs with the OS PR and DM `4.344.0`).

  ## 1. Identity: `IBLAI_USERNAME`, and the
  `users/platforms/` auto-detect is gone

  - The deploy and paywall-setup shells renamed
  `USERNAME` → `IBLAI_USERNAME`. `USERNAME` is a **zsh
  special parameter** bound to the OS login name:
  assigning it silently reverts, so the "if empty,
  auto-detect" guard never fired and `$BASE` became
  `/users/<os-login>` → 404. A "never name it `USERNAME`"
  note now guards the regression.
  - Resolution chain: `IBLAI_USERNAME` env var (the
  ibl.ai desktop app exports it at spawn) → `iblai.env`
  `IBLAI_USERNAME` → legacy `USERNAME=` file line
  (reading the *file* is safe; only the shell variable is
  special) → ask the user once and persist. The `GET
  /api/core/users/platforms/` auto-detect curl is
  **deleted**, and nothing pre-verifies the platform
  token anymore — a bad `TOKEN` fails loudly on the first
  real deploy call instead.
  - Paywall runtime identity (`lib/paywall.ts`
  `resolveUser` in `references/app-files.md`) switches
  from `users/platforms/` to `GET
  /api/core/token/verify/` with the end-user's `Token` —
  returns the token's user directly; platform membership
  stays enforced server-side by the payments endpoints
  (404 for non-members, passed through).

  ## 2. Deployed apps white-screened: force-dynamic
  starter

  Every vibe-starter route was statically prerendered
  while `middleware.ts` enforces a nonce +
  `strict-dynamic` CSP in production — build-time script
  tags carry no nonce, so **all `_next/static` chunks
  were blocked** on deployed apps (local dev runs
  report-only, which is why it only showed after
  deploying). The root layout now sets `export const
  dynamic = "force-dynamic"`, so nonces are stamped per
  request and enforcement actually works. Verified: `pnpm
  build` passes with every route `ƒ (Dynamic)`. The
  deploy skill's `.env.production` allowlist also gains
  `CSP_MODE`, making the middleware's documented runtime
  `report-only` override reachable on deployed apps.
  Static-export deploys are unaffected (no middleware
  ships in export mode).

  ## 3. The deploy URL is never derived from the project
  name

  Vercel mints the `*.vercel.app` subdomain itself —
  right-truncated for long names, truncated+hash on a
  collision — so
  `https://<vercel_project_name>.vercel.app` could be a
  dead (or someone else's) host, and the agent was
  opening it. Now:
  - `APP_URL` comes only from the API: the 202's `.url`,
  then the poll's `.deployment.aliases[0]` once the build
  is READY (the deployment's alias list is what the
  Vercel CLI itself trusts). If the URL is still
  unreported, the skill says so instead of guessing, and
  the Tauri `devUrl` write is skipped until it's
  confirmed.
  - Every `<project>.vercel.app` construction/claim is
  scrubbed from the skills, READMEs and the starter
  README.
  - Best with DM ≥ `4.344.0` (where `.url` is the
  Vercel-confirmed alias or empty); against `4.343.0` the
  202 `.url` is still name-derived, but the poll's
  `aliases[0]` overrides it with the real host at READY.

  ## 4. Poll reads `push_state` first

  The old poll read `.deployment.ready_state`
  unconditionally — but on a redeploy `.deployment` is
  the **previous** deployment until the new push lands,
  so a stale `READY` could mask a failed upload (and a
  stuck push burned the full 10-minute budget silently).
  The poll now checks `push_state` first, stops loudly on
  `failed` printing `push_error` (new `PUSH_FAILED`
  outcome in the docs), and only trusts `ready_state`
  after `pushed`.

  ## Housekeeping

  `iblai.env` docs updated for the new key across
  `CLAUDE.md`, `docs/skill-setup.md`, ops-init/readme
  skills and the starter `AGENTS.md`; adapters
  regenerated via `scripts/build-adapters.mjs`;
  `validate-skills.sh` green; `ops-deploy/SKILL.md` at
  194/500 lines. `PLAYWRIGHT_USERNAME`/`MAIL_USERNAME`
  untouched. No `users/platforms` references remain
  anywhere in skills or adapters.

  🤖 Generated with [Claude
  Code](https://claude.com/claude-code)