### PR TITLE
feat(ops-deploy): add container and static-host targets

### DIFF
--- a/adapters/codex/iblai-vibe-ops-deploy.md
+++ b/adapters/codex/iblai-vibe-ops-deploy.md
@@ -1,6 +1,6 @@
 # iblai-vibe-ops-deploy
 
-> Use this skill when the user asks to deploy, publish, host, share, or ship their ibl.ai app to the web — it deploys through the ibl.ai platform's hosting API (Vercel-backed) using only the platform API key in iblai.env (no Vercel account, token, or CLI), then updates devUrl in tauri.conf.json for mobile dev builds. For desktop/mobile native builds, see /iblai-vibe-ops-build.
+> Use this skill when the user asks to deploy, publish, host, share, or ship their ibl.ai app to the web — it deploys through the ibl.ai platform's hosting API (Vercel-backed) using only the platform API key in iblai.env (no Vercel account, token, or CLI), then updates devUrl in tauri.conf.json for mobile dev builds. Also covers deploying to infrastructure the team controls — a container on their own server, on-prem, Cloud Run, Kubernetes — and to any static host. For desktop/mobile native builds, see /iblai-vibe-ops-build.
 
 # /iblai-vibe-ops-deploy
 
@@ -16,6 +16,25 @@ poll until the build is READY. The app lands on the `*.vercel.app` URL the
 API reports (never derived from the project name), public by default (no Vercel
 SSO/password protection to disable). POST again with the same `project`
 slug to redeploy.
+
+## Which target
+
+Platform hosting (Steps 1–5 below) is the default and covers most asks. It is
+**not** the right answer when the app has to run on infrastructure the team
+controls:
+
+- The user said *server*, *on-prem*, *self-host*, *our own VM*, *Docker*,
+  *Kubernetes*, *air-gapped*, or named an internal hostname → **container**,
+  see [`references/docker-deploy.md`](references/docker-deploy.md).
+- The project already has a `Dockerfile` / `docker-compose.yml` /
+  `entrypoint.sh` (skillsai and mentorai both do) → **container**. Deploy the
+  way the project already deploys.
+- No `package.json`, or the app is plain HTML/JS served from a directory →
+  **static host** (see the section near the end), or a container, which adds
+  rewrites and runtime config a bare static host cannot do.
+
+If the target is a compliance or data-residency decision — a school district, a
+health system, a government tenant — do not pick it for them. Ask.
 
 ## Step 1: Config
 
@@ -178,14 +197,80 @@ Hand the returned `required_records` DNS instructions to the user — they
 add them at their registrar. `GET` / `DELETE` on the same path list /
 remove domains.
 
+## Deploy to a server the team controls
+
+Full recipe — Dockerfile (Next.js and static shapes), nginx routes,
+entrypoint, compose, TLS, CI smoke test — in
+[`references/docker-deploy.md`](references/docker-deploy.md). The shape:
+
+```bash
+docker build -t <app> .
+docker run -d -p 8080:8080 \
+  -e NEXT_PUBLIC_IBL_PLATFORM=<tenant> \
+  -e NEXT_PUBLIC_API_BASE_URL=https://api.iblai.app \
+  <app>
+```
+
+Two rules decide whether the deploy survives contact with a second
+environment:
+
+- **One image, every environment.** No tenant, no backend, no customer baked
+  in. The digest that passed staging is the digest that runs production, and
+  repointing is a restart. See *Runtime configuration* below — do that part
+  before containerizing, not after.
+- **Reproduce the SSO callback route.** The ibl.ai Auth SPA returns to
+  `<origin>/sso-login-complete`. A static server that does not map that path
+  404s the callback and login dies with no useful error. Next.js routing
+  handles it; nginx, S3 and GitHub Pages do not, unless told.
+
+## Static host
+
+For an app with no build step, or an existing bucket/host:
+
+1. Render the config file the browser reads (below) for the *target*
+   environment, not the developer's.
+2. Upload the served directory.
+3. Reproduce the `/sso-login-complete` → `/sso-login-complete.html` rewrite in
+   the host's config.
+4. Serve that config file `Cache-Control: no-store`. Cached, a repointed
+   deployment keeps sending returning users to the old backend — and it looks
+   like the repoint silently failed.
+
+## Runtime configuration
+
+Read [`references/runtime-config.md`](references/runtime-config.md) before any
+deploy that is not throwaway.
+
+An ibl.ai frontend is defined by which backend it talks to. Baked in at build
+time — inlined `NEXT_PUBLIC_*`, a hand-edited committed config — those values
+make an artifact that can only ever be one environment: staging and production
+become different builds, and repointing means a rebuild. Rendering them at
+process start from the environment is what every ibl.ai app that ships to a
+server already does (`window.__ENV__` in skillsai/mentorai).
+
+## Every target: the tenant has to know the origin
+
+Add the deployment's origin to the tenant's **allowed redirect origins**.
+Sign-in leaves for the login SPA and returns to `<origin>/sso-login-complete`;
+an origin the tenant does not know is a login that never comes back — and the
+symptom looks like a broken app, not a missing setting.
+
 ## When to Deploy
 
 - Before running dev builds (`pnpm exec tauri dev`, `… tauri ios dev`,
   `… tauri android dev`) so the WebView loads from a network URL
 - After frontend changes when iterating on dev builds
 - When sharing a preview URL
