### PR TITLE
docs: explain the five core iblai/api families, add the live-tenant pattern, ibl.ai/docs links, README truth pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ All notable changes to the [vibe](https://github.com/iblai/vibe) toolkit.
   without a separate provider key. `Bearer` applies to `/v1` only; everything else
   keeps `Api-Token`.
 
+## [1.25.0] - 2026-09-02
+
+### Added
+
+- ship ready-made Stripe app-paywall components as installable assets, unit-tested via the render gate; vibe-starter stays Stripe-free
+
 ## [1.24.0] - 2026-09-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,12 @@ NEXT_PUBLIC_DEFAULT_AGENT_ID=your-agent-id
 > `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`.
 > Then fill in your values."
 >
+> Where the values come from: an account and an organization at
+> https://ibl.ai/join; the org key (`PLATFORM`) is listed on
+> https://login.iblai.app/me; the Platform API Token (`TOKEN`) is minted
+> from that signed-in session by `/iblai-api-login` (`npx skills add
+> iblai/api`), or use an org secret directly. Keep `iblai.env` gitignored.
+>
 > Do NOT ask the user for their platform key directly. Guide them to populate
 > `iblai.env` instead, then map the values into `.env.local`
 > (`NEXT_PUBLIC_MAIN_TENANT_KEY` ← `PLATFORM`).
@@ -181,8 +187,55 @@ NEXT_PUBLIC_DEFAULT_AGENT_ID=your-agent-id
 > name like `MyApp` or `AgentBot`, convert it to `my-app` / `agent-bot`
 > before using it. Allowed characters: lowercase letters, digits, `-`, `_`.
 >
-> When adding chat (`/iblai-vibe-agent-chat`), you MUST ask the user for their
-> agent/mentor ID (a UUID). Do not use placeholder values for agent IDs.
+> When adding chat (`/iblai-vibe-agent-chat`) you MUST have a real
+> agent/mentor ID (a UUID): take it from an os.ibl.ai URL the user already
+> gave (see **Learn from a live tenant** below), otherwise ask. Never use a
+> placeholder.
+
+### Learn from a live tenant
+
+> **AI Assistant:** When the user says something like “You’re also logged
+> into `https://os.ibl.ai/platform/<tenant>/<agent-uuid>` as `<email>`”,
+> that sentence is configuration plus a reference app. Act on it; do not
+> ask again for anything it already contains.
+>
+> 1. **Decode the URL.** In `iblai/os` the route is
+>    `app/platform/[tenantKey]/[mentorId]` — “chat with this agent in this
+>    tenant”; the agent-scoped pages (analytics, notifications, …) nest under
+>    it. So `<tenant>` → `PLATFORM` / `NEXT_PUBLIC_MAIN_TENANT_KEY`,
+>    `<agent-uuid>` → `NEXT_PUBLIC_DEFAULT_AGENT_ID`, and `os.ibl.ai` runs on
+>    the hosted platform → `DOMAIN=iblai.app` (`api.iblai.app`,
+>    `login.iblai.app`). A self-hosted OS host implies another domain — ask.
+> 2. **Get a token from the session, never a password.** With a browser tool
+>    (`claude --chrome`, or the Playwright server in `.mcp.json`): open the
+>    URL, confirm the user is signed in, read `dm_token` and
+>    `userData.user_nicename` (the username) from localStorage, then mint a
+>    Platform API Token exactly as `/iblai-api-login` step 2 documents —
+>    `POST https://api.iblai.app/dm/api/core/platform/api-tokens/` with
+>    `Authorization: Token <dm_token>` and body
+>    `{ username, name, key: "", platform_key: <tenant>, created, expires: "" }`;
+>    the secret is shown once. Write it to the gitignored `iblai.env` as
+>    `TOKEN` (plus `IBLAI_USERNAME`), map it into `.env.local` as
+>    `IBLAI_API_KEY`, and verify with
+>    `GET …/dm/api/core/platform/users/?platform_key=<tenant>` under
+>    `Authorization: Api-Token …` → 200. No browser tool? Ask the user to
+>    paste a Platform API Token instead.
+> 3. **Learn shapes from live data.** Call the families in *Platform data
+>    most apps lean on* (below) against that tenant and copy field names from
+>    real responses instead of guessing. For the surface you are building,
+>    watch the OS page’s network calls to see which endpoints and params the
+>    production app actually uses.
+> 4. **Learn wiring from source.** The same `iblai/os` route mounts the SDK
+>    components the `/iblai-vibe-agent-*` skills install —
+>    `components/modals/edit-mentor-modal/settings-tab.tsx` wraps
+>    `AgentSettingsTab` in `AgentSettingsProvider`;
+>    `…/[mentorId]/analytics/page.tsx` renders `AnalyticsOverview`. Read it
+>    before inventing props.
+> 5. **Keep it out of git.** The token (and `dm_token`) live only in
+>    gitignored env files; keep the tenant key and email out of docs,
+>    screenshots, and commit messages. No new env key is needed for the
+>    reference URL — rebuild it from `PLATFORM` and
+>    `NEXT_PUBLIC_DEFAULT_AGENT_ID`.
 
 ## Commands
 
@@ -300,6 +353,7 @@ Invoke with `/` in Claude Code:
 | `/iblai-vibe-ops-release` | Generate a Makefile + Fastlane config to build & submit to the App Store and Google Play |
 | `/iblai-vibe-ops-test` | Test your app before showing work to the user |
 | `/iblai-vibe-ops-upgrade` | Upgrade the ibl.ai SDK and vibe skills to the latest versions |
+| `/iblai-vibe-readme` | Write or refresh the project README.md |
 | `/iblai-vibe-scaffold` | Scaffold a new app or add features — the base/agent project templates + the assembly steps |
 | `/iblai-vibe-iconography` | Generate every app-icon size (Tauri desktop, iOS, Windows MSIX, macOS) from one source image |
 | `/iblai-vibe-windows-msix` | Build and distribute a Tauri app as a Windows MSIX (sideload / Microsoft Store) |
@@ -326,7 +380,19 @@ Invoke with `/` in Claude Code:
 | `/iblai-vibe-agent-task` | Add the agent Tasks tab (schedule automated periodic agent tasks with run logs) |
 | `/iblai-vibe-agent-tool` | Add the agent Tools tab (enable/disable agent tools) |
 | `/iblai-vibe-agent-support` | Add the agent Support tab (human support ticket inbox with availability toggle, filters, ticket detail, status updates, and replies) |
+| `/iblai-vibe-agent-audit` | Add the agent Audit tab (audit log of who changed what and when, with user/date/action filters) |
+| `/iblai-vibe-agent-chat-sidebar` | Wrap the Chat surface with the SDK's AppSidebar (projects dropdown, pinned/recent messages, host-supplied menu items) |
+| `/iblai-vibe-agent-mcp` | Add the agent MCP tab (connector management — featured and custom connectors, OAuth, add/edit dialogs) |
+| `/iblai-vibe-agent-sandbox` | Add the agent Sandbox tab (Computing Runtime / Virtual Machine Shell / Claw sandbox types, OpenClaw instances, agent prompt config) |
+| `/iblai-vibe-agent-voice` | Add the agent Voice tab (pick the agent's voice and configure voice calls) |
 | `/iblai-vibe-crm-overview` | Reference + family index for the CRM API (auth, seeded defaults, RBAC roles, sub-skill map) |
+| `/iblai-vibe-monetization` | Family index for item-level monetization — Stripe Connect Express, paywalls, pricing tiers, checkout, subscriptions, revenue analytics |
+| `/iblai-vibe-monetization-onboard` | Stripe Connect Express onboarding surface (status card, complete-setup / dashboard actions, the `is_ready_for_payments` gate) |
+| `/iblai-vibe-monetization-configure` | Admin MonetizationTab + seller wizard (turn an agent/course/program/custom item into a paid product; paywall settings, pricing tiers) |
+| `/iblai-vibe-monetization-checkout` | Buyer-facing PaywallModal, access check, Stripe checkout, and public/guest buy |
+| `/iblai-vibe-monetization-subscription` | User PurchasesTab in the Profile (list, detail, cancel subscriptions) |
+| `/iblai-vibe-monetization-analytics` | Revenue dashboards, subscriber lists, and paywalls-overview hooks for custom admin surfaces |
+| `/iblai-vibe-monetization-app-paywall` | Pay-to-enter gate for the whole app on the tenant's own Stripe key (no Connect, no commission) |
 
 ### Companion repos
 
@@ -342,16 +408,97 @@ routes between all of them:
   npx skills add iblai/api
   ```
 
-  Direct skill references (raw SKILL.md):
-  [agent-memory](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-memory/SKILL.md) ·
-  [agent-setting](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-setting/SKILL.md) ·
-  [analytics](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-analytics/SKILL.md) ·
-  [profile](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile/SKILL.md) ·
-  [profile-metadata](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile-metadata/SKILL.md)
+  The five families below are the ones most apps read or write.
 
 - [`iblai/os`](https://github.com/iblai/os) — source of the Agentic OS
   ([os.ibl.ai](https://os.ibl.ai)), the flagship production app built on
-  this same SDK. Read it as the reference implementation, or self-host it.
+  this same SDK. Read it as the reference implementation, or self-host it —
+  or learn from the live app: see **Learn from a live tenant** above.
+
+### Platform data most apps lean on
+
+Most apps on the platform read or write the same five REST families. Each
+entry: what it gives your app → the SDK entry points that call it from the
+browser → the `/iblai-vibe-*` skill that mounts the UI → the `iblai/api`
+skill (raw SKILL.md: endpoints, bodies, errors). Ask `@iblai/mcp`
+(`get_api_query_info`, `get_component_info`) for the full hook/prop surface.
+
+- **Per-user metadata** — one schemaless JSON object per user × org
+  (`…/dm/api/core/users/platform-metadata/?platform_key=`). Preferences,
+  feature flags, onboarding progress, app state — without localStorage or a
+  database of your own. Auto-created on first GET (`{}`); PATCH merges
+  (`metadata` + `delete_keys`), PUT replaces, DELETE resets; org admins add
+  `&username=` to target another user. SDK: `useGetUserPlatformMetadataQuery`,
+  `useUpdateUserPlatformMetadataMutation` (PATCH only — PUT, DELETE and
+  `delete_keys` need a direct call). `OnboardingWizard` (`/web-containers`)
+  saves its answers here under `onboarding`; os.ibl.ai keeps its per-user
+  coding-mode preference here. No `/iblai-vibe-*` skill wraps this family —
+  call the hooks.
+  REST: [profile-metadata](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile-metadata/SKILL.md)
+- **Agent settings** — one agent’s identity (name, description, categories,
+  image), visibility, and capability flags (anonymous, featured, LTI,
+  attachments, voice, memory, multi-query RAG, forkable). Everything saves
+  through one `PUT …/mentors/{mentor}/settings/` (multipart, only the changed
+  fields); fork copies the agent into any org you admin; delete is
+  destructive. SDK: `useGetMentorSettingsQuery`, `useEditMentorMutation`
+  (that PUT), `useForkMentorMutation`, `useDeleteMentorMutation`,
+  `useGetMentorCategoriesQuery`. UI: `AgentSettingsProvider` +
+  `AgentSettingsTab` (`/web-containers/next`) — the provider is the context
+  every `/iblai-vibe-agent-*` tab skill mounts.
+  Skill: `/iblai-vibe-agent-setting`. REST: [agent-setting](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-setting/SKILL.md)
+- **Agent memory** — three stores: global memories (per user, every agent),
+  agent memories (per user × agent, filed under categories with extraction
+  prompts), and agent knowledge (per agent, no user, curated, injected into
+  every chat as `## Agent Knowledge`). Show users what an agent remembers,
+  let them add or delete facts, toggle capture/recall
+  (`auto_capture_enabled`, `use_memory_in_responses`); the org flag
+  `enable_memsearch` gates it all. SDK (`features/memory`):
+  `useGetUserMemorySettingsQuery` / `useUpdateUserMemorySettingsMutation`,
+  `useGetGlobalMemoriesQuery`, `useGetMentorMemoriesListQuery`,
+  `useCreateMentorMemoryMutation`, `useGetMemsearchStatusQuery`; agent
+  knowledge is REST-only today. UI: `AgentMemoryTab` (`/next`), the
+  `Profile` Memory tab, `Account targetTab="memory"`.
+  Skills: `/iblai-vibe-agent-memory` (one agent), `/iblai-vibe-memory`
+  (whole org). REST: [agent-memory](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-memory/SKILL.md)
+- **Analytics** — one `/dm/api/analytics/` family; `mentor_unique_id`
+  present = one agent, absent = the whole org. Usage and engagement KPIs,
+  transcripts, catalog engagement, costs (already marked-up USD), per-user
+  learning snapshots (self-access needs no grant), audit logs of agent
+  changes, async Data Reports (POST → poll → CSV/JSON). SDK
+  (`features/analytics`): `useGetTopicsStatsQuery`, `useGetUsersStatsQuery`,
+  `useGetSessionStatsQuery`, `useGetFinancialStatsQuery`,
+  `useGetTranscriptsMessagesQuery`, `useGetLearnerDetailsQuery`,
+  `useTimeTrackingMutation`; reports `useGetReportsQuery` /
+  `useCreateReportMutation`; audit `useGetAuditLogsQuery`; `llm-usage/`
+  (per-model/-user cost, tokens, latency) is REST-only. UI:
+  `AnalyticsLayout`, `AnalyticsOverview`, `AnalyticsUsersStats`,
+  `AnalyticsFinancialStats`, `AnalyticsTranscriptsStats`,
+  `AnalyticsReports`, `AnalyticsAuditLogStats`, `AgentAnalyticsTab`.
+  Skills: `/iblai-vibe-analytics`, `/iblai-vibe-agent-audit`. The live
+  schema is the contract: `https://api.iblai.app/dm/api/docs/schema/`.
+  REST: [analytics](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-analytics/SKILL.md)
+- **Profile** — the signed-in user’s own record: account fields (name, bio,
+  language, social links, image) on the LMS host via `merge-patch+json`,
+  career records (education, experience, résumé) under
+  `…/dm/api/career/…`, and their own memory toggles. Any “me” page,
+  avatar/dropdown, or résumé feature. vibe-starter’s `/profile` page only
+  reads the SSO cache (`localStorage.userData`) — for live or editable data
+  use the hooks or mount `Profile`. SDK: `useGetUserMetadataQuery`,
+  `useUpdateUserMetadataEdxMutation`, `useUploadProfileImageMutation`
+  (`features/user`); `useGetUserEducationQuery`,
+  `useGetUserExperienceQuery`, `useGetUserResumeQuery` (`features/career`).
+  UI: `Profile` (+ `EducationTab` / `ExperienceTab` / `ResumeTab`),
+  `UserProfileDropdown`, `UserProfileModal`, `Account` (`/next`).
+  Skills: `/iblai-vibe-profile`, `/iblai-vibe-account`, `/iblai-vibe-history`.
+  REST: [profile](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile/SKILL.md)
+
+**Auth on the wire.** In the browser the SDK sends `Authorization: Token
+<dm_token>` (session tokens in localStorage `dm_token` / `axd_token`), so
+every hook above works with the signed-in user’s session and permissions —
+no API key. The REST skills send `Authorization: Api-Token $IBLAI_API_KEY`,
+a Platform API Token (`TOKEN` in `iblai.env`, `IBLAI_API_KEY` in
+`.env.local`): server-side only, never in client code. REST base is
+`https://api.iblai.app/dm` (profile account fields: `…/lms`).
 
 ### Marketing Skills
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ npx skills add iblai/vibe-marketing
 
 See [`iblai/vibe-marketing`](https://github.com/iblai/vibe-marketing) for the full catalogue.
 
+### Get your credentials
+
+1. Sign up at [ibl.ai/join](https://ibl.ai/join) -- it creates your account **and** your organization.
+2. Your org key (`PLATFORM` in `iblai.env`) is listed on [login.iblai.app/me](https://login.iblai.app/me).
+3. Mint a Platform API Token (`TOKEN`) from that signed-in session with [`/iblai-api-login`](https://github.com/iblai/api/blob/main/skills/iblai-api-login/SKILL.md) (`npx skills add iblai/api`), or use an org secret directly. Keep `iblai.env` out of git.
+
 ### ibl.ai Components for Next.js Apps
 Ask Claude to add ibl.ai Chat, Profile, Account, Notification or Analytics component to your Next.js project. 
 ### ibl.ai App Template
@@ -45,13 +51,13 @@ Ask Claude to start an ibl.ai agent app.
 
 ## What is Vibe
 
-A developer toolkit for vibe coding with the [ibl.ai](https://ibl.ai) platform. Vibe gives you a production-ready scaffold powered by the [@iblai/iblai-js](https://www.npmjs.com/package/@iblai/iblai-js) SDK, pre-built components, Claude Code skills, and a full backend at `iblai.app`. You go from zero to a deployed AI app in minutes -- authentication, AI chat, profiles, notification, and analytics are already wired up. No API tokens to manage.
+A developer toolkit for vibe coding with the [ibl.ai](https://ibl.ai) platform. Vibe gives you a production-ready scaffold powered by the [@iblai/iblai-js](https://www.npmjs.com/package/@iblai/iblai-js) SDK, pre-built components, Claude Code skills, and a full backend at `iblai.app`. You go from zero to a deployed AI app in minutes -- authentication, AI chat, profiles, notification, and analytics are already wired up. End users sign in through SSO -- no tokens in the browser; you keep one Platform API Token in a gitignored `iblai.env` for server-side calls and deploys.
 
 **Why it matters:**
 
 - **Start building in minutes, not days** -- the skills scaffold a complete app with auth, AI chat, and a dashboard out of the box
 - **Backend included** -- `iblai.app` provides SSO auth, AI agent infrastructure, analytics, and tenant management (free tier available)
-- **Client-side auth via SSO** -- no API tokens to store, rotate, or leak
+- **Client-side auth via SSO** -- end users never handle tokens; the one Platform API Token you hold stays server-side in `iblai.env`
 - **Claude Code skills guide every step** -- adding features is a conversation, not a scavenger hunt through docs
 - **shadcn/ui fills in UI gaps** -- consistent design language without the overhead of a custom design system
 - **Ship everywhere** -- web (Vercel), desktop (macOS/Windows/Linux), and mobile (iOS/Android) via Tauri v2
@@ -65,7 +71,7 @@ A developer toolkit for vibe coding with the [ibl.ai](https://ibl.ai) platform. 
 
 ## How It Works
 
-1. **Scaffold** -- run `npx create-next-app@latest myapp` to generate a full Next.js app.
+1. **Scaffold** -- ask your agent to start a new project: `/iblai-vibe-ops-init` copies the vibe-starter template (Next.js + SSO auth + navbar + profile/account/notifications) into the current directory. A vanilla `create-next-app` plus the individual skills is the fallback.
 2. **Connect** -- Use Claude Code skills to add auth, AI chat, profiles, and more components to your app to connect to `iblai.app` (or your own instance) for authentication, AI agents, and data
 3. **Customize** -- use the skills to add features, swap components, and adjust business logic
 4. **Deploy** -- ship to the web via ibl.ai hosting (Vercel) or package with Tauri
@@ -223,7 +229,7 @@ The `/iblai-vibe` index skill routes between this repo and all companions.
 
 | Feature | Description |
 |---------|-------------|
-| **Authentication** | SSO login via iblai.app -- no token management, session handling built in |
+| **Authentication** | SSO login via iblai.app -- session handling built in, no token management for end users |
 | **AI Chat** | Streaming chat with ibl.ai agents, markdown rendering, conversation history |
 | **User Profile** | Editable profile page with avatar, bio, and preferences |
 | **Account Settings** | Password changes, notification preferences, connected services |
@@ -316,7 +322,6 @@ The scaffolded app ships with skills that teach Claude how to work with your cod
 | `/iblai-vibe-course-create` | Generate, edit, and publish edX courses via the ibl.ai Course Creation API |
 | `/iblai-vibe-component` | Overview of all components + app creation paths |
 | `/iblai-vibe-onboard` | Design and build a high-converting onboarding questionnaire flow |
-| `/iblai-landing` | Build a high-converting landing page using a 12-section conversion framework |
 | `/iblai-vibe-ops-build` | Build and run on desktop and mobile (iOS, Android, macOS, Windows) |
 | `/iblai-vibe-ops-test` | Test your app before showing work to the user |
 | `/iblai-vibe-ops-upgrade` | Upgrade the ibl.ai SDK and vibe skills to the latest versions |
@@ -346,20 +351,20 @@ The scaffolded app ships with skills that teach Claude how to work with your cod
 | `/iblai-vibe-agent-tool` | Add the agent Tools tab (enable/disable agent tools) |
 | `/iblai-vibe-agent-support` | Add the agent Support tab (human support ticket inbox with availability toggle, filters, ticket detail, status updates, and replies) |
 
-Skills are in `skills/` (symlinked to `.claude/skills/`). Read them, extend them, or write your own.
+Skills are in `skills/`; `npx skills add` installs them into your project's `.claude/skills/` (in this repo that directory is a symlink). Read them, extend them, or write your own.
 
 ## Platform Capabilities
 
 | Feature | Web | macOS | Windows/Surface | iOS | Android |
 |---------|-----|-------|-----------------|-----|---------|
-| SSO Authentication | Yes | Yes | Yes | No | No |
+| SSO Authentication | Yes | Yes | Yes | Yes | Yes |
 | AI Chat | Yes | Yes | Yes | Yes | Yes |
 | User Profile | Yes | Yes | Yes | Yes | Yes |
 | Account Settings | Yes | Yes | Yes | Yes | Yes |
 | Analytics Dashboard | Yes | Yes | Yes | Yes | Yes |
 | Notifications | Yes | Yes | Yes | Yes | Yes |
 
-> **iOS & Android SSO limitation:** Mobile WebViews use a non-standard user-agent that SSO providers reject. Completing the OAuth flow requires a system browser popup (ASWebAuthenticationSession on iOS, Chrome Custom Tabs on Android). This is not yet implemented -- mobile users must authenticate via another method for now.
+> **iOS & Android SSO:** mobile WebViews are rejected by SSO providers, so the Tauri shell opens sign-in in the system browser (ASWebAuthenticationSession on iOS, Chrome Custom Tabs on Android) and returns through a deep link. Set `TAURI_CUSTOM_SCHEME` in `iblai.env` -- see [`/iblai-vibe-ops-build`](skills/iblai-vibe-ops-build/SKILL.md) "Mobile SSO".
 
 ## Deploy Anywhere
 
@@ -444,6 +449,8 @@ For a Windows Store / sideload **MSIX** package instead, see
 - [@iblai/mcp](https://www.npmjs.com/package/@iblai/mcp) -- MCP server for AI-assisted development
 - [skills.sh/iblai/vibe](https://skills.sh/iblai/vibe) -- install skills with `npx skills add iblai/vibe --all`
 - [Skills Reference](https://github.com/iblai/vibe/tree/main/skills) -- documentation for all bundled Claude Code skills
+- [ibl.ai/docs](https://ibl.ai/docs) -- platform documentation
+- [ibl.ai/developer](https://ibl.ai/developer) -- developer docs (API reference, platform guides)
 
 ## License
 

--- a/adapters/codex/iblai-vibe-agent-chat.md
+++ b/adapters/codex/iblai-vibe-agent-chat.md
@@ -46,7 +46,10 @@ Do NOT implement dark mode unless the user explicitly asks for it.
   the axd token, username, and tenants from the providers tree.
 - A working store, providers, and SSO callback route — i.e. an app that
   already passes `/iblai-vibe-auth` verification.
-- An agent/mentor ID (a UUID) — get one at https://mentorai.iblai.app.
+- An agent/mentor ID (a UUID) — the last path segment of an
+  `https://os.ibl.ai/platform/<tenant>/<agent-uuid>` URL the user gave, or
+  create an agent on [os.ibl.ai](https://os.ibl.ai) (or with
+  `/iblai-api-agent-create` from `iblai/api`).
 - **Minimum SDK versions.** The `Chat` component and its required hooks
   are only present in recent SDKs. Older-but-recent installs silently
   lack them. Require at least:
@@ -107,16 +110,18 @@ yours doesn't, read `process.env.NEXT_PUBLIC_SUPPORT_EMAIL` directly in
 
 ## Step 2: Get the Agent ID
 
-Ask the user for their agent/mentor UUID. Write it directly to
-`.env.local` using the Edit tool — do NOT echo it back in shell
-commands:
+If the user already gave an os.ibl.ai URL
+(`https://os.ibl.ai/platform/<tenant>/<agent-uuid>`), the UUID is its last
+path segment — use it, don’t ask. Otherwise ask the user for their
+agent/mentor UUID. Write it directly to `.env.local` using the Edit tool —
+do NOT echo it back in shell commands:
 
 ```
 NEXT_PUBLIC_DEFAULT_AGENT_ID=<the-uuid>
 ```
 
-If the user doesn't have one, direct them to https://mentorai.iblai.app
-to create an agent.
+If the user doesn't have one, direct them to create an agent on
+https://os.ibl.ai (or run `/iblai-api-agent-create` from `iblai/api`).
 
 ## Step 3: Install Dependencies
 

--- a/adapters/codex/iblai-vibe-readme.md
+++ b/adapters/codex/iblai-vibe-readme.md
@@ -274,7 +274,7 @@ See `CLAUDE.md` for the full list of skills and component priority rules.
 
 ## Resources
 
-- [ibl.ai Documentation](https://docs.ibl.ai)
+- [ibl.ai Documentation](https://ibl.ai/docs)
 - [@iblai/iblai-js](https://www.npmjs.com/package/@iblai/iblai-js) — the ibl.ai SDK
 - [@iblai/mcp](https://www.npmjs.com/package/@iblai/mcp) — MCP server for AI-assisted development
 - [Vibe](https://github.com/iblai/vibe) — developer toolkit for building with ibl.ai

--- a/adapters/codex/iblai-vibe.md
+++ b/adapters/codex/iblai-vibe.md
@@ -31,7 +31,10 @@ or skill that matches the task.
   wire `/iblai-vibe-auth` first, then the feature skill.
 - **Drive the platform REST API** (automations, backends, data work) →
   install `iblai/api` and open the `iblai-api-*` skill for that API family.
-- **See how a production app wires the SDK** → read the `iblai/os` source.
+- **See how a production app wires the SDK** → read the `iblai/os` source,
+  or — if the user is signed in to os.ibl.ai — learn from the live tenant
+  ([CLAUDE.md → Learn from a live tenant](https://github.com/iblai/vibe/blob/main/CLAUDE.md#learn-from-a-live-tenant)):
+  decode the URL, mint a token from the session, read real responses.
 - **Marketing / growth work** → install `iblai/vibe-marketing`.
 
 ## Key links
@@ -39,8 +42,14 @@ or skill that matches the task.
 - [CLAUDE.md](https://github.com/iblai/vibe/blob/main/CLAUDE.md) — full agent guidance and the complete skill table
 - [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) — brand guidelines
 - [skills/](https://github.com/iblai/vibe/tree/main/skills) — every skill in canonical SKILL.md format (Cursor / Codex adapters pre-generated in [adapters/](https://github.com/iblai/vibe/tree/main/adapters))
-- [docs.ibl.ai](https://docs.ibl.ai) — platform documentation
-- `iblai/api` quick references (raw SKILL.md): [agent-memory](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-memory/SKILL.md) · [agent-setting](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-setting/SKILL.md) · [analytics](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-analytics/SKILL.md) · [profile](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile/SKILL.md) · [profile-metadata](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile-metadata/SKILL.md)
+- [ibl.ai/docs](https://ibl.ai/docs) — platform documentation
+- [ibl.ai/developer](https://ibl.ai/developer) — developer docs
+- `iblai/api` quick references for the five REST families most apps read or write (raw SKILL.md; the matching SDK hooks and vibe skills are in [CLAUDE.md → Platform data most apps lean on](https://github.com/iblai/vibe/blob/main/CLAUDE.md#platform-data-most-apps-lean-on)):
+  [profile-metadata](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile-metadata/SKILL.md) — schemaless per-user × org JSON for preferences, flags, onboarding progress, app state; no vibe skill, call the SDK hooks ·
+  [agent-setting](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-setting/SKILL.md) — an agent’s identity and capability flags via one PUT of changed fields; fork, delete ·
+  [agent-memory](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-memory/SKILL.md) — global, per-agent, and shared-knowledge memories plus capture/recall toggles ·
+  [analytics](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-analytics/SKILL.md) — usage, costs, transcripts, per-user learning, reports; `mentor_unique_id` scopes to one agent ·
+  [profile](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile/SKILL.md) — the signed-in user’s account, social links, career records, résumé
 
 ## Related skills
 

--- a/adapters/cursor/iblai-vibe-agent-chat.mdc
+++ b/adapters/cursor/iblai-vibe-agent-chat.mdc
@@ -48,7 +48,10 @@ Do NOT implement dark mode unless the user explicitly asks for it.
   the axd token, username, and tenants from the providers tree.
 - A working store, providers, and SSO callback route — i.e. an app that
   already passes `/iblai-vibe-auth` verification.
-- An agent/mentor ID (a UUID) — get one at https://mentorai.iblai.app.
+- An agent/mentor ID (a UUID) — the last path segment of an
+  `https://os.ibl.ai/platform/<tenant>/<agent-uuid>` URL the user gave, or
+  create an agent on [os.ibl.ai](https://os.ibl.ai) (or with
+  `/iblai-api-agent-create` from `iblai/api`).
 - **Minimum SDK versions.** The `Chat` component and its required hooks
   are only present in recent SDKs. Older-but-recent installs silently
   lack them. Require at least:
@@ -109,16 +112,18 @@ yours doesn't, read `process.env.NEXT_PUBLIC_SUPPORT_EMAIL` directly in
 
 ## Step 2: Get the Agent ID
 
-Ask the user for their agent/mentor UUID. Write it directly to
-`.env.local` using the Edit tool — do NOT echo it back in shell
-commands:
+If the user already gave an os.ibl.ai URL
+(`https://os.ibl.ai/platform/<tenant>/<agent-uuid>`), the UUID is its last
+path segment — use it, don’t ask. Otherwise ask the user for their
+agent/mentor UUID. Write it directly to `.env.local` using the Edit tool —
+do NOT echo it back in shell commands:
 
 ```
 NEXT_PUBLIC_DEFAULT_AGENT_ID=<the-uuid>
 ```
 
-If the user doesn't have one, direct them to https://mentorai.iblai.app
-to create an agent.
+If the user doesn't have one, direct them to create an agent on
+https://os.ibl.ai (or run `/iblai-api-agent-create` from `iblai/api`).
 
 ## Step 3: Install Dependencies
 

--- a/adapters/cursor/iblai-vibe-readme.mdc
+++ b/adapters/cursor/iblai-vibe-readme.mdc
@@ -276,7 +276,7 @@ See `CLAUDE.md` for the full list of skills and component priority rules.
 
 ## Resources
 
-- [ibl.ai Documentation](https://docs.ibl.ai)
+- [ibl.ai Documentation](https://ibl.ai/docs)
 - [@iblai/iblai-js](https://www.npmjs.com/package/@iblai/iblai-js) — the ibl.ai SDK
 - [@iblai/mcp](https://www.npmjs.com/package/@iblai/mcp) — MCP server for AI-assisted development
 - [Vibe](https://github.com/iblai/vibe) — developer toolkit for building with ibl.ai

--- a/adapters/cursor/iblai-vibe.mdc
+++ b/adapters/cursor/iblai-vibe.mdc
@@ -33,7 +33,10 @@ or skill that matches the task.
   wire `/iblai-vibe-auth` first, then the feature skill.
 - **Drive the platform REST API** (automations, backends, data work) →
   install `iblai/api` and open the `iblai-api-*` skill for that API family.
-- **See how a production app wires the SDK** → read the `iblai/os` source.
+- **See how a production app wires the SDK** → read the `iblai/os` source,
+  or — if the user is signed in to os.ibl.ai — learn from the live tenant
+  ([CLAUDE.md → Learn from a live tenant](https://github.com/iblai/vibe/blob/main/CLAUDE.md#learn-from-a-live-tenant)):
+  decode the URL, mint a token from the session, read real responses.
 - **Marketing / growth work** → install `iblai/vibe-marketing`.
 
 ## Key links
@@ -41,8 +44,14 @@ or skill that matches the task.
 - [CLAUDE.md](https://github.com/iblai/vibe/blob/main/CLAUDE.md) — full agent guidance and the complete skill table
 - [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) — brand guidelines
 - [skills/](https://github.com/iblai/vibe/tree/main/skills) — every skill in canonical SKILL.md format (Cursor / Codex adapters pre-generated in [adapters/](https://github.com/iblai/vibe/tree/main/adapters))
-- [docs.ibl.ai](https://docs.ibl.ai) — platform documentation
-- `iblai/api` quick references (raw SKILL.md): [agent-memory](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-memory/SKILL.md) · [agent-setting](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-setting/SKILL.md) · [analytics](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-analytics/SKILL.md) · [profile](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile/SKILL.md) · [profile-metadata](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile-metadata/SKILL.md)
+- [ibl.ai/docs](https://ibl.ai/docs) — platform documentation
+- [ibl.ai/developer](https://ibl.ai/developer) — developer docs
+- `iblai/api` quick references for the five REST families most apps read or write (raw SKILL.md; the matching SDK hooks and vibe skills are in [CLAUDE.md → Platform data most apps lean on](https://github.com/iblai/vibe/blob/main/CLAUDE.md#platform-data-most-apps-lean-on)):
+  [profile-metadata](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile-metadata/SKILL.md) — schemaless per-user × org JSON for preferences, flags, onboarding progress, app state; no vibe skill, call the SDK hooks ·
+  [agent-setting](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-setting/SKILL.md) — an agent’s identity and capability flags via one PUT of changed fields; fork, delete ·
+  [agent-memory](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-memory/SKILL.md) — global, per-agent, and shared-knowledge memories plus capture/recall toggles ·
+  [analytics](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-analytics/SKILL.md) — usage, costs, transcripts, per-user learning, reports; `mentor_unique_id` scopes to one agent ·
+  [profile](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile/SKILL.md) — the signed-in user’s account, social links, career records, résumé
 
 ## Related skills
 

--- a/docs/skill-setup.md
+++ b/docs/skill-setup.md
@@ -64,6 +64,12 @@ these variables, tell the user:
 > template and fill in your values:
 > `curl -o iblai.env https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/iblai.env`"
 
+Where the values come from: the org key (`PLATFORM`) is listed on
+https://login.iblai.app/me (no account yet: https://ibl.ai/join); the
+Platform API Token (`TOKEN`) is minted from that signed-in session by
+`/iblai-api-login` (`npx skills add iblai/api`), or an org secret works
+directly. Make sure `iblai.env` is gitignored before writing a token into it.
+
 Do NOT ask the user for their platform key directly — guide them to
 populate `iblai.env` instead.
 

--- a/iblai.env
+++ b/iblai.env
@@ -1,5 +1,8 @@
 # ibl.ai Platform Configuration
 # replace PLATFORM with your tenant key and TOKEN with your platform api key.
+# PLATFORM (org key) is listed on https://login.iblai.app/me (no account yet: https://ibl.ai/join).
+# TOKEN is a Platform API Token: mint one with /iblai-api-login (npx skills add iblai/api)
+# or use an org secret. Keep this file out of git.
 DOMAIN=iblai.app
 PLATFORM=your-platform
 TOKEN=your-platform-api-key

--- a/skills/iblai-vibe-agent-chat/SKILL.md
+++ b/skills/iblai-vibe-agent-chat/SKILL.md
@@ -49,7 +49,10 @@ Do NOT implement dark mode unless the user explicitly asks for it.
   the axd token, username, and tenants from the providers tree.
 - A working store, providers, and SSO callback route — i.e. an app that
   already passes `/iblai-vibe-auth` verification.
-- An agent/mentor ID (a UUID) — get one at https://mentorai.iblai.app.
+- An agent/mentor ID (a UUID) — the last path segment of an
+  `https://os.ibl.ai/platform/<tenant>/<agent-uuid>` URL the user gave, or
+  create an agent on [os.ibl.ai](https://os.ibl.ai) (or with
+  `/iblai-api-agent-create` from `iblai/api`).
 - **Minimum SDK versions.** The `Chat` component and its required hooks
   are only present in recent SDKs. Older-but-recent installs silently
   lack them. Require at least:
@@ -110,16 +113,18 @@ yours doesn't, read `process.env.NEXT_PUBLIC_SUPPORT_EMAIL` directly in
 
 ## Step 2: Get the Agent ID
 
-Ask the user for their agent/mentor UUID. Write it directly to
-`.env.local` using the Edit tool — do NOT echo it back in shell
-commands:
+If the user already gave an os.ibl.ai URL
+(`https://os.ibl.ai/platform/<tenant>/<agent-uuid>`), the UUID is its last
+path segment — use it, don’t ask. Otherwise ask the user for their
+agent/mentor UUID. Write it directly to `.env.local` using the Edit tool —
+do NOT echo it back in shell commands:
 
 ```
 NEXT_PUBLIC_DEFAULT_AGENT_ID=<the-uuid>
 ```
 
-If the user doesn't have one, direct them to https://mentorai.iblai.app
-to create an agent.
+If the user doesn't have one, direct them to create an agent on
+https://os.ibl.ai (or run `/iblai-api-agent-create` from `iblai/api`).
 
 ## Step 3: Install Dependencies
 

--- a/skills/iblai-vibe-auth/assets/home-page.tsx.j2
+++ b/skills/iblai-vibe-auth/assets/home-page.tsx.j2
@@ -18,7 +18,7 @@ export default function Home() {
         </p>
         <div className="flex gap-3 justify-center">
           <a
-            href="https://docs.ibl.ai"
+            href="https://ibl.ai/docs"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-[#2563EB] to-[#93C5FD]"

--- a/skills/iblai-vibe-ops-init/assets/vibe-starter/README.md
+++ b/skills/iblai-vibe-ops-init/assets/vibe-starter/README.md
@@ -48,7 +48,7 @@ A pre-wired Next.js 16 + Tailwind v4 + shadcn/ui project with the [`@iblai/iblai
 
 - **Start building in minutes, not days** — auth, navbar, and the standard ibl.ai pages are already wired
 - **Backend included** — connects to [iblai.app](https://iblai.app) for SSO auth, AI agent infrastructure, analytics, and tenant management
-- **Client-side auth via SSO** — no API tokens to store, rotate, or leak
+- **Client-side auth via SSO** — end users never handle tokens; the one Platform API Token you hold stays server-side in `iblai.env`
 - **Claude Code skills guide every step** — adding features is a conversation, not a scavenger hunt through docs
 - **shadcn/ui fills in UI gaps** — consistent design language without the overhead of a custom design system
 - **Ship everywhere** — web (Vercel), desktop (macOS/Windows/Linux), and mobile (iOS/Android) via Tauri v2
@@ -146,7 +146,7 @@ create_page_template("Dashboard", "mentor")   # Generate a page following ibl.ai
 
 | Feature | Web | macOS | Windows/Surface | iOS | Android |
 |---------|-----|-------|-----------------|-----|---------|
-| SSO Authentication | Yes | Yes | Yes | No | No |
+| SSO Authentication | Yes | Yes | Yes | Yes | Yes |
 | AI Chat | Yes | Yes | Yes | Yes | Yes |
 | User Profile | Yes | Yes | Yes | Yes | Yes |
 | Account Settings | Yes | Yes | Yes | Yes | Yes |
@@ -154,7 +154,7 @@ create_page_template("Dashboard", "mentor")   # Generate a page following ibl.ai
 | Notifications | Yes | Yes | Yes | Yes | Yes |
 | Credit Balance | Yes | Yes | Yes | Yes | Yes |
 
-> **iOS & Android SSO limitation:** Mobile WebViews use a non-standard user-agent that SSO providers reject. Completing the OAuth flow requires a system browser popup (ASWebAuthenticationSession on iOS, Chrome Custom Tabs on Android). This is not yet implemented — mobile users must authenticate via another method for now.
+> **iOS & Android SSO:** mobile WebViews are rejected by SSO providers, so the Tauri shell opens sign-in in the system browser (ASWebAuthenticationSession on iOS, Chrome Custom Tabs on Android) and returns through a deep link. Set `TAURI_CUSTOM_SCHEME` in `iblai.env` — see [`/iblai-vibe-ops-build`](https://github.com/iblai/vibe/blob/main/skills/iblai-vibe-ops-build/SKILL.md) “Mobile SSO”.
 
 ## Brand
 

--- a/skills/iblai-vibe-ops-init/assets/vibe-starter/app/(app)/page.tsx
+++ b/skills/iblai-vibe-ops-init/assets/vibe-starter/app/(app)/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
         </p>
         <div className="flex gap-3 justify-center">
           <a
-            href="https://docs.ibl.ai"
+            href="https://ibl.ai/docs"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-[#2563EB] to-[#93C5FD]"

--- a/skills/iblai-vibe-readme/SKILL.md
+++ b/skills/iblai-vibe-readme/SKILL.md
@@ -277,7 +277,7 @@ See `CLAUDE.md` for the full list of skills and component priority rules.
 
 ## Resources
 
-- [ibl.ai Documentation](https://docs.ibl.ai)
+- [ibl.ai Documentation](https://ibl.ai/docs)
 - [@iblai/iblai-js](https://www.npmjs.com/package/@iblai/iblai-js) — the ibl.ai SDK
 - [@iblai/mcp](https://www.npmjs.com/package/@iblai/mcp) — MCP server for AI-assisted development
 - [Vibe](https://github.com/iblai/vibe) — developer toolkit for building with ibl.ai

--- a/skills/iblai-vibe-scaffold/assets/base/app/(app)/page.tsx.j2
+++ b/skills/iblai-vibe-scaffold/assets/base/app/(app)/page.tsx.j2
@@ -26,7 +26,7 @@ export default function Home() {
         </p>
         <div className="flex gap-4 justify-center">
           <a
-            href="https://docs.ibl.ai"
+            href="https://ibl.ai/docs"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white"

--- a/skills/iblai-vibe-scaffold/assets/shared/.gitignore.j2
+++ b/skills/iblai-vibe-scaffold/assets/shared/.gitignore.j2
@@ -29,6 +29,10 @@ yarn-error.log*
 .env*.local
 .env
 
+# ibl.ai platform shorthand (holds your platform API token)
+iblai.env*
+!iblai.env.example
+
 # vercel
 .vercel
 

--- a/skills/iblai-vibe/SKILL.md
+++ b/skills/iblai-vibe/SKILL.md
@@ -34,7 +34,10 @@ or skill that matches the task.
   wire `/iblai-vibe-auth` first, then the feature skill.
 - **Drive the platform REST API** (automations, backends, data work) →
   install `iblai/api` and open the `iblai-api-*` skill for that API family.
-- **See how a production app wires the SDK** → read the `iblai/os` source.
+- **See how a production app wires the SDK** → read the `iblai/os` source,
+  or — if the user is signed in to os.ibl.ai — learn from the live tenant
+  ([CLAUDE.md → Learn from a live tenant](https://github.com/iblai/vibe/blob/main/CLAUDE.md#learn-from-a-live-tenant)):
+  decode the URL, mint a token from the session, read real responses.
 - **Marketing / growth work** → install `iblai/vibe-marketing`.
 
 ## Key links
@@ -42,8 +45,14 @@ or skill that matches the task.
 - [CLAUDE.md](https://github.com/iblai/vibe/blob/main/CLAUDE.md) — full agent guidance and the complete skill table
 - [BRAND.md](https://raw.githubusercontent.com/iblai/vibe/refs/heads/main/BRAND.md) — brand guidelines
 - [skills/](https://github.com/iblai/vibe/tree/main/skills) — every skill in canonical SKILL.md format (Cursor / Codex adapters pre-generated in [adapters/](https://github.com/iblai/vibe/tree/main/adapters))
-- [docs.ibl.ai](https://docs.ibl.ai) — platform documentation
-- `iblai/api` quick references (raw SKILL.md): [agent-memory](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-memory/SKILL.md) · [agent-setting](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-setting/SKILL.md) · [analytics](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-analytics/SKILL.md) · [profile](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile/SKILL.md) · [profile-metadata](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile-metadata/SKILL.md)
+- [ibl.ai/docs](https://ibl.ai/docs) — platform documentation
+- [ibl.ai/developer](https://ibl.ai/developer) — developer docs
+- `iblai/api` quick references for the five REST families most apps read or write (raw SKILL.md; the matching SDK hooks and vibe skills are in [CLAUDE.md → Platform data most apps lean on](https://github.com/iblai/vibe/blob/main/CLAUDE.md#platform-data-most-apps-lean-on)):
+  [profile-metadata](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile-metadata/SKILL.md) — schemaless per-user × org JSON for preferences, flags, onboarding progress, app state; no vibe skill, call the SDK hooks ·
+  [agent-setting](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-setting/SKILL.md) — an agent’s identity and capability flags via one PUT of changed fields; fork, delete ·
+  [agent-memory](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-agent-memory/SKILL.md) — global, per-agent, and shared-knowledge memories plus capture/recall toggles ·
+  [analytics](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-analytics/SKILL.md) — usage, costs, transcripts, per-user learning, reports; `mentor_unique_id` scopes to one agent ·
+  [profile](https://raw.githubusercontent.com/iblai/api/refs/heads/main/skills/iblai-api-profile/SKILL.md) — the signed-in user’s account, social links, career records, résumé
 
 ## Related skills
 


### PR DESCRIPTION
## Checklist
- [x] Tests were added/updated according to the feature/bugfix/change made
- [x] Version was rolled according to [semver requirements](https://semver.org/#summary)
- [x] API endpoints openapi schema was updated if applicable

## Changes
## What

- **CLAUDE.md — "Platform data most apps lean on."** Replaces the five bare `iblai/api` raw links with one entry per family (per-user metadata, agent settings, agent memory, analytics, profile): what it gives an app, the SDK hooks/components that wrap it, the `/iblai-vibe-*` skill, and the raw SKILL.md link. Closes with an auth-on-the-wire note (`Token <dm_token>` in the browser vs `Api-Token` server-side).
- **CLAUDE.md — "Learn from a live tenant."** AI-assistant callout for "you're logged into `https://os.ibl.ai/platform/<tenant>/<agent-uuid>` as `<email>`": decode the URL into `PLATFORM` / default agent id / domain, mint a Platform API Token from the session exactly as `/iblai-api-login` documents, learn shapes from live responses and wiring from `iblai/os`, keep tenant/email/token out of git. The agent-id rule now takes the UUID from that URL before asking.
- **Credentials pointers** (CLAUDE.md env callout, README Quick Start, `iblai.env`, `docs/skill-setup.md`): sign up at `ibl.ai/join`, org key on `login.iblai.app/me`, token via `/iblai-api-login` or an org secret.
- **`/iblai-vibe` index skill**: compact per-family "why" with the same raw links and pointers to both CLAUDE.md sections. **`/iblai-vibe-agent-chat`**: agent id from the OS URL when given; `os.ibl.ai` replaces `mentorai.iblai.app`.
- **`docs.ibl.ai` → `https://ibl.ai/docs`** in both skills and the three page templates; README now links `ibl.ai/docs` and `ibl.ai/developer`.
- **README truth pass**: scaffold step is vibe-starter via `/iblai-vibe-ops-init`; "No API tokens to manage" corrected (end users use SSO, the developer keeps one Platform API Token in gitignored `iblai.env`); non-existent `/iblai-landing` row removed; "symlinked to `.claude/skills/`" clarified; iOS/Android SSO marked as shipped (system browser + deep link, `TAURI_CUSTOM_SCHEME`) in README and vibe-starter README; 13 missing skills added to the CLAUDE.md table; `iblai.env*` gitignored in the scaffold template.
- Adapters regenerated (`node scripts/build-adapters.mjs`).

## Verification

- `bash scripts/validate-skills.sh` — all valid; warnings identical to `main` (51, pre-existing).
- `node scripts/check-sdk-pins.mjs` — clean.
- `node scripts/check-links.mjs` — 150/150 resolve, including the two new CLAUDE.md anchors.
- `node scripts/test-skills-render.mjs --skills iblai-vibe-auth,iblai-vibe-scaffold,iblai-vibe-ops-init` — starter typecheck + unit tests, asset overlays, prose fences all green.
- `grep -rn "docs\.ibl\.ai"` → 0 hits.

## Notes

- Merging cuts a patch release via `release.yml`; the commit subject becomes the CHANGELOG line.
- `run-tests` label runs the deterministic tier (including `--build`) and the agent tier on the six touched skills.
- Follow-ups not in this PR: a human "get your org key and API token" page, one generated README skill table (19 skills still missing from the README lists), `.mcp.json` in vibe-starter, the stale `ibl.ai/developer/platform/vibe-sdk` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)