+- When handing an app to someone who has to run it on their own
+  infrastructure — that is the container path, and it is worth setting up
+  before they ask
 
 ## Going Back to Local
 
 Remove `devUrl` from `src-tauri/tauri.conf.json`; the WebView loads local
 static files again.
+
+## Reference
+
+- Container/server: [`references/docker-deploy.md`](references/docker-deploy.md)
+- Runtime config: [`references/runtime-config.md`](references/runtime-config.md)

--- a/adapters/cursor/iblai-vibe-ops-deploy.mdc
+++ b/adapters/cursor/iblai-vibe-ops-deploy.mdc
@@ -1,5 +1,5 @@
 ---
-description: "Use this skill when the user asks to deploy, publish, host, share, or ship their ibl.ai app to the web — it deploys through the ibl.ai platform's hosting API (Vercel-backed) using only the platform API key in iblai.env (no Vercel account, token, or CLI), then updates devUrl in tauri.conf.json for mobile dev builds. For desktop/mobile native builds, see /iblai-vibe-ops-build."
+description: "Use this skill when the user asks to deploy, publish, host, share, or ship their ibl.ai app to the web — it deploys through the ibl.ai platform's hosting API (Vercel-backed) using only the platform API key in iblai.env (no Vercel account, token, or CLI), then updates devUrl in tauri.conf.json for mobile dev builds. Also covers deploying to infrastructure the team controls — a container on their own server, on-prem, Cloud Run, Kubernetes — and to any static host. For desktop/mobile native builds, see /iblai-vibe-ops-build."
 globs:
 alwaysApply: false
 ---
@@ -18,6 +18,25 @@ poll until the build is READY. The app lands on the `*.vercel.app` URL the
 API reports (never derived from the project name), public by default (no Vercel
 SSO/password protection to disable). POST again with the same `project`
 slug to redeploy.
+
+## Which target
+
+Platform hosting (Steps 1–5 below) is the default and covers most asks. It is
+**not** the right answer when the app has to run on infrastructure the team
+controls:
+
+- The user said *server*, *on-prem*, *self-host*, *our own VM*, *Docker*,
+  *Kubernetes*, *air-gapped*, or named an internal hostname → **container**,
+  see [`references/docker-deploy.md`](references/docker-deploy.md).
+- The project already has a `Dockerfile` / `docker-compose.yml` /
+  `entrypoint.sh` (skillsai and mentorai both do) → **container**. Deploy the
+  way the project already deploys.
+- No `package.json`, or the app is plain HTML/JS served from a directory →
+  **static host** (see the section near the end), or a container, which adds
+  rewrites and runtime config a bare static host cannot do.
+
+If the target is a compliance or data-residency decision — a school district, a
+health system, a government tenant — do not pick it for them. Ask.
 
 ## Step 1: Config
 
@@ -180,14 +199,80 @@ Hand the returned `required_records` DNS instructions to the user — they
 add them at their registrar. `GET` / `DELETE` on the same path list /
 remove domains.
 
+## Deploy to a server the team controls
+
+Full recipe — Dockerfile (Next.js and static shapes), nginx routes,
+entrypoint, compose, TLS, CI smoke test — in
+[`references/docker-deploy.md`](references/docker-deploy.md). The shape:
+
+```bash
+docker build -t <app> .
+docker run -d -p 8080:8080 \
+  -e NEXT_PUBLIC_IBL_PLATFORM=<tenant> \
+  -e NEXT_PUBLIC_API_BASE_URL=https://api.iblai.app \
+  <app>
+```
+
+Two rules decide whether the deploy survives contact with a second
+environment:
+
+- **One image, every environment.** No tenant, no backend, no customer baked
+  in. The digest that passed staging is the digest that runs production, and
+  repointing is a restart. See *Runtime configuration* below — do that part
+  before containerizing, not after.
+- **Reproduce the SSO callback route.** The ibl.ai Auth SPA returns to
+  `<origin>/sso-login-complete`. A static server that does not map that path
+  404s the callback and login dies with no useful error. Next.js routing
+  handles it; nginx, S3 and GitHub Pages do not, unless told.
+
+## Static host
+
+For an app with no build step, or an existing bucket/host:
+
+1. Render the config file the browser reads (below) for the *target*
+   environment, not the developer's.
+2. Upload the served directory.
+3. Reproduce the `/sso-login-complete` → `/sso-login-complete.html` rewrite in
+   the host's config.
+4. Serve that config file `Cache-Control: no-store`. Cached, a repointed
+   deployment keeps sending returning users to the old backend — and it looks
+   like the repoint silently failed.
+
+## Runtime configuration
+
+Read [`references/runtime-config.md`](references/runtime-config.md) before any
+deploy that is not throwaway.
+
+An ibl.ai frontend is defined by which backend it talks to. Baked in at build
+time — inlined `NEXT_PUBLIC_*`, a hand-edited committed config — those values
+make an artifact that can only ever be one environment: staging and production
+become different builds, and repointing means a rebuild. Rendering them at
+process start from the environment is what every ibl.ai app that ships to a
+server already does (`window.__ENV__` in skillsai/mentorai).
+
+## Every target: the tenant has to know the origin
+
+Add the deployment's origin to the tenant's **allowed redirect origins**.
+Sign-in leaves for the login SPA and returns to `<origin>/sso-login-complete`;
+an origin the tenant does not know is a login that never comes back — and the
+symptom looks like a broken app, not a missing setting.
+
 ## When to Deploy
 
 - Before running dev builds (`pnpm exec tauri dev`, `… tauri ios dev`,
   `… tauri android dev`) so the WebView loads from a network URL
 - After frontend changes when iterating on dev builds
 - When sharing a preview URL
+- When handing an app to someone who has to run it on their own
+  infrastructure — that is the container path, and it is worth setting up
+  before they ask
 
 ## Going Back to Local
 
 Remove `devUrl` from `src-tauri/tauri.conf.json`; the WebView loads local
 static files again.
+
+## Reference
+
+- Container/server: [`references/docker-deploy.md`](references/docker-deploy.md)
+- Runtime config: [`references/runtime-config.md`](references/runtime-config.md)

--- a/skills/iblai-vibe-ops-deploy/SKILL.md
+++ b/skills/iblai-vibe-ops-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iblai-vibe-ops-deploy
-description: Use this skill when the user asks to deploy, publish, host, share, or ship their ibl.ai app to the web — it deploys through the ibl.ai platform's hosting API (Vercel-backed) using only the platform API key in iblai.env (no Vercel account, token, or CLI), then updates devUrl in tauri.conf.json for mobile dev builds. For desktop/mobile native builds, see /iblai-vibe-ops-build.
+description: Use this skill when the user asks to deploy, publish, host, share, or ship their ibl.ai app to the web — it deploys through the ibl.ai platform's hosting API (Vercel-backed) using only the platform API key in iblai.env (no Vercel account, token, or CLI), then updates devUrl in tauri.conf.json for mobile dev builds. Also covers deploying to infrastructure the team controls — a container on their own server, on-prem, Cloud Run, Kubernetes — and to any static host. For desktop/mobile native builds, see /iblai-vibe-ops-build.
 globs:
 alwaysApply: false
 ---
@@ -19,6 +19,25 @@ poll until the build is READY. The app lands on the `*.vercel.app` URL the
 API reports (never derived from the project name), public by default (no Vercel
 SSO/password protection to disable). POST again with the same `project`
 slug to redeploy.
+
+## Which target
+
+Platform hosting (Steps 1–5 below) is the default and covers most asks. It is
+**not** the right answer when the app has to run on infrastructure the team
+controls:
+
+- The user said *server*, *on-prem*, *self-host*, *our own VM*, *Docker*,
+  *Kubernetes*, *air-gapped*, or named an internal hostname → **container**,
+  see [`references/docker-deploy.md`](references/docker-deploy.md).
+- The project already has a `Dockerfile` / `docker-compose.yml` /
+  `entrypoint.sh` (skillsai and mentorai both do) → **container**. Deploy the
+  way the project already deploys.
+- No `package.json`, or the app is plain HTML/JS served from a directory →
+  **static host** (see the section near the end), or a container, which adds
+  rewrites and runtime config a bare static host cannot do.
+
+If the target is a compliance or data-residency decision — a school district, a
+health system, a government tenant — do not pick it for them. Ask.
 
 ## Step 1: Config
 
@@ -181,14 +200,80 @@ Hand the returned `required_records` DNS instructions to the user — they
 add them at their registrar. `GET` / `DELETE` on the same path list /
 remove domains.
 
+## Deploy to a server the team controls
+
+Full recipe — Dockerfile (Next.js and static shapes), nginx routes,
+entrypoint, compose, TLS, CI smoke test — in
+[`references/docker-deploy.md`](references/docker-deploy.md). The shape:
+
+```bash
+docker build -t <app> .
+docker run -d -p 8080:8080 \
+  -e NEXT_PUBLIC_IBL_PLATFORM=<tenant> \
+  -e NEXT_PUBLIC_API_BASE_URL=https://api.iblai.app \
+  <app>
+```
+
+Two rules decide whether the deploy survives contact with a second
+environment:
+
+- **One image, every environment.** No tenant, no backend, no customer baked
+  in. The digest that passed staging is the digest that runs production, and
+  repointing is a restart. See *Runtime configuration* below — do that part
+  before containerizing, not after.
+- **Reproduce the SSO callback route.** The ibl.ai Auth SPA returns to
+  `<origin>/sso-login-complete`. A static server that does not map that path
+  404s the callback and login dies with no useful error. Next.js routing
+  handles it; nginx, S3 and GitHub Pages do not, unless told.
+
+## Static host
+
+For an app with no build step, or an existing bucket/host:
+
+1. Render the config file the browser reads (below) for the *target*
+   environment, not the developer's.
+2. Upload the served directory.
+3. Reproduce the `/sso-login-complete` → `/sso-login-complete.html` rewrite in
+   the host's config.
+4. Serve that config file `Cache-Control: no-store`. Cached, a repointed
+   deployment keeps sending returning users to the old backend — and it looks
+   like the repoint silently failed.
+
+## Runtime configuration
+
+Read [`references/runtime-config.md`](references/runtime-config.md) before any
+deploy that is not throwaway.
+
+An ibl.ai frontend is defined by which backend it talks to. Baked in at build
+time — inlined `NEXT_PUBLIC_*`, a hand-edited committed config — those values
+make an artifact that can only ever be one environment: staging and production
+become different builds, and repointing means a rebuild. Rendering them at
+process start from the environment is what every ibl.ai app that ships to a
+server already does (`window.__ENV__` in skillsai/mentorai).
+
+## Every target: the tenant has to know the origin
+
+Add the deployment's origin to the tenant's **allowed redirect origins**.
+Sign-in leaves for the login SPA and returns to `<origin>/sso-login-complete`;
+an origin the tenant does not know is a login that never comes back — and the
+symptom looks like a broken app, not a missing setting.
+
 ## When to Deploy
 
 - Before running dev builds (`pnpm exec tauri dev`, `… tauri ios dev`,
   `… tauri android dev`) so the WebView loads from a network URL
 - After frontend changes when iterating on dev builds
 - When sharing a preview URL
+- When handing an app to someone who has to run it on their own
+  infrastructure — that is the container path, and it is worth setting up
+  before they ask
 
 ## Going Back to Local
 
 Remove `devUrl` from `src-tauri/tauri.conf.json`; the WebView loads local
 static files again.
+
+## Reference
+
+- Container/server: [`references/docker-deploy.md`](references/docker-deploy.md)
+- Runtime config: [`references/runtime-config.md`](references/runtime-config.md)

--- a/skills/iblai-vibe-ops-deploy/references/docker-deploy.md
+++ b/skills/iblai-vibe-ops-deploy/references/docker-deploy.md
@@ -1,0 +1,179 @@
+# Deploy to a server — container recipe
+
+For when the app has to run somewhere the team controls: a district VM, on-prem
+hardware, Cloud Run, ECS, a Kubernetes cluster, a customer's own tenant.
+
+Prerequisite: [`runtime-config.md`](runtime-config.md). A container that bakes
+its backend in is a container that can only ever be one environment — do that
+part first.
+
+## Two shapes
+
+**Next.js app (skillsai, mentorai, vibe-starter).** Multi-stage: build with
+pnpm, run with `next start`. An `entrypoint.sh` writes `public/env.js` from the
+environment, then execs the server. Both shipping apps already have this —
+copy theirs rather than inventing one:
+
+```dockerfile
+FROM node:20 AS base
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@latest --activate
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+COPY . .
+RUN pnpm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+COPY --from=builder /app/.next .next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json /app/next.config.mjs /app/entrypoint.sh ./
+RUN chmod +x entrypoint.sh
+EXPOSE 5000
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["pnpm", "exec", "next", "start", "-p", "5000"]
+```
+
+**Static app (no build step).** nginx serving a directory, plus a tiny runtime
+to render the config. Install `nodejs` in the runtime image so the config
+generator has one implementation shared with local dev and CI — a shell
+reimplementation is a second source of truth and will drift:
+
+```dockerfile
+FROM nginx:1.27-alpine
+RUN apk add --no-cache nodejs
+COPY public/ /srv/www/
+COPY tools/gen-config.mjs /srv/tools/gen-config.mjs
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker/entrypoint.sh /srv/entrypoint.sh
+RUN chmod +x /srv/entrypoint.sh \
+    && touch /var/run/nginx.pid \
+    && chown -R nginx:nginx /srv/www /var/cache/nginx /var/run/nginx.pid
+USER nginx
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://127.0.0.1:8080/healthz >/dev/null || exit 1
+ENTRYPOINT ["/srv/entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+Port **8080**, user **nginx** — an unprivileged container needs no
+`NET_BIND_SERVICE` and drops straight into a hardened runtime.
+
+## nginx: the routes that are not optional
+
+```nginx
+server {
+    listen 8080;
+    root /srv/www;
+    index index.html;
+
+    location = /healthz { access_log off; return 200 'ok'; }
+
+    # Rewritten on every container start — never cache it.
+    location = /iblai-config.js { add_header Cache-Control 'no-store' always; }
+
+    # THE ONE THAT BREAKS DEPLOYS. The ibl.ai Auth SPA returns to
+    # <origin>/sso-login-complete with no .html extension.
+    location = /sso-login-complete { try_files /sso-login-complete.html =404; }
+
+    # Client-routed sub-apps.
+    location /app/ { try_files $uri $uri/ /app/index.html; }
+
+    location ~* /assets/.+\.(js|css|woff2?|png|jpg|svg)$ {
+        expires 1y;
+        add_header Cache-Control 'public, immutable';
+    }
+    location ~* \.html$ { add_header Cache-Control 'no-cache' always; }
+
+    location / { try_files $uri $uri/ =404; }
+
+    location ~ /(\.|iblai\.env) { deny all; }
+}
+```
+
+If the app is also deployed to Firebase or S3, keep the two configs in sync and
+say so in a comment in both. They are the same routing table written twice, and
+they drift silently.
+
+## Entrypoint
+
+```sh
+#!/bin/sh
+set -e
+# --env /dev/null: in a container the environment is the only source. Falling
+# back to a committed config file would silently serve whichever tenant was
+# checked in — exactly what this indirection exists to prevent.
+node /srv/tools/gen-config.mjs --env /dev/null --out /srv/www/iblai-config.js
+[ -z "$IBLAI_PLATFORM" ] && echo "WARNING: IBLAI_PLATFORM unset" >&2
+exec "$@"
+```
+
+## Compose
+
+```yaml
+services:
+  web:
+    build: { context: . }
+    restart: unless-stopped
+    ports: ["${PORT:-8080}:8080"]
+    environment:
+      IBLAI_DOMAIN: "${IBLAI_DOMAIN:-iblai.app}"
+      IBLAI_PLATFORM: "${IBLAI_PLATFORM:?set the tenant key}"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+```
+
+Compose reads `.env` automatically, so a second environment is a second `.env`
+— no rebuild.
+
+## TLS
+
+Nothing in the container terminates TLS. Put it behind what the team already
+runs:
+
+```
+app.district.edu {
+    reverse_proxy localhost:8080
+}
+```
+
+(Caddy, which also handles certificates.) Behind nginx, forward `Host` and
+`X-Forwarded-Proto`.
+
+## CI
+
+Build on every PR to prove the Dockerfile still works; publish on merge. Then
+**smoke-test the image you just built** — a container that starts is not a
+container that serves:
+
+```yaml
+- run: |
+    docker run -d --name smoke -p 8080:8080 \
+      -e IBLAI_DOMAIN=example.test -e IBLAI_PLATFORM=ci-tenant smoke:local
+    for i in $(seq 1 20); do curl -fsS http://127.0.0.1:8080/healthz && break || sleep 1; done
+    curl -fsS -o /dev/null http://127.0.0.1:8080/
+    curl -fsS -o /dev/null http://127.0.0.1:8080/sso-login-complete   # the rewrite
+    curl -fsS http://127.0.0.1:8080/iblai-config.js | grep -q ci-tenant  # env reached the config
+```
+
+Those three assertions catch the three things that actually break: the app, the
+SSO callback, and configuration that never made it out of the environment.
+
+Tag with the commit sha, not `latest` — promoting an environment should mean
+running a known digest with different variables.
+
+## Before it works
+
+Add the deployment origin to the tenant's **allowed redirect origins**. Sign-in
+leaves for the login SPA and returns to `<origin>/sso-login-complete`; an
+origin the tenant does not know is a login that never comes back.
+
+## Related
+
+- Runtime config: [`runtime-config.md`](runtime-config.md)
+- Platform hosting path (the default): [`../SKILL.md`](../SKILL.md) Steps 1–5
+- Owning skill: [`../SKILL.md`](../SKILL.md)

--- a/skills/iblai-vibe-ops-deploy/references/runtime-config.md
+++ b/skills/iblai-vibe-ops-deploy/references/runtime-config.md
@@ -1,0 +1,104 @@
+# Runtime configuration — one artifact, every environment
+
+An ibl.ai frontend is mostly defined by *which backend it talks to*: the tenant
+key, `api.*`, `login.*`, `mentorai.*`, the ASGI socket. Where those values live
+decides whether the app can be deployed twice.
+
+**Build-time is the wrong place.** `NEXT_PUBLIC_*` are inlined into the client
+bundle by the compiler; a config file edited by hand and committed is inlined
+into the repo. Either way the artifact *is* an environment:
+
+- staging and production are different builds of the same commit
+- repointing a customer means a rebuild, not a restart
+- promoting "the build that passed QA" promotes something that was never
+  actually tested against production
+- a self-hosting customer has to build from source to change a hostname
+
+**Runtime is the right place.** Render the config when the process starts, from
+the environment it started in. Same image, different variables, different
+deployment.
+
+## The pattern
+
+Both shipping ibl.ai apps already do this. `skillsai/entrypoint.sh` and
+`mentorai/entrypoint.sh` write a `window.__ENV__` object into a file the app
+loads before its bundle, then exec the server:
+
+```sh
+#!/bin/sh
+set -e
+
+cat <<EOF > /app/public/env.js
+window.__ENV__ = {
+  NEXT_PUBLIC_API_BASE_URL: "${NEXT_PUBLIC_API_BASE_URL}",
+  NEXT_PUBLIC_AUTH_URL: "${NEXT_PUBLIC_AUTH_URL}",
+  NEXT_PUBLIC_MENTOR_URL: "${NEXT_PUBLIC_MENTOR_URL}",
+  NEXT_PUBLIC_PLATFORM_BASE_DOMAIN: "${NEXT_PUBLIC_PLATFORM_BASE_DOMAIN}",
+};
+EOF
+
+exec "$@"
+```
+
+Read it with a helper that falls back to the compiled-in value, so local `pnpm
+dev` keeps working:
+
+```ts
+export const env = (key: string, fallback = '') =>
+  (typeof window !== 'undefined' && window.__ENV__?.[key]) ||
+  process.env[key] ||
+  fallback
+```
+
+For an app with no build step, generate the whole config file instead — same
+idea, one implementation shared by local dev, static deploys and containers.
+The WRSD platform's `tools/gen-config.mjs` renders `public/iblai-config.js`
+from `iblai.env` **or** `IBLAI_*` environment variables, and its container
+entrypoint calls it with `--env /dev/null` so only the environment can win.
+
+## Derive, don't enumerate
+
+ibl.ai hostnames follow `<service>.<domain>`. Take **one** value and derive:
+
+```js
+const domain  = raw.domain || 'iblai.app'
+const api     = raw.apiBaseUrl || `https://api.${domain}`
+const auth    = raw.authUrl    || `https://login.${domain}`
+const mentor  = raw.mentorUrl  || `https://mentorai.${domain}`
+const ws      = raw.wsBaseUrl  || `wss://asgi.data.${domain}`
+```
+
+Moving to a self-hosted `iblai/os` then costs one variable instead of five kept
+consistent by hand. Keep the per-endpoint overrides for installs that do not
+follow the convention, but let blank mean *derive* — never ship them filled in
+with the defaults they would have derived anyway, or `domain` becomes a knob
+that silently does nothing.
+
+## Rules
+
+1. **Never emit the platform `TOKEN`.** It is server-side only. Browser config
+   is served to every visitor. Generators should not have a code path that can
+   include it.
+2. **Serve the config `no-store`.** Cached, a repointed deployment keeps
+   sending returning users to the old backend — and it looks like the repoint
+   silently failed.
+3. **Generated files are generated.** Put a DO-NOT-EDIT header on them, and
+   give CI a `--check` mode that regenerates and diffs. Hand-editing a
+   generated config is how half a deployment ends up on one backend.
+4. **Prefix environment variables.** `IBLAI_DOMAIN`, not `DOMAIN`. Unprefixed
+   generic names collide with whatever else is in the container's environment.
+5. **Warn when the tenant is unset** at startup, in the entrypoint. A blank
+   platform key produces a confusing empty app, not an error.
+
+## What cannot move
+
+Be explicit, in the deploy docs, about anything that does *not* follow the
+config — a legacy backend, an SSO client id tied to one domain, an analytics
+project. A repoint that silently leaves one surface pointing at the old
+environment is worse than one that refuses to.
+
+## Related
+
+- Container recipe: [`docker-deploy.md`](docker-deploy.md)
+- Owning skill: [`../SKILL.md`](../SKILL.md)
+- Auth/env plumbing: `iblai-vibe-auth`


### PR DESCRIPTION
## What

`iblai-vibe-ops-deploy` only knew platform hosting. An app that has to run on infrastructure the team controls — a district VM, on-prem, Cloud Run, Kubernetes — fell through it, as did an app with no build step.

This adds a target-selection step (platform hosting stays the default, Steps 1–5 untouched) and two references.

## Added

**`references/docker-deploy.md`** — Dockerfile for both shapes (Next.js multi-stage; nginx for a no-build app), the nginx routes that are not optional, entrypoint, compose, TLS, and a CI smoke test that asserts three things: the app serves, the SSO callback resolves, and the environment actually reached the browser config.

**`references/runtime-config.md`** — why build-time config produces an artifact that can only ever be one environment, the `window.__ENV__` pattern skillsai and mentorai already ship, deriving every hostname from one `domain`, and the rule that generated config is generated (DO-NOT-EDIT header, `--check` in CI).

Both were written against a real migration: the WRSD AI Platform now ships as one image whose backend is an environment variable.

## Also documented

The `/sso-login-complete` rewrite and the allowed-redirect-origin requirement — the two ways a deploy silently breaks sign-in on any host that is not Next.js. Neither was written down anywhere.

## Note for review

The diff is additive. `main` rewrote this skill around the platform hosting API (no more Vercel CLI / `VERCEL_TOKEN`), and none of that detail is touched — the new sections sit after Step 5, plus one "Which target" section after the intro and a widened `description`. Adapters regenerated with `scripts/build-adapters.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)